### PR TITLE
Consistent naming/typing of constructor/create parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,7 @@ declare class Datastore extends EventEmitter {
    * For more information visit:
    * https://github.com/louischatriot/nedb#creatingloading-a-database
    */
-  static create(options: Nedb.DatastoreOptions): Datastore
+  static create(pathOrOptions?: string | Nedb.DatastoreOptions): Datastore
 }
 
 declare namespace Nedb {

--- a/src/Datastore.js
+++ b/src/Datastore.js
@@ -29,12 +29,12 @@ const
  * datastore.on('update', (datastore, result, query, update, options) => {
  * })
  * datastore.on('load', (datastore) => {
- *     // this event doesn't have a result
+ *	 // this event doesn't have a result
  * })
  * datastore.on('ensureIndex', (datastore, options) => {
- *     // this event doesn't have a result
- *     // but it has the options argument which will be passed to the
- *     // event handlers
+ *	 // this event doesn't have a result
+ *	 // but it has the options argument which will be passed to the
+ *	 // event handlers
  * })
  *
  * @example
@@ -49,8 +49,8 @@ const
  * @example
  * let datastore = Datastore.create()
  * datastore.on('__error__', (datastore, event, error, ...args) => {
- *     // for example
- *     // datastore, 'find', error, [{ foo: 'bar' }, {}]
+ *	 // for example
+ *	 // datastore, 'find', error, [{ foo: 'bar' }, {}]
  * })
  * 
  * @class
@@ -387,15 +387,15 @@ class Datastore extends EventEmitter {
 	static create(pathOrOptions) {
 		return new Proxy(new this(pathOrOptions), {
 			get(target, key) {
-                return target[key]
-                    ? target[key]
-                    : target.__original[key]
+				return target[key]
+					? target[key]
+					: target.__original[key]
 			},
 
 			set(target, key, value) {
-                return target.__original.hasOwnProperty(key)
-                    ? (target.__original[key] = value)
-                    : (target[key] = value)
+				return target.__original.hasOwnProperty(key)
+					? (target.__original[key] = value)
+					: (target[key] = value)
 			}
 		})
 	}

--- a/src/Datastore.js
+++ b/src/Datastore.js
@@ -72,10 +72,10 @@ class Datastore extends EventEmitter {
 	 * It's basically the same as the original:
 	 * https://github.com/louischatriot/nedb#creatingloading-a-database
 	 * 
-	 * @param  {Object} [options]
+	 * @param  {string|Object} [pathOrOptions]
 	 * @return {static}
 	 */
-	constructor(options) {
+	constructor(pathOrOptions) {
 		super()
 
 		Object.defineProperties(this, {
@@ -89,7 +89,7 @@ class Datastore extends EventEmitter {
 				configurable: true,
 				enumerable: false,
 				writable: false,
-				value: new OriginalDatastore(options)
+				value: new OriginalDatastore(pathOrOptions)
 			}
 		})
 	}
@@ -381,11 +381,11 @@ class Datastore extends EventEmitter {
 	 * For more information visit:
 	 * https://github.com/louischatriot/nedb#creatingloading-a-database
 	 * 
-	 * @param  {string|Object} options
+	 * @param  {string|Object} pathOrOptions
 	 * @return {Proxy.<static>}
 	 */
-	static create(options) {
-		return new Proxy(new this(options), {
+	static create(pathOrOptions) {
+		return new Proxy(new this(pathOrOptions), {
 			get(target, key) {
                 return target[key]
                     ? target[key]


### PR DESCRIPTION
Both the constructor and `create()` accept a path string or options. Unified naming, documentation, and Typescript typing to reflect this.