### PR TITLE
Match NeDB's update callback signature

### DIFF
--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -69,10 +69,13 @@ class Datastore {
 	update(query, update, options = {}) {
 		return this.load().then(() => {
 			return new Promise((resolve, reject) => {
-				this.__original.update(query, update, options, (error, result) => {
+				this.__original.update(query, update, options, (error, numAffected, affectedDocuments, upsert) => {
 					if (error)
 						reject(error);
-					else resolve(result);
+					else if (options.upsert === true || options.returnUpdatedDocs === true) {
+            resolve([numAffected, affectedDocuments, upsert]);
+          }
+          else resolve(numAffected);
 				});
 			});
 		});

--- a/test/d.update.test.js
+++ b/test/d.update.test.js
@@ -1,0 +1,82 @@
+const {expect} = require('chai'),
+  Datastore = require('../lib/Datastore');
+
+describe('Update', () => {
+  let documents = [
+    { name: 'first document' },
+    { name: 'second document' },
+    { name: 'third document' }
+  ];
+
+  describe(`single`, () => {
+    it('should update single document', () => {
+      let db = new Datastore();
+      return db.insert(documents)
+        .then((inserted) => {
+          return db.update(
+            { name: 'first document' },
+            { name: 'updated document' },
+            { multi: false }
+          );
+        })
+        .then((numAffected) => {
+          expect(numAffected).to.equal(1);
+        });
+    });
+  });
+
+  describe(`single affected`, () => {
+    it('should update and return single document', () => {
+      let db = new Datastore();
+      return db.insert(documents)
+        .then((inserted) => {
+          return db.update(
+            { name: 'first document' },
+            { name: 'updated document' },
+            { multi: false, returnUpdatedDocs: true }
+          );
+        })
+        .then(([numAffected, affectedDocument]) => {
+          expect(numAffected).to.equal(1);
+          expect(affectedDocument).to.deep.include({
+            name: 'updated document'
+          });
+        });
+    });
+  });
+
+  describe(`bulk`, () => {
+    it('should update multiple documents', () => {
+      let db = new Datastore();
+      return db.insert(documents)
+        .then((inserted) => {
+          return db.update(
+            { name: { $regex: /document$/ } },
+            { $set: { test: true } },
+            { multi: true }
+          );
+        })
+        .then((numAffected) => {
+          expect(numAffected).to.equal(3);
+        });
+    });
+  });
+
+  describe(`bulk affected`, () => {
+    it('should update and return multiple documents', () => {
+      let db = new Datastore();
+      return db.insert(documents)
+        .then((inserted) => {
+          return db.update(
+            { name: { $regex: /document$/ } },
+            { $set: { test: true } },
+            { multi: true, returnUpdatedDocs: true }
+          );
+        })
+        .then(([numAffected, affectedDocuments]) => {
+          expect(numAffected).to.equal(3);
+          expect(affectedDocuments).to.be.an('array').that.has.lengthOf(3);
+        });
+    });
+  });
+});


### PR DESCRIPTION
NeDB has some extra options when it comes to updates:
https://github.com/louischatriot/nedb#updating-documents

When `upsert` or `returnUpdatedDocs` is set to `true`, the callback gets two more parameters. Since promises always resolve to a single value, an array containing these values will be resolved instead (which can be easily destructured).