### PR TITLE
Fixed reference to persistence (typo)

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -136,7 +136,7 @@ Datastore constructor...
 
 You should use `Datastore.create(...)` instead
 of `new Datastore(...)`. With that you can access
-the original datastore's properties such as `datastore.persistance`.
+the original datastore's properties such as `datastore.persistence`.
 
 Create a Datastore instance.
 
@@ -416,7 +416,7 @@ Create a database instance.
 
 Use this over `new Datastore(...)` to access
 original nedb datastore properties, such as
-`datastore.persistance`.
+`datastore.persistence`.
 
 Note that the datastore will be created
 relative to `process.cwd()`

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ declare class Datastore extends EventEmitter {
    *
    * You should use `Datastore.create(...)` instead
    * of `new Datastore(...)`. With that you can access
-   * the original datastore's properties such as `datastore.persistance`.
+   * the original datastore's properties such as `datastore.persistence`.
    *
    * It's basically the same as the original:
    * https://github.com/louischatriot/nedb#creatingloading-a-database
@@ -183,7 +183,7 @@ declare class Datastore extends EventEmitter {
    *
    * Use this over `new Datastore(...)` to access
    * original nedb datastore properties, such as
-   * `datastore.persistance`.
+   * `datastore.persistence`.
    *
    * For more information visit:
    * https://github.com/louischatriot/nedb#creatingloading-a-database

--- a/src/Datastore.js
+++ b/src/Datastore.js
@@ -61,7 +61,7 @@ class Datastore extends EventEmitter {
 	 *
 	 * You should use `Datastore.create(...)` instead
 	 * of `new Datastore(...)`. With that you can access
-	 * the original datastore's properties such as `datastore.persistance`.
+	 * the original datastore's properties such as `datastore.persistence`.
 	 *
 	 * Create a Datastore instance.
 	 * 
@@ -372,7 +372,7 @@ class Datastore extends EventEmitter {
 	 *
 	 * Use this over `new Datastore(...)` to access
 	 * original nedb datastore properties, such as
-	 * `datastore.persistance`.
+	 * `datastore.persistence`.
 	 *
 	 * Note that the datastore will be created
 	 * relative to `process.cwd()`


### PR DESCRIPTION
The actual property in NeDB is called `persistence`, not `persistance`. Adapted documentation to avoid confusion.