### PR TITLE
Return type of find() should be Cursor<T>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,7 +104,7 @@ declare class Datastore extends EventEmitter {
    * // in an async function
    * await datastore.find({ ... }).sort({ ... })
    */
-  find<T>(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Nedb.Cursor<(T & Document)[]>
+  find<T>(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Nedb.Cursor<T & Document>
 
   /**
    * Find a document that matches a query.
@@ -195,7 +195,7 @@ declare class Datastore extends EventEmitter {
 }
 
 declare namespace Nedb {
-  interface Cursor<T> extends Promise<T> {
+  interface Cursor<T> extends Promise<T[]> {
     sort(query: any): Cursor<T>
     skip(n: number): Cursor<T>
     limit(n: number): Cursor<T>


### PR DESCRIPTION
Hi, I hope you don't mind be opening a PR for this issue.
The return value of `find()` was previously `Nedb.Cursor<(T & Document)[]>`, which meant that the return value of `Cursor.exec()` ended up with a double-wrapped array.

Changing the interface of Cursor<T> to always refer to the single entity, but extending a Promise of the array, fixes the issue (tested locally).

An alternative would have been to change the interface to `Cursor<T extends any[]> implements Promise<T>`, and update the return type of `exec(): Promise<T>`, but I felt that this option was simpler.

Let me know if you have any questions or feedback!

Fixes #43
