### PR TITLE
When .then() is called on a Cursor, execute it.

### DIFF
--- a/lib/Cursor.js
+++ b/lib/Cursor.js
@@ -52,6 +52,10 @@ class Cursor {
 			});
 		});
 	}
+
+	then() {
+		return this.exec();
+	}
 }
 
 module.exports = Cursor;

--- a/lib/Cursor.js
+++ b/lib/Cursor.js
@@ -53,8 +53,8 @@ class Cursor {
 		});
 	}
 
-	then() {
-		return this.exec();
+	then(onFulfilled, onRejected) {
+		return this.exec().then(onFulfilled, onRejected);
 	}
 }
 

--- a/test/c.find.test.js
+++ b/test/c.find.test.js
@@ -31,4 +31,16 @@ describe('Find', () => {
 				});
 		});
 	});
+
+  describe(`find().then()`, () => {
+    let db = new Datastore();
+    it('should find all inserted docs', () => {
+      return db.insert(documents)
+        .then(() => {
+          return db.find().then((result) => {
+            expect(result).to.be.an('array').that.has.lengthOf(3);
+          });
+        });
+    });
+  });
 });


### PR DESCRIPTION
Currently, `.find()` returns a `Cursor`. Calling `.then()` on this `Cursor` isn't possible. I added a `then` function to the `Cursor` class, which simple calls `this.exec()` which returns a promise. This removes the need to use `.exec()` when directly chaining the the `find()` call.

```
const db = new Datastore();
findAll() {
  return db.find()
    .then((documents) => {
      // process documents
    })
    .catch((err) => {});
}
```

Note that `.exec()` is still necessary when `find()` is in the `.then()` of a Promise chain (otherwise the promise would be resolved with the `Cursor` object).

```
const db = new Datastore();
insertAndRetrieve(documents) {
  return db.insert(documents)
    .then(() => {
      return db.find().exec();
    })
    .then((insertedDocuments) => {});
}
```