### PR TITLE
Embed nedb and rewrite it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,9 @@
       "license": "ISC",
       "dependencies": {
         "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "^0.5.1",
-        "underscore": "~1.4.4"
+        "localforage": "^1.9.0",
+        "mkdirp": "^1.0.4",
+        "underscore": "^1.13.1"
       },
       "devDependencies": {
         "chai": "^4.2.0",
@@ -122,14 +121,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "node_modules/binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
-      "dependencies": {
-        "underscore": "~1.4.4"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -176,15 +167,15 @@
       }
     },
     "node_modules/catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 10"
       }
     },
     "node_modules/chai": {
@@ -742,9 +733,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",
@@ -911,25 +902,25 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.4.tgz",
-      "integrity": "sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       },
       "bin": {
         "jsdoc": "jsdoc.js"
@@ -1028,9 +1019,9 @@
       }
     },
     "node_modules/jsdoc/node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
@@ -1038,24 +1029,6 @@
       "engines": {
         "node": ">= 8.16.2"
       }
-    },
-    "node_modules/jsdoc/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jsdoc/node_modules/underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
-      "dev": true
     },
     "node_modules/klaw": {
       "version": "3.0.0",
@@ -1105,9 +1078,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.camelcase": {
@@ -1201,17 +1174,18 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp2": {
@@ -1853,9 +1827,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "node_modules/walk-back": {
       "version": "4.0.0",
@@ -2134,14 +2108,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
-      "requires": {
-        "underscore": "~1.4.4"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -2182,12 +2148,12 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "chai": {
@@ -2640,9 +2606,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -2768,43 +2734,31 @@
       }
     },
     "jsdoc": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.4.tgz",
-      "integrity": "sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       },
       "dependencies": {
         "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+          "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
           "dev": true
         }
       }
@@ -2929,9 +2883,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -3010,15 +2964,13 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mkdirp2": {
       "version": "1.0.4",
@@ -3540,9 +3492,9 @@
       }
     },
     "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "walk-back": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "version": "4.1.3",
       "license": "ISC",
       "dependencies": {
-        "nedb": "^1.8.0"
+        "async": "0.2.10",
+        "binary-search-tree": "0.2.5",
+        "localforage": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "underscore": "~1.4.4"
       },
       "devDependencies": {
         "chai": "^4.2.0",
@@ -1080,9 +1084,9 @@
       }
     },
     "node_modules/localforage": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.6.0.tgz",
-      "integrity": "sha1-iwBZvus4dcSBJChsp/2/I9UrjJc=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -1197,8 +1201,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -1210,11 +1213,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mkdirp2": {
       "version": "1.0.4",
@@ -1312,18 +1310,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "node_modules/nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
-      "dependencies": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.1",
@@ -2925,9 +2911,9 @@
       }
     },
     "localforage": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.6.0.tgz",
-      "integrity": "sha1-iwBZvus4dcSBJChsp/2/I9UrjJc=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
       "requires": {
         "lie": "3.1.1"
       }
@@ -3024,8 +3010,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -3033,13 +3018,6 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "mkdirp2": {
@@ -3121,18 +3099,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
-      "requires": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
-      }
     },
     "neo-async": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
   },
   "homepage": "https://github.com/bajankristof/nedb-promises#readme",
   "dependencies": {
-    "nedb": "^1.8.0"
+    "async": "0.2.10",
+    "binary-search-tree": "0.2.5",
+    "localforage": "^1.3.0",
+    "mkdirp": "^0.5.1",
+    "underscore": "~1.4.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
   "homepage": "https://github.com/bajankristof/nedb-promises#readme",
   "dependencies": {
     "async": "0.2.10",
-    "binary-search-tree": "0.2.5",
-    "localforage": "^1.3.0",
-    "mkdirp": "^0.5.1",
-    "underscore": "~1.4.4"
+    "localforage": "^1.9.0",
+    "mkdirp": "^1.0.4",
+    "underscore": "^1.13.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/Cursor.js
+++ b/src/Cursor.js
@@ -1,5 +1,5 @@
 const
-    OriginalCursor = require('nedb/lib/cursor')
+    OriginalCursor = require('./nedb/cursor')
 
 /**
  * @class
@@ -77,7 +77,7 @@ class Cursor {
      *  .sort(...)
      *  .limit(...)
      *  .exec()
-     * 
+     *
      * @return {Promise.<Object[]>}
      */
     exec() {
@@ -98,10 +98,10 @@ class Cursor {
 
     /**
      * Execute the cursor and set promise callbacks.
-     * 
+     *
      * For more information visit:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-     * 
+     *
      * @param  {Function} fulfilled
      * @param  {Function} [rejected]
      * @return {Promise}
@@ -115,7 +115,7 @@ class Cursor {
      *
      * For more information visit:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
-     * 
+     *
      * @param  {Function} rejected
      * @return {Promise}
      */

--- a/src/Datastore.js
+++ b/src/Datastore.js
@@ -1,11 +1,11 @@
 const
     Cursor = require('./Cursor'),
     EventEmitter = require('events'),
-    OriginalDatastore = require('nedb')
+    OriginalDatastore = require('./nedb/datastore')
 
 /**
  * @summary
- * As of v2.0.0 the Datastore class extends node's built 
+ * As of v2.0.0 the Datastore class extends node's built
  * in EventEmitter class and implements each method as an event
  * plus additional error events. It also inherits the `compaction.done`
  * event from nedb but for consistency, in this library the event
@@ -17,12 +17,12 @@ const
  *
  * All events have a matching error event that goes by the name of `${method}Error`,
  * for example `findError` or `loadError`. The callbacks of these events will receive
- * the same parameters as the normal event handlers except that instead of the 
+ * the same parameters as the normal event handlers except that instead of the
  * operation result there will be an operation error. (Check out the second example!)
  *
  * A generic `__error__` event is also available. This event will be emitted at any of
  * the above error events. The callbacks of this event will receive the same parameters
- * as the specific error event handlers except that there will be one more parameter 
+ * as the specific error event handlers except that there will be one more parameter
  * passed between the datastore and the error object, that being the name of the method
  * that failed. (Check out the third example!)
  *
@@ -57,7 +57,7 @@ const
  *     // for example
  *     // datastore, 'find', error, [{ foo: 'bar' }, {}]
  * })
- * 
+ *
  * @class
  */
 class Datastore extends EventEmitter {
@@ -69,14 +69,14 @@ class Datastore extends EventEmitter {
      * the original datastore's properties such as `datastore.persistence`.
      *
      * Create a Datastore instance.
-     * 
+     *
      * Note that the datastore will be created
      * relative to `process.cwd()`
      * (unless an absolute path was passed).
-     * 
+     *
      * It's basically the same as the original:
      * https://github.com/louischatriot/nedb#creatingloading-a-database
-     * 
+     *
      * @param  {string|Object} [pathOrOptions]
      * @return {static}
      */
@@ -143,7 +143,7 @@ class Datastore extends EventEmitter {
      * @example
      * // in an async function
      * await datastore.find({ ... }).sort({ ... })
-     * 
+     *
      * @param  {Object} [query]
      * @param  {Object} [projection]
      * @return {Cursor}
@@ -179,7 +179,7 @@ class Datastore extends EventEmitter {
      * @example
      * // in an async function
      * await datastore.findOne({ ... }).sort({ ... })
-     * 
+     *
      * @param  {Object} [query]
      * @param  {Object} [projection]
      * @return {Cursor}
@@ -208,7 +208,7 @@ class Datastore extends EventEmitter {
      *
      * It's basically the same as the original:
      * https://github.com/louischatriot/nedb#inserting-documents
-     * 
+     *
      * @param  {Object|Object[]} docs
      * @return {Promise.<Object|Object[]>}
      */
@@ -239,7 +239,7 @@ class Datastore extends EventEmitter {
      * the returned promise will resolve with
      * an object (if `options.multi` is `false`) or
      * with an array of objects.
-     * 
+     *
      * @param  {Object} query
      * @param  {Object} update
      * @param  {Object} [options]
@@ -275,7 +275,7 @@ class Datastore extends EventEmitter {
      *
      * It's basically the same as the original:
      * https://github.com/louischatriot/nedb#removing-documents
-     * 
+     *
      * @param  {Object} [query]
      * @param  {Object} [options]
      * @return {Promise.<number>}
@@ -315,7 +315,7 @@ class Datastore extends EventEmitter {
      * await datastore.count({ ... })
      * // or
      * await datastore.count({ ... }).sort(...).limit(...)
-     * 
+     *
      * @param  {Object} [query]
      * @return {Cursor}
      */
@@ -336,7 +336,7 @@ class Datastore extends EventEmitter {
 
     /**
      * https://github.com/louischatriot/nedb#indexing
-     * 
+     *
      * @param  {Object} options
      * @return {Promise.<undefined>}
      */
@@ -357,7 +357,7 @@ class Datastore extends EventEmitter {
 
     /**
      * https://github.com/louischatriot/nedb#indexing
-     * 
+     *
      * @param  {string} field
      * @return {Promise.<undefined>}
      */
@@ -389,7 +389,7 @@ class Datastore extends EventEmitter {
      *
      * For more information visit:
      * https://github.com/louischatriot/nedb#creatingloading-a-database
-     * 
+     *
      * @param  {string|Object} [pathOrOptions]
      * @return {Proxy.<static>}
      */

--- a/src/binarySearchTree/avltree.js
+++ b/src/binarySearchTree/avltree.js
@@ -1,0 +1,455 @@
+/**
+ * Self-balancing binary search tree using the AVL implementation
+ */
+var BinarySearchTree = require('./bst')
+  , customUtils = require('./customUtils')
+  , util = require('util')
+  , _ = require('underscore')
+  ;
+
+
+/**
+ * Constructor
+ * We can't use a direct pointer to the root node (as in the simple binary search tree)
+ * as the root will change during tree rotations
+ * @param {Boolean}  options.unique Whether to enforce a 'unique' constraint on the key or not
+ * @param {Function} options.compareKeys Initialize this BST's compareKeys
+ */
+function AVLTree (options) {
+  this.tree = new _AVLTree(options);
+}
+
+
+/**
+ * Constructor of the internal AVLTree
+ * @param {Object} options Optional
+ * @param {Boolean}  options.unique Whether to enforce a 'unique' constraint on the key or not
+ * @param {Key}      options.key Initialize this BST's key with key
+ * @param {Value}    options.value Initialize this BST's data with [value]
+ * @param {Function} options.compareKeys Initialize this BST's compareKeys
+ */
+function _AVLTree (options) {
+  options = options || {};
+
+  this.left = null;
+  this.right = null;
+  this.parent = options.parent !== undefined ? options.parent : null;
+  if (options.hasOwnProperty('key')) { this.key = options.key; }
+  this.data = options.hasOwnProperty('value') ? [options.value] : [];
+  this.unique = options.unique || false;
+
+  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction;
+  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality;
+}
+
+
+/**
+ * Inherit basic functions from the basic binary search tree
+ */
+util.inherits(_AVLTree, BinarySearchTree);
+
+/**
+ * Keep a pointer to the internal tree constructor for testing purposes
+ */
+AVLTree._AVLTree = _AVLTree;
+
+
+/**
+ * Check the recorded height is correct for every node
+ * Throws if one height doesn't match
+ */
+_AVLTree.prototype.checkHeightCorrect = function () {
+  var leftH, rightH;
+
+  if (!this.hasOwnProperty('key')) { return; }   // Empty tree
+
+  if (this.left && this.left.height === undefined) { throw new Error("Undefined height for node " + this.left.key); }
+  if (this.right && this.right.height === undefined) { throw new Error("Undefined height for node " + this.right.key); }
+  if (this.height === undefined) { throw new Error("Undefined height for node " + this.key); }
+
+  leftH = this.left ? this.left.height : 0;
+  rightH = this.right ? this.right.height : 0;
+
+  if (this.height !== 1 + Math.max(leftH, rightH)) { throw new Error("Height constraint failed for node " + this.key); }
+  if (this.left) { this.left.checkHeightCorrect(); }
+  if (this.right) { this.right.checkHeightCorrect(); }
+};
+
+
+/**
+ * Return the balance factor
+ */
+_AVLTree.prototype.balanceFactor = function () {
+  var leftH = this.left ? this.left.height : 0
+    , rightH = this.right ? this.right.height : 0
+    ;
+  return leftH - rightH;
+};
+
+
+/**
+ * Check that the balance factors are all between -1 and 1
+ */
+_AVLTree.prototype.checkBalanceFactors = function () {
+  if (Math.abs(this.balanceFactor()) > 1) { throw new Error('Tree is unbalanced at node ' + this.key); }
+
+  if (this.left) { this.left.checkBalanceFactors(); }
+  if (this.right) { this.right.checkBalanceFactors(); }
+};
+
+
+/**
+ * When checking if the BST conditions are met, also check that the heights are correct
+ * and the tree is balanced
+ */
+_AVLTree.prototype.checkIsAVLT = function () {
+  _AVLTree.super_.prototype.checkIsBST.call(this);
+  this.checkHeightCorrect();
+  this.checkBalanceFactors();
+};
+AVLTree.prototype.checkIsAVLT = function () { this.tree.checkIsAVLT(); };
+
+
+/**
+ * Perform a right rotation of the tree if possible
+ * and return the root of the resulting tree
+ * The resulting tree's nodes' heights are also updated
+ */
+_AVLTree.prototype.rightRotation = function () {
+  var q = this
+    , p = this.left
+    , b
+    , ah, bh, ch;
+
+  if (!p) { return this; }   // No change
+
+  b = p.right;
+
+  // Alter tree structure
+  if (q.parent) {
+    p.parent = q.parent;
+    if (q.parent.left === q) { q.parent.left = p; } else { q.parent.right = p; }
+  } else {
+    p.parent = null;
+  }
+  p.right = q;
+  q.parent = p;
+  q.left = b;
+  if (b) { b.parent = q; }
+
+  // Update heights
+  ah = p.left ? p.left.height : 0;
+  bh = b ? b.height : 0;
+  ch = q.right ? q.right.height : 0;
+  q.height = Math.max(bh, ch) + 1;
+  p.height = Math.max(ah, q.height) + 1;
+
+  return p;
+};
+
+
+/**
+ * Perform a left rotation of the tree if possible
+ * and return the root of the resulting tree
+ * The resulting tree's nodes' heights are also updated
+ */
+_AVLTree.prototype.leftRotation = function () {
+  var p = this
+    , q = this.right
+    , b
+    , ah, bh, ch;
+
+  if (!q) { return this; }   // No change
+
+  b = q.left;
+
+  // Alter tree structure
+  if (p.parent) {
+    q.parent = p.parent;
+    if (p.parent.left === p) { p.parent.left = q; } else { p.parent.right = q; }
+  } else {
+    q.parent = null;
+  }
+  q.left = p;
+  p.parent = q;
+  p.right = b;
+  if (b) { b.parent = p; }
+
+  // Update heights
+  ah = p.left ? p.left.height : 0;
+  bh = b ? b.height : 0;
+  ch = q.right ? q.right.height : 0;
+  p.height = Math.max(ah, bh) + 1;
+  q.height = Math.max(ch, p.height) + 1;
+
+  return q;
+};
+
+
+/**
+ * Modify the tree if its right subtree is too small compared to the left
+ * Return the new root if any
+ */
+_AVLTree.prototype.rightTooSmall = function () {
+  if (this.balanceFactor() <= 1) { return this; }   // Right is not too small, don't change
+
+  if (this.left.balanceFactor() < 0) {
+    this.left.leftRotation();
+  }
+
+  return this.rightRotation();
+};
+
+
+/**
+ * Modify the tree if its left subtree is too small compared to the right
+ * Return the new root if any
+ */
+_AVLTree.prototype.leftTooSmall = function () {
+  if (this.balanceFactor() >= -1) { return this; }   // Left is not too small, don't change
+
+  if (this.right.balanceFactor() > 0) {
+    this.right.rightRotation();
+  }
+
+  return this.leftRotation();
+};
+
+
+/**
+ * Rebalance the tree along the given path. The path is given reversed (as he was calculated
+ * in the insert and delete functions).
+ * Returns the new root of the tree
+ * Of course, the first element of the path must be the root of the tree
+ */
+_AVLTree.prototype.rebalanceAlongPath = function (path) {
+  var newRoot = this
+    , rotated
+    , i;
+
+  if (!this.hasOwnProperty('key')) { delete this.height; return this; }   // Empty tree
+
+  // Rebalance the tree and update all heights
+  for (i = path.length - 1; i >= 0; i -= 1) {
+    path[i].height = 1 + Math.max(path[i].left ? path[i].left.height : 0, path[i].right ? path[i].right.height : 0);
+
+    if (path[i].balanceFactor() > 1) {
+      rotated = path[i].rightTooSmall();
+      if (i === 0) { newRoot = rotated; }
+    }
+
+    if (path[i].balanceFactor() < -1) {
+      rotated = path[i].leftTooSmall();
+      if (i === 0) { newRoot = rotated; }
+    }
+  }
+
+  return newRoot;
+};
+
+
+/**
+ * Insert a key, value pair in the tree while maintaining the AVL tree height constraint
+ * Return a pointer to the root node, which may have changed
+ */
+_AVLTree.prototype.insert = function (key, value) {
+  var insertPath = []
+    , currentNode = this
+    ;
+
+  // Empty tree, insert as root
+  if (!this.hasOwnProperty('key')) {
+    this.key = key;
+    this.data.push(value);
+    this.height = 1;
+    return this;
+  }
+
+  // Insert new leaf at the right place
+  while (true) {
+    // Same key: no change in the tree structure
+    if (currentNode.compareKeys(currentNode.key, key) === 0) {
+      if (currentNode.unique) {
+        var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
+        err.key = key;
+        err.errorType = 'uniqueViolated';
+        throw err;
+      } else {
+        currentNode.data.push(value);
+      }
+      return this;
+    }
+
+    insertPath.push(currentNode);
+
+    if (currentNode.compareKeys(key, currentNode.key) < 0) {
+      if (!currentNode.left) {
+        insertPath.push(currentNode.createLeftChild({ key: key, value: value }));
+        break;
+      } else {
+        currentNode = currentNode.left;
+      }
+    } else {
+      if (!currentNode.right) {
+        insertPath.push(currentNode.createRightChild({ key: key, value: value }));
+        break;
+      } else {
+        currentNode = currentNode.right;
+      }
+    }
+  }
+
+  return this.rebalanceAlongPath(insertPath);
+};
+
+// Insert in the internal tree, update the pointer to the root if needed
+AVLTree.prototype.insert = function (key, value) {
+  var newTree = this.tree.insert(key, value);
+
+  // If newTree is undefined, that means its structure was not modified
+  if (newTree) { this.tree = newTree; }
+};
+
+
+/**
+ * Delete a key or just a value and return the new root of the tree
+ * @param {Key} key
+ * @param {Value} value Optional. If not set, the whole key is deleted. If set, only this value is deleted
+ */
+_AVLTree.prototype.delete = function (key, value) {
+  var newData = [], replaceWith
+    , self = this
+    , currentNode = this
+    , deletePath = []
+    ;
+
+  if (!this.hasOwnProperty('key')) { return this; }   // Empty tree
+
+  // Either no match is found and the function will return from within the loop
+  // Or a match is found and deletePath will contain the path from the root to the node to delete after the loop
+  while (true) {
+    if (currentNode.compareKeys(key, currentNode.key) === 0) { break; }
+
+    deletePath.push(currentNode);
+
+    if (currentNode.compareKeys(key, currentNode.key) < 0) {
+      if (currentNode.left) {
+        currentNode = currentNode.left;
+      } else {
+        return this;   // Key not found, no modification
+      }
+    } else {
+      // currentNode.compareKeys(key, currentNode.key) is > 0
+      if (currentNode.right) {
+        currentNode = currentNode.right;
+      } else {
+        return this;   // Key not found, no modification
+      }
+    }
+  }
+
+  // Delete only a value (no tree modification)
+  if (currentNode.data.length > 1 && value !== undefined) {
+    currentNode.data.forEach(function (d) {
+      if (!currentNode.checkValueEquality(d, value)) { newData.push(d); }
+    });
+    currentNode.data = newData;
+    return this;
+  }
+
+  // Delete a whole node
+
+  // Leaf
+  if (!currentNode.left && !currentNode.right) {
+    if (currentNode === this) {   // This leaf is also the root
+      delete currentNode.key;
+      currentNode.data = [];
+      delete currentNode.height;
+      return this;
+    } else {
+      if (currentNode.parent.left === currentNode) {
+        currentNode.parent.left = null;
+      } else {
+        currentNode.parent.right = null;
+      }
+      return this.rebalanceAlongPath(deletePath);
+    }
+  }
+
+
+  // Node with only one child
+  if (!currentNode.left || !currentNode.right) {
+    replaceWith = currentNode.left ? currentNode.left : currentNode.right;
+
+    if (currentNode === this) {   // This node is also the root
+      replaceWith.parent = null;
+      return replaceWith;   // height of replaceWith is necessarily 1 because the tree was balanced before deletion
+    } else {
+      if (currentNode.parent.left === currentNode) {
+        currentNode.parent.left = replaceWith;
+        replaceWith.parent = currentNode.parent;
+      } else {
+        currentNode.parent.right = replaceWith;
+        replaceWith.parent = currentNode.parent;
+      }
+
+      return this.rebalanceAlongPath(deletePath);
+    }
+  }
+
+
+  // Node with two children
+  // Use the in-order predecessor (no need to randomize since we actively rebalance)
+  deletePath.push(currentNode);
+  replaceWith = currentNode.left;
+
+  // Special case: the in-order predecessor is right below the node to delete
+  if (!replaceWith.right) {
+    currentNode.key = replaceWith.key;
+    currentNode.data = replaceWith.data;
+    currentNode.left = replaceWith.left;
+    if (replaceWith.left) { replaceWith.left.parent = currentNode; }
+    return this.rebalanceAlongPath(deletePath);
+  }
+
+  // After this loop, replaceWith is the right-most leaf in the left subtree
+  // and deletePath the path from the root (inclusive) to replaceWith (exclusive)
+  while (true) {
+    if (replaceWith.right) {
+      deletePath.push(replaceWith);
+      replaceWith = replaceWith.right;
+    } else {
+      break;
+    }
+  }
+
+  currentNode.key = replaceWith.key;
+  currentNode.data = replaceWith.data;
+
+  replaceWith.parent.right = replaceWith.left;
+  if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+
+  return this.rebalanceAlongPath(deletePath);
+};
+
+// Delete a value
+AVLTree.prototype.delete = function (key, value) {
+  var newTree = this.tree.delete(key, value);
+
+  // If newTree is undefined, that means its structure was not modified
+  if (newTree) { this.tree = newTree; }
+};
+
+
+/**
+ * Other functions we want to use on an AVLTree as if it were the internal _AVLTree
+ */
+['getNumberOfKeys', 'search', 'betweenBounds', 'prettyPrint', 'executeOnEveryNode'].forEach(function (fn) {
+  AVLTree.prototype[fn] = function () {
+    return this.tree[fn].apply(this.tree, arguments);
+  };
+});
+
+
+// Interface
+module.exports = AVLTree;

--- a/src/binarySearchTree/avltree.js
+++ b/src/binarySearchTree/avltree.js
@@ -2,11 +2,9 @@
  * Self-balancing binary search tree using the AVL implementation
  */
 var BinarySearchTree = require('./bst')
-  , customUtils = require('./customUtils')
-  , util = require('util')
-  , _ = require('underscore')
-  ;
-
+var customUtils = require('./customUtils')
+var util = require('util')
+var _ = require('underscore')
 
 /**
  * Constructor
@@ -16,9 +14,8 @@ var BinarySearchTree = require('./bst')
  * @param {Function} options.compareKeys Initialize this BST's compareKeys
  */
 function AVLTree (options) {
-  this.tree = new _AVLTree(options);
+  this.tree = new _AVLTree(options)
 }
-
 
 /**
  * Constructor of the internal AVLTree
@@ -29,86 +26,80 @@ function AVLTree (options) {
  * @param {Function} options.compareKeys Initialize this BST's compareKeys
  */
 function _AVLTree (options) {
-  options = options || {};
+  options = options || {}
 
-  this.left = null;
-  this.right = null;
-  this.parent = options.parent !== undefined ? options.parent : null;
-  if (options.hasOwnProperty('key')) { this.key = options.key; }
-  this.data = options.hasOwnProperty('value') ? [options.value] : [];
-  this.unique = options.unique || false;
+  this.left = null
+  this.right = null
+  this.parent = options.parent !== undefined ? options.parent : null
+  if (options.hasOwnProperty('key')) { this.key = options.key }
+  this.data = options.hasOwnProperty('value') ? [options.value] : []
+  this.unique = options.unique || false
 
-  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction;
-  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality;
+  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction
+  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality
 }
-
 
 /**
  * Inherit basic functions from the basic binary search tree
  */
-util.inherits(_AVLTree, BinarySearchTree);
+util.inherits(_AVLTree, BinarySearchTree)
 
 /**
  * Keep a pointer to the internal tree constructor for testing purposes
  */
-AVLTree._AVLTree = _AVLTree;
-
+AVLTree._AVLTree = _AVLTree
 
 /**
  * Check the recorded height is correct for every node
  * Throws if one height doesn't match
  */
 _AVLTree.prototype.checkHeightCorrect = function () {
-  var leftH, rightH;
+  let leftH
+  let rightH
 
-  if (!this.hasOwnProperty('key')) { return; }   // Empty tree
+  if (!this.hasOwnProperty('key')) { return }   // Empty tree
 
-  if (this.left && this.left.height === undefined) { throw new Error("Undefined height for node " + this.left.key); }
-  if (this.right && this.right.height === undefined) { throw new Error("Undefined height for node " + this.right.key); }
-  if (this.height === undefined) { throw new Error("Undefined height for node " + this.key); }
+  if (this.left && this.left.height === undefined) { throw new Error('Undefined height for node ' + this.left.key) }
+  if (this.right && this.right.height === undefined) { throw new Error('Undefined height for node ' + this.right.key) }
+  if (this.height === undefined) { throw new Error('Undefined height for node ' + this.key) }
 
-  leftH = this.left ? this.left.height : 0;
-  rightH = this.right ? this.right.height : 0;
+  leftH = this.left ? this.left.height : 0
+  rightH = this.right ? this.right.height : 0
 
-  if (this.height !== 1 + Math.max(leftH, rightH)) { throw new Error("Height constraint failed for node " + this.key); }
-  if (this.left) { this.left.checkHeightCorrect(); }
-  if (this.right) { this.right.checkHeightCorrect(); }
-};
-
+  if (this.height !== 1 + Math.max(leftH, rightH)) { throw new Error('Height constraint failed for node ' + this.key) }
+  if (this.left) { this.left.checkHeightCorrect() }
+  if (this.right) { this.right.checkHeightCorrect() }
+}
 
 /**
  * Return the balance factor
  */
 _AVLTree.prototype.balanceFactor = function () {
-  var leftH = this.left ? this.left.height : 0
-    , rightH = this.right ? this.right.height : 0
-    ;
-  return leftH - rightH;
-};
-
+  const leftH = this.left ? this.left.height : 0
+  const rightH = this.right ? this.right.height : 0
+  return leftH - rightH
+}
 
 /**
  * Check that the balance factors are all between -1 and 1
  */
 _AVLTree.prototype.checkBalanceFactors = function () {
-  if (Math.abs(this.balanceFactor()) > 1) { throw new Error('Tree is unbalanced at node ' + this.key); }
+  if (Math.abs(this.balanceFactor()) > 1) { throw new Error('Tree is unbalanced at node ' + this.key) }
 
-  if (this.left) { this.left.checkBalanceFactors(); }
-  if (this.right) { this.right.checkBalanceFactors(); }
-};
-
+  if (this.left) { this.left.checkBalanceFactors() }
+  if (this.right) { this.right.checkBalanceFactors() }
+}
 
 /**
  * When checking if the BST conditions are met, also check that the heights are correct
  * and the tree is balanced
  */
 _AVLTree.prototype.checkIsAVLT = function () {
-  _AVLTree.super_.prototype.checkIsBST.call(this);
-  this.checkHeightCorrect();
-  this.checkBalanceFactors();
-};
-AVLTree.prototype.checkIsAVLT = function () { this.tree.checkIsAVLT(); };
-
+  _AVLTree.super_.prototype.checkIsBST.call(this)
+  this.checkHeightCorrect()
+  this.checkBalanceFactors()
+}
+AVLTree.prototype.checkIsAVLT = function () { this.tree.checkIsAVLT() }
 
 /**
  * Perform a right rotation of the tree if possible
@@ -116,37 +107,38 @@ AVLTree.prototype.checkIsAVLT = function () { this.tree.checkIsAVLT(); };
  * The resulting tree's nodes' heights are also updated
  */
 _AVLTree.prototype.rightRotation = function () {
-  var q = this
-    , p = this.left
-    , b
-    , ah, bh, ch;
+  const q = this
+  const p = this.left
+  let b
+  let ah
+  let bh
+  let ch
 
-  if (!p) { return this; }   // No change
+  if (!p) { return this }   // No change
 
-  b = p.right;
+  b = p.right
 
   // Alter tree structure
   if (q.parent) {
-    p.parent = q.parent;
-    if (q.parent.left === q) { q.parent.left = p; } else { q.parent.right = p; }
+    p.parent = q.parent
+    if (q.parent.left === q) { q.parent.left = p } else { q.parent.right = p }
   } else {
-    p.parent = null;
+    p.parent = null
   }
-  p.right = q;
-  q.parent = p;
-  q.left = b;
-  if (b) { b.parent = q; }
+  p.right = q
+  q.parent = p
+  q.left = b
+  if (b) { b.parent = q }
 
   // Update heights
-  ah = p.left ? p.left.height : 0;
-  bh = b ? b.height : 0;
-  ch = q.right ? q.right.height : 0;
-  q.height = Math.max(bh, ch) + 1;
-  p.height = Math.max(ah, q.height) + 1;
+  ah = p.left ? p.left.height : 0
+  bh = b ? b.height : 0
+  ch = q.right ? q.right.height : 0
+  q.height = Math.max(bh, ch) + 1
+  p.height = Math.max(ah, q.height) + 1
 
-  return p;
-};
-
+  return p
+}
 
 /**
  * Perform a left rotation of the tree if possible
@@ -154,67 +146,66 @@ _AVLTree.prototype.rightRotation = function () {
  * The resulting tree's nodes' heights are also updated
  */
 _AVLTree.prototype.leftRotation = function () {
-  var p = this
-    , q = this.right
-    , b
-    , ah, bh, ch;
+  const p = this
+  const q = this.right
+  let b
+  let ah
+  let bh
+  let ch
 
-  if (!q) { return this; }   // No change
+  if (!q) { return this }   // No change
 
-  b = q.left;
+  b = q.left
 
   // Alter tree structure
   if (p.parent) {
-    q.parent = p.parent;
-    if (p.parent.left === p) { p.parent.left = q; } else { p.parent.right = q; }
+    q.parent = p.parent
+    if (p.parent.left === p) { p.parent.left = q } else { p.parent.right = q }
   } else {
-    q.parent = null;
+    q.parent = null
   }
-  q.left = p;
-  p.parent = q;
-  p.right = b;
-  if (b) { b.parent = p; }
+  q.left = p
+  p.parent = q
+  p.right = b
+  if (b) { b.parent = p }
 
   // Update heights
-  ah = p.left ? p.left.height : 0;
-  bh = b ? b.height : 0;
-  ch = q.right ? q.right.height : 0;
-  p.height = Math.max(ah, bh) + 1;
-  q.height = Math.max(ch, p.height) + 1;
+  ah = p.left ? p.left.height : 0
+  bh = b ? b.height : 0
+  ch = q.right ? q.right.height : 0
+  p.height = Math.max(ah, bh) + 1
+  q.height = Math.max(ch, p.height) + 1
 
-  return q;
-};
-
+  return q
+}
 
 /**
  * Modify the tree if its right subtree is too small compared to the left
  * Return the new root if any
  */
 _AVLTree.prototype.rightTooSmall = function () {
-  if (this.balanceFactor() <= 1) { return this; }   // Right is not too small, don't change
+  if (this.balanceFactor() <= 1) { return this }   // Right is not too small, don't change
 
   if (this.left.balanceFactor() < 0) {
-    this.left.leftRotation();
+    this.left.leftRotation()
   }
 
-  return this.rightRotation();
-};
-
+  return this.rightRotation()
+}
 
 /**
  * Modify the tree if its left subtree is too small compared to the right
  * Return the new root if any
  */
 _AVLTree.prototype.leftTooSmall = function () {
-  if (this.balanceFactor() >= -1) { return this; }   // Left is not too small, don't change
+  if (this.balanceFactor() >= -1) { return this }   // Left is not too small, don't change
 
   if (this.right.balanceFactor() > 0) {
-    this.right.rightRotation();
+    this.right.rightRotation()
   }
 
-  return this.leftRotation();
-};
-
+  return this.leftRotation()
+}
 
 /**
  * Rebalance the tree along the given path. The path is given reversed (as he was calculated
@@ -223,46 +214,47 @@ _AVLTree.prototype.leftTooSmall = function () {
  * Of course, the first element of the path must be the root of the tree
  */
 _AVLTree.prototype.rebalanceAlongPath = function (path) {
-  var newRoot = this
-    , rotated
-    , i;
+  let newRoot = this
+  let rotated
+  let i
 
-  if (!this.hasOwnProperty('key')) { delete this.height; return this; }   // Empty tree
+  if (!this.hasOwnProperty('key')) {
+    delete this.height
+    return this
+  }   // Empty tree
 
   // Rebalance the tree and update all heights
   for (i = path.length - 1; i >= 0; i -= 1) {
-    path[i].height = 1 + Math.max(path[i].left ? path[i].left.height : 0, path[i].right ? path[i].right.height : 0);
+    path[i].height = 1 + Math.max(path[i].left ? path[i].left.height : 0, path[i].right ? path[i].right.height : 0)
 
     if (path[i].balanceFactor() > 1) {
-      rotated = path[i].rightTooSmall();
-      if (i === 0) { newRoot = rotated; }
+      rotated = path[i].rightTooSmall()
+      if (i === 0) { newRoot = rotated }
     }
 
     if (path[i].balanceFactor() < -1) {
-      rotated = path[i].leftTooSmall();
-      if (i === 0) { newRoot = rotated; }
+      rotated = path[i].leftTooSmall()
+      if (i === 0) { newRoot = rotated }
     }
   }
 
-  return newRoot;
-};
-
+  return newRoot
+}
 
 /**
  * Insert a key, value pair in the tree while maintaining the AVL tree height constraint
  * Return a pointer to the root node, which may have changed
  */
 _AVLTree.prototype.insert = function (key, value) {
-  var insertPath = []
-    , currentNode = this
-    ;
+  const insertPath = []
+  let currentNode = this
 
   // Empty tree, insert as root
   if (!this.hasOwnProperty('key')) {
-    this.key = key;
-    this.data.push(value);
-    this.height = 1;
-    return this;
+    this.key = key
+    this.data.push(value)
+    this.height = 1
+    return this
   }
 
   // Insert new leaf at the right place
@@ -270,46 +262,45 @@ _AVLTree.prototype.insert = function (key, value) {
     // Same key: no change in the tree structure
     if (currentNode.compareKeys(currentNode.key, key) === 0) {
       if (currentNode.unique) {
-        var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
-        err.key = key;
-        err.errorType = 'uniqueViolated';
-        throw err;
+        const err = new Error('Can\'t insert key ' + key + ', it violates the unique constraint')
+        err.key = key
+        err.errorType = 'uniqueViolated'
+        throw err
       } else {
-        currentNode.data.push(value);
+        currentNode.data.push(value)
       }
-      return this;
+      return this
     }
 
-    insertPath.push(currentNode);
+    insertPath.push(currentNode)
 
     if (currentNode.compareKeys(key, currentNode.key) < 0) {
       if (!currentNode.left) {
-        insertPath.push(currentNode.createLeftChild({ key: key, value: value }));
-        break;
+        insertPath.push(currentNode.createLeftChild({ key: key, value: value }))
+        break
       } else {
-        currentNode = currentNode.left;
+        currentNode = currentNode.left
       }
     } else {
       if (!currentNode.right) {
-        insertPath.push(currentNode.createRightChild({ key: key, value: value }));
-        break;
+        insertPath.push(currentNode.createRightChild({ key: key, value: value }))
+        break
       } else {
-        currentNode = currentNode.right;
+        currentNode = currentNode.right
       }
     }
   }
 
-  return this.rebalanceAlongPath(insertPath);
-};
+  return this.rebalanceAlongPath(insertPath)
+}
 
 // Insert in the internal tree, update the pointer to the root if needed
 AVLTree.prototype.insert = function (key, value) {
-  var newTree = this.tree.insert(key, value);
+  const newTree = this.tree.insert(key, value)
 
   // If newTree is undefined, that means its structure was not modified
-  if (newTree) { this.tree = newTree; }
-};
-
+  if (newTree) { this.tree = newTree }
+}
 
 /**
  * Delete a key or just a value and return the new root of the tree
@@ -317,33 +308,33 @@ AVLTree.prototype.insert = function (key, value) {
  * @param {Value} value Optional. If not set, the whole key is deleted. If set, only this value is deleted
  */
 _AVLTree.prototype.delete = function (key, value) {
-  var newData = [], replaceWith
-    , self = this
-    , currentNode = this
-    , deletePath = []
-    ;
+  const newData = []
+  let replaceWith
+  const self = this
+  let currentNode = this
+  const deletePath = []
 
-  if (!this.hasOwnProperty('key')) { return this; }   // Empty tree
+  if (!this.hasOwnProperty('key')) { return this }   // Empty tree
 
   // Either no match is found and the function will return from within the loop
   // Or a match is found and deletePath will contain the path from the root to the node to delete after the loop
   while (true) {
-    if (currentNode.compareKeys(key, currentNode.key) === 0) { break; }
+    if (currentNode.compareKeys(key, currentNode.key) === 0) { break }
 
-    deletePath.push(currentNode);
+    deletePath.push(currentNode)
 
     if (currentNode.compareKeys(key, currentNode.key) < 0) {
       if (currentNode.left) {
-        currentNode = currentNode.left;
+        currentNode = currentNode.left
       } else {
-        return this;   // Key not found, no modification
+        return this   // Key not found, no modification
       }
     } else {
       // currentNode.compareKeys(key, currentNode.key) is > 0
       if (currentNode.right) {
-        currentNode = currentNode.right;
+        currentNode = currentNode.right
       } else {
-        return this;   // Key not found, no modification
+        return this   // Key not found, no modification
       }
     }
   }
@@ -351,10 +342,10 @@ _AVLTree.prototype.delete = function (key, value) {
   // Delete only a value (no tree modification)
   if (currentNode.data.length > 1 && value !== undefined) {
     currentNode.data.forEach(function (d) {
-      if (!currentNode.checkValueEquality(d, value)) { newData.push(d); }
-    });
-    currentNode.data = newData;
-    return this;
+      if (!currentNode.checkValueEquality(d, value)) { newData.push(d) }
+    })
+    currentNode.data = newData
+    return this
   }
 
   // Delete a whole node
@@ -362,94 +353,90 @@ _AVLTree.prototype.delete = function (key, value) {
   // Leaf
   if (!currentNode.left && !currentNode.right) {
     if (currentNode === this) {   // This leaf is also the root
-      delete currentNode.key;
-      currentNode.data = [];
-      delete currentNode.height;
-      return this;
+      delete currentNode.key
+      currentNode.data = []
+      delete currentNode.height
+      return this
     } else {
       if (currentNode.parent.left === currentNode) {
-        currentNode.parent.left = null;
+        currentNode.parent.left = null
       } else {
-        currentNode.parent.right = null;
+        currentNode.parent.right = null
       }
-      return this.rebalanceAlongPath(deletePath);
+      return this.rebalanceAlongPath(deletePath)
     }
   }
-
 
   // Node with only one child
   if (!currentNode.left || !currentNode.right) {
-    replaceWith = currentNode.left ? currentNode.left : currentNode.right;
+    replaceWith = currentNode.left ? currentNode.left : currentNode.right
 
     if (currentNode === this) {   // This node is also the root
-      replaceWith.parent = null;
-      return replaceWith;   // height of replaceWith is necessarily 1 because the tree was balanced before deletion
+      replaceWith.parent = null
+      return replaceWith   // height of replaceWith is necessarily 1 because the tree was balanced before deletion
     } else {
       if (currentNode.parent.left === currentNode) {
-        currentNode.parent.left = replaceWith;
-        replaceWith.parent = currentNode.parent;
+        currentNode.parent.left = replaceWith
+        replaceWith.parent = currentNode.parent
       } else {
-        currentNode.parent.right = replaceWith;
-        replaceWith.parent = currentNode.parent;
+        currentNode.parent.right = replaceWith
+        replaceWith.parent = currentNode.parent
       }
 
-      return this.rebalanceAlongPath(deletePath);
+      return this.rebalanceAlongPath(deletePath)
     }
   }
 
-
   // Node with two children
   // Use the in-order predecessor (no need to randomize since we actively rebalance)
-  deletePath.push(currentNode);
-  replaceWith = currentNode.left;
+  deletePath.push(currentNode)
+  replaceWith = currentNode.left
 
   // Special case: the in-order predecessor is right below the node to delete
   if (!replaceWith.right) {
-    currentNode.key = replaceWith.key;
-    currentNode.data = replaceWith.data;
-    currentNode.left = replaceWith.left;
-    if (replaceWith.left) { replaceWith.left.parent = currentNode; }
-    return this.rebalanceAlongPath(deletePath);
+    currentNode.key = replaceWith.key
+    currentNode.data = replaceWith.data
+    currentNode.left = replaceWith.left
+    if (replaceWith.left) { replaceWith.left.parent = currentNode }
+    return this.rebalanceAlongPath(deletePath)
   }
 
   // After this loop, replaceWith is the right-most leaf in the left subtree
   // and deletePath the path from the root (inclusive) to replaceWith (exclusive)
   while (true) {
     if (replaceWith.right) {
-      deletePath.push(replaceWith);
-      replaceWith = replaceWith.right;
+      deletePath.push(replaceWith)
+      replaceWith = replaceWith.right
     } else {
-      break;
+      break
     }
   }
 
-  currentNode.key = replaceWith.key;
-  currentNode.data = replaceWith.data;
+  currentNode.key = replaceWith.key
+  currentNode.data = replaceWith.data
 
-  replaceWith.parent.right = replaceWith.left;
-  if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+  replaceWith.parent.right = replaceWith.left
+  if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent }
 
-  return this.rebalanceAlongPath(deletePath);
-};
+  return this.rebalanceAlongPath(deletePath)
+}
 
 // Delete a value
 AVLTree.prototype.delete = function (key, value) {
-  var newTree = this.tree.delete(key, value);
+  const newTree = this.tree.delete(key, value)
 
   // If newTree is undefined, that means its structure was not modified
-  if (newTree) { this.tree = newTree; }
-};
-
+  if (newTree) { this.tree = newTree }
+}
 
 /**
  * Other functions we want to use on an AVLTree as if it were the internal _AVLTree
  */
 ['getNumberOfKeys', 'search', 'betweenBounds', 'prettyPrint', 'executeOnEveryNode'].forEach(function (fn) {
   AVLTree.prototype[fn] = function () {
-    return this.tree[fn].apply(this.tree, arguments);
-  };
-});
-
+    return this.tree[fn].apply(this.tree, arguments)
+  }
+})
 
 // Interface
-module.exports = AVLTree;
+module.exports = AVLTree

--- a/src/binarySearchTree/avltree.js
+++ b/src/binarySearchTree/avltree.js
@@ -427,7 +427,7 @@ AVLTree.prototype.delete = function (key, value) {
 
   // If newTree is undefined, that means its structure was not modified
   if (newTree) { this.tree = newTree }
-}
+};
 
 /**
  * Other functions we want to use on an AVLTree as if it were the internal _AVLTree

--- a/src/binarySearchTree/bst.js
+++ b/src/binarySearchTree/bst.js
@@ -1,0 +1,543 @@
+/**
+ * Simple binary search tree
+ */
+var customUtils = require('./customUtils');
+
+
+/**
+ * Constructor
+ * @param {Object} options Optional
+ * @param {Boolean}  options.unique Whether to enforce a 'unique' constraint on the key or not
+ * @param {Key}      options.key Initialize this BST's key with key
+ * @param {Value}    options.value Initialize this BST's data with [value]
+ * @param {Function} options.compareKeys Initialize this BST's compareKeys
+ */
+function BinarySearchTree (options) {
+  options = options || {};
+
+  this.left = null;
+  this.right = null;
+  this.parent = options.parent !== undefined ? options.parent : null;
+  if (options.hasOwnProperty('key')) { this.key = options.key; }
+  this.data = options.hasOwnProperty('value') ? [options.value] : [];
+  this.unique = options.unique || false;
+
+  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction;
+  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality;
+}
+
+
+// ================================
+// Methods used to test the tree
+// ================================
+
+
+/**
+ * Get the descendant with max key
+ */
+BinarySearchTree.prototype.getMaxKeyDescendant = function () {
+  if (this.right) {
+    return this.right.getMaxKeyDescendant();
+  } else {
+    return this;
+  }
+};
+
+
+/**
+ * Get the maximum key
+ */
+BinarySearchTree.prototype.getMaxKey = function () {
+  return this.getMaxKeyDescendant().key;
+};
+
+
+/**
+ * Get the descendant with min key
+ */
+BinarySearchTree.prototype.getMinKeyDescendant = function () {
+  if (this.left) {
+    return this.left.getMinKeyDescendant()
+  } else {
+    return this;
+  }
+};
+
+
+/**
+ * Get the minimum key
+ */
+BinarySearchTree.prototype.getMinKey = function () {
+  return this.getMinKeyDescendant().key;
+};
+
+
+/**
+ * Check that all nodes (incl. leaves) fullfil condition given by fn
+ * test is a function passed every (key, data) and which throws if the condition is not met
+ */
+BinarySearchTree.prototype.checkAllNodesFullfillCondition = function (test) {
+  if (!this.hasOwnProperty('key')) { return; }
+
+  test(this.key, this.data);
+  if (this.left) { this.left.checkAllNodesFullfillCondition(test); }
+  if (this.right) { this.right.checkAllNodesFullfillCondition(test); }
+};
+
+
+/**
+ * Check that the core BST properties on node ordering are verified
+ * Throw if they aren't
+ */
+BinarySearchTree.prototype.checkNodeOrdering = function () {
+  var self = this;
+
+  if (!this.hasOwnProperty('key')) { return; }
+
+  if (this.left) {
+    this.left.checkAllNodesFullfillCondition(function (k) {
+      if (self.compareKeys(k, self.key) >= 0) {
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
+      }
+    });
+    this.left.checkNodeOrdering();
+  }
+
+  if (this.right) {
+    this.right.checkAllNodesFullfillCondition(function (k) {
+      if (self.compareKeys(k, self.key) <= 0) {
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
+      }
+    });
+    this.right.checkNodeOrdering();
+  }
+};
+
+
+/**
+ * Check that all pointers are coherent in this tree
+ */
+BinarySearchTree.prototype.checkInternalPointers = function () {
+  if (this.left) {
+    if (this.left.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
+    this.left.checkInternalPointers();
+  }
+
+  if (this.right) {
+    if (this.right.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
+    this.right.checkInternalPointers();
+  }
+};
+
+
+/**
+ * Check that a tree is a BST as defined here (node ordering and pointer references)
+ */
+BinarySearchTree.prototype.checkIsBST = function () {
+  this.checkNodeOrdering();
+  this.checkInternalPointers();
+  if (this.parent) { throw new Error("The root shouldn't have a parent"); }
+};
+
+
+/**
+ * Get number of keys inserted
+ */
+BinarySearchTree.prototype.getNumberOfKeys = function () {
+  var res;
+
+  if (!this.hasOwnProperty('key')) { return 0; }
+
+  res = 1;
+  if (this.left) { res += this.left.getNumberOfKeys(); }
+  if (this.right) { res += this.right.getNumberOfKeys(); }
+
+  return res;
+};
+
+
+
+// ============================================
+// Methods used to actually work on the tree
+// ============================================
+
+/**
+ * Create a BST similar (i.e. same options except for key and value) to the current one
+ * Use the same constructor (i.e. BinarySearchTree, AVLTree etc)
+ * @param {Object} options see constructor
+ */
+BinarySearchTree.prototype.createSimilar = function (options) {
+  options = options || {};
+  options.unique = this.unique;
+  options.compareKeys = this.compareKeys;
+  options.checkValueEquality = this.checkValueEquality;
+
+  return new this.constructor(options);
+};
+
+
+/**
+ * Create the left child of this BST and return it
+ */
+BinarySearchTree.prototype.createLeftChild = function (options) {
+  var leftChild = this.createSimilar(options);
+  leftChild.parent = this;
+  this.left = leftChild;
+
+  return leftChild;
+};
+
+
+/**
+ * Create the right child of this BST and return it
+ */
+BinarySearchTree.prototype.createRightChild = function (options) {
+  var rightChild = this.createSimilar(options);
+  rightChild.parent = this;
+  this.right = rightChild;
+
+  return rightChild;
+};
+
+
+/**
+ * Insert a new element
+ */
+BinarySearchTree.prototype.insert = function (key, value) {
+  // Empty tree, insert as root
+  if (!this.hasOwnProperty('key')) {
+    this.key = key;
+    this.data.push(value);
+    return;
+  }
+
+  // Same key as root
+  if (this.compareKeys(this.key, key) === 0) {
+    if (this.unique) {
+      var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
+      err.key = key;
+      err.errorType = 'uniqueViolated';
+      throw err;
+    } else {
+      this.data.push(value);
+    }
+    return;
+  }
+
+  if (this.compareKeys(key, this.key) < 0) {
+    // Insert in left subtree
+    if (this.left) {
+      this.left.insert(key, value);
+    } else {
+      this.createLeftChild({ key: key, value: value });
+    }
+  } else {
+    // Insert in right subtree
+    if (this.right) {
+      this.right.insert(key, value);
+    } else {
+      this.createRightChild({ key: key, value: value });
+    }
+  }
+};
+
+
+/**
+ * Search for all data corresponding to a key
+ */
+BinarySearchTree.prototype.search = function (key) {
+  if (!this.hasOwnProperty('key')) { return []; }
+
+  if (this.compareKeys(this.key, key) === 0) { return this.data; }
+
+  if (this.compareKeys(key, this.key) < 0) {
+    if (this.left) {
+      return this.left.search(key);
+    } else {
+      return [];
+    }
+  } else {
+    if (this.right) {
+      return this.right.search(key);
+    } else {
+      return [];
+    }
+  }
+};
+
+
+/**
+ * Return a function that tells whether a given key matches a lower bound
+ */
+BinarySearchTree.prototype.getLowerBoundMatcher = function (query) {
+  var self = this;
+
+  // No lower bound
+  if (!query.hasOwnProperty('$gt') && !query.hasOwnProperty('$gte')) {
+    return function () { return true; };
+  }
+
+  if (query.hasOwnProperty('$gt') && query.hasOwnProperty('$gte')) {
+    if (self.compareKeys(query.$gte, query.$gt) === 0) {
+      return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+    }
+
+    if (self.compareKeys(query.$gte, query.$gt) > 0) {
+      return function (key) { return self.compareKeys(key, query.$gte) >= 0; };
+    } else {
+      return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+    }
+  }
+
+  if (query.hasOwnProperty('$gt')) {
+    return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+  } else {
+    return function (key) { return self.compareKeys(key, query.$gte) >= 0; };
+  }
+};
+
+
+/**
+ * Return a function that tells whether a given key matches an upper bound
+ */
+BinarySearchTree.prototype.getUpperBoundMatcher = function (query) {
+  var self = this;
+
+  // No lower bound
+  if (!query.hasOwnProperty('$lt') && !query.hasOwnProperty('$lte')) {
+    return function () { return true; };
+  }
+
+  if (query.hasOwnProperty('$lt') && query.hasOwnProperty('$lte')) {
+    if (self.compareKeys(query.$lte, query.$lt) === 0) {
+      return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+    }
+
+    if (self.compareKeys(query.$lte, query.$lt) < 0) {
+      return function (key) { return self.compareKeys(key, query.$lte) <= 0; };
+    } else {
+      return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+    }
+  }
+
+  if (query.hasOwnProperty('$lt')) {
+    return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+  } else {
+    return function (key) { return self.compareKeys(key, query.$lte) <= 0; };
+  }
+};
+
+
+// Append all elements in toAppend to array
+function append (array, toAppend) {
+  var i;
+
+  for (i = 0; i < toAppend.length; i += 1) {
+    array.push(toAppend[i]);
+  }
+}
+
+
+/**
+ * Get all data for a key between bounds
+ * Return it in key order
+ * @param {Object} query Mongo-style query where keys are $lt, $lte, $gt or $gte (other keys are not considered)
+ * @param {Functions} lbm/ubm matching functions calculated at the first recursive step
+ */
+BinarySearchTree.prototype.betweenBounds = function (query, lbm, ubm) {
+  var res = [];
+
+  if (!this.hasOwnProperty('key')) { return []; }   // Empty tree
+
+  lbm = lbm || this.getLowerBoundMatcher(query);
+  ubm = ubm || this.getUpperBoundMatcher(query);
+
+  if (lbm(this.key) && this.left) { append(res, this.left.betweenBounds(query, lbm, ubm)); }
+  if (lbm(this.key) && ubm(this.key)) { append(res, this.data); }
+  if (ubm(this.key) && this.right) { append(res, this.right.betweenBounds(query, lbm, ubm)); }
+
+  return res;
+};
+
+
+/**
+ * Delete the current node if it is a leaf
+ * Return true if it was deleted
+ */
+BinarySearchTree.prototype.deleteIfLeaf = function () {
+  if (this.left || this.right) { return false; }
+
+  // The leaf is itself a root
+  if (!this.parent) {
+    delete this.key;
+    this.data = [];
+    return true;
+  }
+
+  if (this.parent.left === this) {
+    this.parent.left = null;
+  } else {
+    this.parent.right = null;
+  }
+
+  return true;
+};
+
+
+/**
+ * Delete the current node if it has only one child
+ * Return true if it was deleted
+ */
+BinarySearchTree.prototype.deleteIfOnlyOneChild = function () {
+  var child;
+
+  if (this.left && !this.right) { child = this.left; }
+  if (!this.left && this.right) { child = this.right; }
+  if (!child) { return false; }
+
+  // Root
+  if (!this.parent) {
+    this.key = child.key;
+    this.data = child.data;
+
+    this.left = null;
+    if (child.left) {
+      this.left = child.left;
+      child.left.parent = this;
+    }
+
+    this.right = null;
+    if (child.right) {
+      this.right = child.right;
+      child.right.parent = this;
+    }
+
+    return true;
+  }
+
+  if (this.parent.left === this) {
+    this.parent.left = child;
+    child.parent = this.parent;
+  } else {
+    this.parent.right = child;
+    child.parent = this.parent;
+  }
+
+  return true;
+};
+
+
+/**
+ * Delete a key or just a value
+ * @param {Key} key
+ * @param {Value} value Optional. If not set, the whole key is deleted. If set, only this value is deleted
+ */
+BinarySearchTree.prototype.delete = function (key, value) {
+  var newData = [], replaceWith
+    , self = this
+    ;
+
+  if (!this.hasOwnProperty('key')) { return; }
+
+  if (this.compareKeys(key, this.key) < 0) {
+    if (this.left) { this.left.delete(key, value); }
+    return;
+  }
+
+  if (this.compareKeys(key, this.key) > 0) {
+    if (this.right) { this.right.delete(key, value); }
+    return;
+  }
+
+  if (!this.compareKeys(key, this.key) === 0) { return; }
+
+  // Delete only a value
+  if (this.data.length > 1 && value !== undefined) {
+    this.data.forEach(function (d) {
+      if (!self.checkValueEquality(d, value)) { newData.push(d); }
+    });
+    self.data = newData;
+    return;
+  }
+
+  // Delete the whole node
+  if (this.deleteIfLeaf()) {
+    return;
+  }
+  if (this.deleteIfOnlyOneChild()) {
+    return;
+  }
+
+  // We are in the case where the node to delete has two children
+  if (Math.random() >= 0.5) {   // Randomize replacement to avoid unbalancing the tree too much
+    // Use the in-order predecessor
+    replaceWith = this.left.getMaxKeyDescendant();
+
+    this.key = replaceWith.key;
+    this.data = replaceWith.data;
+
+    if (this === replaceWith.parent) {   // Special case
+      this.left = replaceWith.left;
+      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+    } else {
+      replaceWith.parent.right = replaceWith.left;
+      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+    }
+  } else {
+    // Use the in-order successor
+    replaceWith = this.right.getMinKeyDescendant();
+
+    this.key = replaceWith.key;
+    this.data = replaceWith.data;
+
+    if (this === replaceWith.parent) {   // Special case
+      this.right = replaceWith.right;
+      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent; }
+    } else {
+      replaceWith.parent.left = replaceWith.right;
+      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent; }
+    }
+  }
+};
+
+
+/**
+ * Execute a function on every node of the tree, in key order
+ * @param {Function} fn Signature: node. Most useful will probably be node.key and node.data
+ */
+BinarySearchTree.prototype.executeOnEveryNode = function (fn) {
+  if (this.left) { this.left.executeOnEveryNode(fn); }
+  fn(this);
+  if (this.right) { this.right.executeOnEveryNode(fn); }
+};
+
+
+/**
+ * Pretty print a tree
+ * @param {Boolean} printData To print the nodes' data along with the key
+ */
+BinarySearchTree.prototype.prettyPrint = function (printData, spacing) {
+  spacing = spacing || "";
+
+  console.log(spacing + "* " + this.key);
+  if (printData) { console.log(spacing + "* " + this.data); }
+
+  if (!this.left && !this.right) { return; }
+
+  if (this.left) {
+    this.left.prettyPrint(printData, spacing + "  ");
+  } else {
+    console.log(spacing + "  *");
+  }
+  if (this.right) {
+    this.right.prettyPrint(printData, spacing + "  ");
+  } else {
+    console.log(spacing + "  *");
+  }
+};
+
+
+
+
+// Interface
+module.exports = BinarySearchTree;

--- a/src/binarySearchTree/bst.js
+++ b/src/binarySearchTree/bst.js
@@ -1,8 +1,7 @@
 /**
  * Simple binary search tree
  */
-var customUtils = require('./customUtils');
-
+const customUtils = require('./customUtils')
 
 /**
  * Constructor
@@ -13,44 +12,40 @@ var customUtils = require('./customUtils');
  * @param {Function} options.compareKeys Initialize this BST's compareKeys
  */
 function BinarySearchTree (options) {
-  options = options || {};
+  options = options || {}
 
-  this.left = null;
-  this.right = null;
-  this.parent = options.parent !== undefined ? options.parent : null;
-  if (options.hasOwnProperty('key')) { this.key = options.key; }
-  this.data = options.hasOwnProperty('value') ? [options.value] : [];
-  this.unique = options.unique || false;
+  this.left = null
+  this.right = null
+  this.parent = options.parent !== undefined ? options.parent : null
+  if (options.hasOwnProperty('key')) { this.key = options.key }
+  this.data = options.hasOwnProperty('value') ? [options.value] : []
+  this.unique = options.unique || false
 
-  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction;
-  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality;
+  this.compareKeys = options.compareKeys || customUtils.defaultCompareKeysFunction
+  this.checkValueEquality = options.checkValueEquality || customUtils.defaultCheckValueEquality
 }
-
 
 // ================================
 // Methods used to test the tree
 // ================================
-
 
 /**
  * Get the descendant with max key
  */
 BinarySearchTree.prototype.getMaxKeyDescendant = function () {
   if (this.right) {
-    return this.right.getMaxKeyDescendant();
+    return this.right.getMaxKeyDescendant()
   } else {
-    return this;
+    return this
   }
-};
-
+}
 
 /**
  * Get the maximum key
  */
 BinarySearchTree.prototype.getMaxKey = function () {
-  return this.getMaxKeyDescendant().key;
-};
-
+  return this.getMaxKeyDescendant().key
+}
 
 /**
  * Get the descendant with min key
@@ -59,103 +54,95 @@ BinarySearchTree.prototype.getMinKeyDescendant = function () {
   if (this.left) {
     return this.left.getMinKeyDescendant()
   } else {
-    return this;
+    return this
   }
-};
-
+}
 
 /**
  * Get the minimum key
  */
 BinarySearchTree.prototype.getMinKey = function () {
-  return this.getMinKeyDescendant().key;
-};
-
+  return this.getMinKeyDescendant().key
+}
 
 /**
  * Check that all nodes (incl. leaves) fullfil condition given by fn
  * test is a function passed every (key, data) and which throws if the condition is not met
  */
 BinarySearchTree.prototype.checkAllNodesFullfillCondition = function (test) {
-  if (!this.hasOwnProperty('key')) { return; }
+  if (!this.hasOwnProperty('key')) { return }
 
-  test(this.key, this.data);
-  if (this.left) { this.left.checkAllNodesFullfillCondition(test); }
-  if (this.right) { this.right.checkAllNodesFullfillCondition(test); }
-};
-
+  test(this.key, this.data)
+  if (this.left) { this.left.checkAllNodesFullfillCondition(test) }
+  if (this.right) { this.right.checkAllNodesFullfillCondition(test) }
+}
 
 /**
  * Check that the core BST properties on node ordering are verified
  * Throw if they aren't
  */
 BinarySearchTree.prototype.checkNodeOrdering = function () {
-  var self = this;
+  const self = this
 
-  if (!this.hasOwnProperty('key')) { return; }
+  if (!this.hasOwnProperty('key')) { return }
 
   if (this.left) {
     this.left.checkAllNodesFullfillCondition(function (k) {
       if (self.compareKeys(k, self.key) >= 0) {
-        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree')
       }
-    });
-    this.left.checkNodeOrdering();
+    })
+    this.left.checkNodeOrdering()
   }
 
   if (this.right) {
     this.right.checkAllNodesFullfillCondition(function (k) {
       if (self.compareKeys(k, self.key) <= 0) {
-        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree')
       }
-    });
-    this.right.checkNodeOrdering();
+    })
+    this.right.checkNodeOrdering()
   }
-};
-
+}
 
 /**
  * Check that all pointers are coherent in this tree
  */
 BinarySearchTree.prototype.checkInternalPointers = function () {
   if (this.left) {
-    if (this.left.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
-    this.left.checkInternalPointers();
+    if (this.left.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key) }
+    this.left.checkInternalPointers()
   }
 
   if (this.right) {
-    if (this.right.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
-    this.right.checkInternalPointers();
+    if (this.right.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key) }
+    this.right.checkInternalPointers()
   }
-};
-
+}
 
 /**
  * Check that a tree is a BST as defined here (node ordering and pointer references)
  */
 BinarySearchTree.prototype.checkIsBST = function () {
-  this.checkNodeOrdering();
-  this.checkInternalPointers();
-  if (this.parent) { throw new Error("The root shouldn't have a parent"); }
-};
-
+  this.checkNodeOrdering()
+  this.checkInternalPointers()
+  if (this.parent) { throw new Error('The root shouldn\'t have a parent') }
+}
 
 /**
  * Get number of keys inserted
  */
 BinarySearchTree.prototype.getNumberOfKeys = function () {
-  var res;
+  let res
 
-  if (!this.hasOwnProperty('key')) { return 0; }
+  if (!this.hasOwnProperty('key')) { return 0 }
 
-  res = 1;
-  if (this.left) { res += this.left.getNumberOfKeys(); }
-  if (this.right) { res += this.right.getNumberOfKeys(); }
+  res = 1
+  if (this.left) { res += this.left.getNumberOfKeys() }
+  if (this.right) { res += this.right.getNumberOfKeys() }
 
-  return res;
-};
-
-
+  return res
+}
 
 // ============================================
 // Methods used to actually work on the tree
@@ -167,38 +154,35 @@ BinarySearchTree.prototype.getNumberOfKeys = function () {
  * @param {Object} options see constructor
  */
 BinarySearchTree.prototype.createSimilar = function (options) {
-  options = options || {};
-  options.unique = this.unique;
-  options.compareKeys = this.compareKeys;
-  options.checkValueEquality = this.checkValueEquality;
+  options = options || {}
+  options.unique = this.unique
+  options.compareKeys = this.compareKeys
+  options.checkValueEquality = this.checkValueEquality
 
-  return new this.constructor(options);
-};
-
+  return new this.constructor(options)
+}
 
 /**
  * Create the left child of this BST and return it
  */
 BinarySearchTree.prototype.createLeftChild = function (options) {
-  var leftChild = this.createSimilar(options);
-  leftChild.parent = this;
-  this.left = leftChild;
+  const leftChild = this.createSimilar(options)
+  leftChild.parent = this
+  this.left = leftChild
 
-  return leftChild;
-};
-
+  return leftChild
+}
 
 /**
  * Create the right child of this BST and return it
  */
 BinarySearchTree.prototype.createRightChild = function (options) {
-  var rightChild = this.createSimilar(options);
-  rightChild.parent = this;
-  this.right = rightChild;
+  const rightChild = this.createSimilar(options)
+  rightChild.parent = this
+  this.right = rightChild
 
-  return rightChild;
-};
-
+  return rightChild
+}
 
 /**
  * Insert a new element
@@ -206,137 +190,132 @@ BinarySearchTree.prototype.createRightChild = function (options) {
 BinarySearchTree.prototype.insert = function (key, value) {
   // Empty tree, insert as root
   if (!this.hasOwnProperty('key')) {
-    this.key = key;
-    this.data.push(value);
-    return;
+    this.key = key
+    this.data.push(value)
+    return
   }
 
   // Same key as root
   if (this.compareKeys(this.key, key) === 0) {
     if (this.unique) {
-      var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
-      err.key = key;
-      err.errorType = 'uniqueViolated';
-      throw err;
+      var err = new Error('Can\'t insert key ' + key + ', it violates the unique constraint')
+      err.key = key
+      err.errorType = 'uniqueViolated'
+      throw err
     } else {
-      this.data.push(value);
+      this.data.push(value)
     }
-    return;
+    return
   }
 
   if (this.compareKeys(key, this.key) < 0) {
     // Insert in left subtree
     if (this.left) {
-      this.left.insert(key, value);
+      this.left.insert(key, value)
     } else {
-      this.createLeftChild({ key: key, value: value });
+      this.createLeftChild({ key: key, value: value })
     }
   } else {
     // Insert in right subtree
     if (this.right) {
-      this.right.insert(key, value);
+      this.right.insert(key, value)
     } else {
-      this.createRightChild({ key: key, value: value });
+      this.createRightChild({ key: key, value: value })
     }
   }
-};
-
+}
 
 /**
  * Search for all data corresponding to a key
  */
 BinarySearchTree.prototype.search = function (key) {
-  if (!this.hasOwnProperty('key')) { return []; }
+  if (!this.hasOwnProperty('key')) { return [] }
 
-  if (this.compareKeys(this.key, key) === 0) { return this.data; }
+  if (this.compareKeys(this.key, key) === 0) { return this.data }
 
   if (this.compareKeys(key, this.key) < 0) {
     if (this.left) {
-      return this.left.search(key);
+      return this.left.search(key)
     } else {
-      return [];
+      return []
     }
   } else {
     if (this.right) {
-      return this.right.search(key);
+      return this.right.search(key)
     } else {
-      return [];
+      return []
     }
   }
-};
-
+}
 
 /**
  * Return a function that tells whether a given key matches a lower bound
  */
 BinarySearchTree.prototype.getLowerBoundMatcher = function (query) {
-  var self = this;
+  const self = this
 
   // No lower bound
   if (!query.hasOwnProperty('$gt') && !query.hasOwnProperty('$gte')) {
-    return function () { return true; };
+    return function () { return true }
   }
 
   if (query.hasOwnProperty('$gt') && query.hasOwnProperty('$gte')) {
     if (self.compareKeys(query.$gte, query.$gt) === 0) {
-      return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+      return function (key) { return self.compareKeys(key, query.$gt) > 0 }
     }
 
     if (self.compareKeys(query.$gte, query.$gt) > 0) {
-      return function (key) { return self.compareKeys(key, query.$gte) >= 0; };
+      return function (key) { return self.compareKeys(key, query.$gte) >= 0 }
     } else {
-      return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+      return function (key) { return self.compareKeys(key, query.$gt) > 0 }
     }
   }
 
   if (query.hasOwnProperty('$gt')) {
-    return function (key) { return self.compareKeys(key, query.$gt) > 0; };
+    return function (key) { return self.compareKeys(key, query.$gt) > 0 }
   } else {
-    return function (key) { return self.compareKeys(key, query.$gte) >= 0; };
+    return function (key) { return self.compareKeys(key, query.$gte) >= 0 }
   }
-};
-
+}
 
 /**
  * Return a function that tells whether a given key matches an upper bound
  */
 BinarySearchTree.prototype.getUpperBoundMatcher = function (query) {
-  var self = this;
+  const self = this
 
   // No lower bound
   if (!query.hasOwnProperty('$lt') && !query.hasOwnProperty('$lte')) {
-    return function () { return true; };
+    return function () { return true }
   }
 
   if (query.hasOwnProperty('$lt') && query.hasOwnProperty('$lte')) {
     if (self.compareKeys(query.$lte, query.$lt) === 0) {
-      return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+      return function (key) { return self.compareKeys(key, query.$lt) < 0 }
     }
 
     if (self.compareKeys(query.$lte, query.$lt) < 0) {
-      return function (key) { return self.compareKeys(key, query.$lte) <= 0; };
+      return function (key) { return self.compareKeys(key, query.$lte) <= 0 }
     } else {
-      return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+      return function (key) { return self.compareKeys(key, query.$lt) < 0 }
     }
   }
 
   if (query.hasOwnProperty('$lt')) {
-    return function (key) { return self.compareKeys(key, query.$lt) < 0; };
+    return function (key) { return self.compareKeys(key, query.$lt) < 0 }
   } else {
-    return function (key) { return self.compareKeys(key, query.$lte) <= 0; };
-  }
-};
-
-
-// Append all elements in toAppend to array
-function append (array, toAppend) {
-  var i;
-
-  for (i = 0; i < toAppend.length; i += 1) {
-    array.push(toAppend[i]);
+    return function (key) { return self.compareKeys(key, query.$lte) <= 0 }
   }
 }
 
+// Append all elements in toAppend to array
+function append (array, toAppend) {
+  let i
+
+  for (i = 0; i < toAppend.length; i += 1) {
+    array.push(toAppend[i])
+  }
+}
 
 /**
  * Get all data for a key between bounds
@@ -345,87 +324,84 @@ function append (array, toAppend) {
  * @param {Functions} lbm/ubm matching functions calculated at the first recursive step
  */
 BinarySearchTree.prototype.betweenBounds = function (query, lbm, ubm) {
-  var res = [];
+  const res = []
 
-  if (!this.hasOwnProperty('key')) { return []; }   // Empty tree
+  if (!this.hasOwnProperty('key')) { return [] }   // Empty tree
 
-  lbm = lbm || this.getLowerBoundMatcher(query);
-  ubm = ubm || this.getUpperBoundMatcher(query);
+  lbm = lbm || this.getLowerBoundMatcher(query)
+  ubm = ubm || this.getUpperBoundMatcher(query)
 
-  if (lbm(this.key) && this.left) { append(res, this.left.betweenBounds(query, lbm, ubm)); }
-  if (lbm(this.key) && ubm(this.key)) { append(res, this.data); }
-  if (ubm(this.key) && this.right) { append(res, this.right.betweenBounds(query, lbm, ubm)); }
+  if (lbm(this.key) && this.left) { append(res, this.left.betweenBounds(query, lbm, ubm)) }
+  if (lbm(this.key) && ubm(this.key)) { append(res, this.data) }
+  if (ubm(this.key) && this.right) { append(res, this.right.betweenBounds(query, lbm, ubm)) }
 
-  return res;
-};
-
+  return res
+}
 
 /**
  * Delete the current node if it is a leaf
  * Return true if it was deleted
  */
 BinarySearchTree.prototype.deleteIfLeaf = function () {
-  if (this.left || this.right) { return false; }
+  if (this.left || this.right) { return false }
 
   // The leaf is itself a root
   if (!this.parent) {
-    delete this.key;
-    this.data = [];
-    return true;
+    delete this.key
+    this.data = []
+    return true
   }
 
   if (this.parent.left === this) {
-    this.parent.left = null;
+    this.parent.left = null
   } else {
-    this.parent.right = null;
+    this.parent.right = null
   }
 
-  return true;
-};
-
+  return true
+}
 
 /**
  * Delete the current node if it has only one child
  * Return true if it was deleted
  */
 BinarySearchTree.prototype.deleteIfOnlyOneChild = function () {
-  var child;
+  let child
 
-  if (this.left && !this.right) { child = this.left; }
-  if (!this.left && this.right) { child = this.right; }
-  if (!child) { return false; }
+  if (this.left && !this.right) { child = this.left }
+  if (!this.left && this.right) { child = this.right }
+  if (!child) { return false }
 
   // Root
   if (!this.parent) {
-    this.key = child.key;
-    this.data = child.data;
+    this.key = child.key
+    this.data = child.data
 
-    this.left = null;
+    this.left = null
     if (child.left) {
-      this.left = child.left;
-      child.left.parent = this;
+      this.left = child.left
+      child.left.parent = this
     }
 
-    this.right = null;
+    this.right = null
     if (child.right) {
-      this.right = child.right;
-      child.right.parent = this;
+      this.right = child.right
+      child.right.parent = this
     }
 
-    return true;
+    return true
   }
 
   if (this.parent.left === this) {
-    this.parent.left = child;
-    child.parent = this.parent;
+    this.parent.left = child
+    child.parent = this.parent
   } else {
-    this.parent.right = child;
-    child.parent = this.parent;
+    this.parent.right = child
+    child.parent = this.parent
   }
 
-  return true;
-};
-
+  return true
+}
 
 /**
  * Delete a key or just a value
@@ -433,111 +409,106 @@ BinarySearchTree.prototype.deleteIfOnlyOneChild = function () {
  * @param {Value} value Optional. If not set, the whole key is deleted. If set, only this value is deleted
  */
 BinarySearchTree.prototype.delete = function (key, value) {
-  var newData = [], replaceWith
-    , self = this
-    ;
+  const newData = []
+  let replaceWith
+  const self = this
 
-  if (!this.hasOwnProperty('key')) { return; }
+  if (!this.hasOwnProperty('key')) { return }
 
   if (this.compareKeys(key, this.key) < 0) {
-    if (this.left) { this.left.delete(key, value); }
-    return;
+    if (this.left) { this.left.delete(key, value) }
+    return
   }
 
   if (this.compareKeys(key, this.key) > 0) {
-    if (this.right) { this.right.delete(key, value); }
-    return;
+    if (this.right) { this.right.delete(key, value) }
+    return
   }
 
-  if (!this.compareKeys(key, this.key) === 0) { return; }
+  if (!this.compareKeys(key, this.key) === 0) { return }
 
   // Delete only a value
   if (this.data.length > 1 && value !== undefined) {
     this.data.forEach(function (d) {
-      if (!self.checkValueEquality(d, value)) { newData.push(d); }
-    });
-    self.data = newData;
-    return;
+      if (!self.checkValueEquality(d, value)) { newData.push(d) }
+    })
+    self.data = newData
+    return
   }
 
   // Delete the whole node
   if (this.deleteIfLeaf()) {
-    return;
+    return
   }
   if (this.deleteIfOnlyOneChild()) {
-    return;
+    return
   }
 
   // We are in the case where the node to delete has two children
   if (Math.random() >= 0.5) {   // Randomize replacement to avoid unbalancing the tree too much
-    // Use the in-order predecessor
-    replaceWith = this.left.getMaxKeyDescendant();
+                                // Use the in-order predecessor
+    replaceWith = this.left.getMaxKeyDescendant()
 
-    this.key = replaceWith.key;
-    this.data = replaceWith.data;
+    this.key = replaceWith.key
+    this.data = replaceWith.data
 
     if (this === replaceWith.parent) {   // Special case
-      this.left = replaceWith.left;
-      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+      this.left = replaceWith.left
+      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent }
     } else {
-      replaceWith.parent.right = replaceWith.left;
-      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent; }
+      replaceWith.parent.right = replaceWith.left
+      if (replaceWith.left) { replaceWith.left.parent = replaceWith.parent }
     }
   } else {
     // Use the in-order successor
-    replaceWith = this.right.getMinKeyDescendant();
+    replaceWith = this.right.getMinKeyDescendant()
 
-    this.key = replaceWith.key;
-    this.data = replaceWith.data;
+    this.key = replaceWith.key
+    this.data = replaceWith.data
 
     if (this === replaceWith.parent) {   // Special case
-      this.right = replaceWith.right;
-      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent; }
+      this.right = replaceWith.right
+      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent }
     } else {
-      replaceWith.parent.left = replaceWith.right;
-      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent; }
+      replaceWith.parent.left = replaceWith.right
+      if (replaceWith.right) { replaceWith.right.parent = replaceWith.parent }
     }
   }
-};
-
+}
 
 /**
  * Execute a function on every node of the tree, in key order
  * @param {Function} fn Signature: node. Most useful will probably be node.key and node.data
  */
 BinarySearchTree.prototype.executeOnEveryNode = function (fn) {
-  if (this.left) { this.left.executeOnEveryNode(fn); }
-  fn(this);
-  if (this.right) { this.right.executeOnEveryNode(fn); }
-};
-
+  if (this.left) { this.left.executeOnEveryNode(fn) }
+  fn(this)
+  if (this.right) { this.right.executeOnEveryNode(fn) }
+}
 
 /**
  * Pretty print a tree
  * @param {Boolean} printData To print the nodes' data along with the key
  */
 BinarySearchTree.prototype.prettyPrint = function (printData, spacing) {
-  spacing = spacing || "";
+  spacing = spacing || ''
 
-  console.log(spacing + "* " + this.key);
-  if (printData) { console.log(spacing + "* " + this.data); }
+  console.log(spacing + '* ' + this.key)
+  if (printData) { console.log(spacing + '* ' + this.data) }
 
-  if (!this.left && !this.right) { return; }
+  if (!this.left && !this.right) { return }
 
   if (this.left) {
-    this.left.prettyPrint(printData, spacing + "  ");
+    this.left.prettyPrint(printData, spacing + '  ')
   } else {
-    console.log(spacing + "  *");
+    console.log(spacing + '  *')
   }
   if (this.right) {
-    this.right.prettyPrint(printData, spacing + "  ");
+    this.right.prettyPrint(printData, spacing + '  ')
   } else {
-    console.log(spacing + "  *");
+    console.log(spacing + '  *')
   }
-};
-
-
-
+}
 
 // Interface
-module.exports = BinarySearchTree;
+module.exports = BinarySearchTree

--- a/src/binarySearchTree/customUtils.js
+++ b/src/binarySearchTree/customUtils.js
@@ -1,0 +1,41 @@
+/**
+ * Return an array with the numbers from 0 to n-1, in a random order
+ */
+function getRandomArray (n) {
+  var res, next;
+
+  if (n === 0) { return []; }
+  if (n === 1) { return [0]; }
+
+  res = getRandomArray(n - 1);
+  next = Math.floor(Math.random() * n);
+  res.splice(next, 0, n - 1);   // Add n-1 at a random position in the array
+
+  return res;
+};
+module.exports.getRandomArray = getRandomArray;
+
+
+/*
+ * Default compareKeys function will work for numbers, strings and dates
+ */
+function defaultCompareKeysFunction (a, b) {
+  if (a < b) { return -1; }
+  if (a > b) { return 1; }
+  if (a === b) { return 0; }
+
+  var err = new Error("Couldn't compare elements");
+  err.a = a;
+  err.b = b;
+  throw err;
+}
+module.exports.defaultCompareKeysFunction = defaultCompareKeysFunction;
+
+
+/**
+ * Check whether two values are equal (used in non-unique deletion)
+ */
+function defaultCheckValueEquality (a, b) {
+  return a === b;
+}
+module.exports.defaultCheckValueEquality = defaultCheckValueEquality;

--- a/src/binarySearchTree/customUtils.js
+++ b/src/binarySearchTree/customUtils.js
@@ -2,40 +2,41 @@
  * Return an array with the numbers from 0 to n-1, in a random order
  */
 function getRandomArray (n) {
-  var res, next;
+  let res, next
 
-  if (n === 0) { return []; }
-  if (n === 1) { return [0]; }
+  if (n === 0) { return [] }
+  if (n === 1) { return [0] }
 
-  res = getRandomArray(n - 1);
-  next = Math.floor(Math.random() * n);
-  res.splice(next, 0, n - 1);   // Add n-1 at a random position in the array
+  res = getRandomArray(n - 1)
+  next = Math.floor(Math.random() * n)
+  res.splice(next, 0, n - 1)   // Add n-1 at a random position in the array
 
-  return res;
-};
-module.exports.getRandomArray = getRandomArray;
+  return res
+}
 
+module.exports.getRandomArray = getRandomArray
 
 /*
  * Default compareKeys function will work for numbers, strings and dates
  */
 function defaultCompareKeysFunction (a, b) {
-  if (a < b) { return -1; }
-  if (a > b) { return 1; }
-  if (a === b) { return 0; }
+  if (a < b) { return -1 }
+  if (a > b) { return 1 }
+  if (a === b) { return 0 }
 
-  var err = new Error("Couldn't compare elements");
-  err.a = a;
-  err.b = b;
-  throw err;
+  const err = new Error('Couldn\'t compare elements')
+  err.a = a
+  err.b = b
+  throw err
 }
-module.exports.defaultCompareKeysFunction = defaultCompareKeysFunction;
 
+module.exports.defaultCompareKeysFunction = defaultCompareKeysFunction
 
 /**
  * Check whether two values are equal (used in non-unique deletion)
  */
 function defaultCheckValueEquality (a, b) {
-  return a === b;
+  return a === b
 }
-module.exports.defaultCheckValueEquality = defaultCheckValueEquality;
+
+module.exports.defaultCheckValueEquality = defaultCheckValueEquality

--- a/src/nedb/cursor.js
+++ b/src/nedb/cursor.js
@@ -1,0 +1,204 @@
+/**
+ * Manage access to data, be it to find, update or remove it
+ */
+var model = require('./model')
+  , _ = require('underscore')
+  ;
+
+
+
+/**
+ * Create a new cursor for this collection
+ * @param {Datastore} db - The datastore this cursor is bound to
+ * @param {Query} query - The query this cursor will operate on
+ * @param {Function} execFn - Handler to be executed after cursor has found the results and before the callback passed to find/findOne/update/remove
+ */
+function Cursor (db, query, execFn) {
+  this.db = db;
+  this.query = query || {};
+  if (execFn) { this.execFn = execFn; }
+}
+
+
+/**
+ * Set a limit to the number of results
+ */
+Cursor.prototype.limit = function(limit) {
+  this._limit = limit;
+  return this;
+};
+
+
+/**
+ * Skip a the number of results
+ */
+Cursor.prototype.skip = function(skip) {
+  this._skip = skip;
+  return this;
+};
+
+
+/**
+ * Sort results of the query
+ * @param {SortQuery} sortQuery - SortQuery is { field: order }, field can use the dot-notation, order is 1 for ascending and -1 for descending
+ */
+Cursor.prototype.sort = function(sortQuery) {
+  this._sort = sortQuery;
+  return this;
+};
+
+
+/**
+ * Add the use of a projection
+ * @param {Object} projection - MongoDB-style projection. {} means take all fields. Then it's { key1: 1, key2: 1 } to take only key1 and key2
+ *                              { key1: 0, key2: 0 } to omit only key1 and key2. Except _id, you can't mix takes and omits
+ */
+Cursor.prototype.projection = function(projection) {
+  this._projection = projection;
+  return this;
+};
+
+
+/**
+ * Apply the projection
+ */
+Cursor.prototype.project = function (candidates) {
+  var res = [], self = this
+    , keepId, action, keys
+    ;
+
+  if (this._projection === undefined || Object.keys(this._projection).length === 0) {
+    return candidates;
+  }
+
+  keepId = this._projection._id === 0 ? false : true;
+  this._projection = _.omit(this._projection, '_id');
+
+  // Check for consistency
+  keys = Object.keys(this._projection);
+  keys.forEach(function (k) {
+    if (action !== undefined && self._projection[k] !== action) { throw new Error("Can't both keep and omit fields except for _id"); }
+    action = self._projection[k];
+  });
+
+  // Do the actual projection
+  candidates.forEach(function (candidate) {
+    var toPush;
+    if (action === 1) {   // pick-type projection
+      toPush = { $set: {} };
+      keys.forEach(function (k) {
+        toPush.$set[k] = model.getDotValue(candidate, k);
+        if (toPush.$set[k] === undefined) { delete toPush.$set[k]; }
+      });
+      toPush = model.modify({}, toPush);
+    } else {   // omit-type projection
+      toPush = { $unset: {} };
+      keys.forEach(function (k) { toPush.$unset[k] = true });
+      toPush = model.modify(candidate, toPush);
+    }
+    if (keepId) {
+      toPush._id = candidate._id;
+    } else {
+      delete toPush._id;
+    }
+    res.push(toPush);
+  });
+
+  return res;
+};
+
+
+/**
+ * Get all matching elements
+ * Will return pointers to matched elements (shallow copies), returning full copies is the role of find or findOne
+ * This is an internal function, use exec which uses the executor
+ *
+ * @param {Function} callback - Signature: err, results
+ */
+Cursor.prototype._exec = function(_callback) {
+  var res = [], added = 0, skipped = 0, self = this
+    , error = null
+    , i, keys, key
+    ;
+
+  function callback (error, res) {
+    if (self.execFn) {
+      return self.execFn(error, res, _callback);
+    } else {
+      return _callback(error, res);
+    }
+  }
+
+  this.db.getCandidates(this.query, function (err, candidates) {
+    if (err) { return callback(err); }
+
+    try {
+      for (i = 0; i < candidates.length; i += 1) {
+        if (model.match(candidates[i], self.query)) {
+          // If a sort is defined, wait for the results to be sorted before applying limit and skip
+          if (!self._sort) {
+            if (self._skip && self._skip > skipped) {
+              skipped += 1;
+            } else {
+              res.push(candidates[i]);
+              added += 1;
+              if (self._limit && self._limit <= added) { break; }
+            }
+          } else {
+            res.push(candidates[i]);
+          }
+        }
+      }
+    } catch (err) {
+      return callback(err);
+    }
+
+    // Apply all sorts
+    if (self._sort) {
+      keys = Object.keys(self._sort);
+
+      // Sorting
+      var criteria = [];
+      for (i = 0; i < keys.length; i++) {
+        key = keys[i];
+        criteria.push({ key: key, direction: self._sort[key] });
+      }
+      res.sort(function(a, b) {
+        var criterion, compare, i;
+        for (i = 0; i < criteria.length; i++) {
+          criterion = criteria[i];
+          compare = criterion.direction * model.compareThings(model.getDotValue(a, criterion.key), model.getDotValue(b, criterion.key), self.db.compareStrings);
+          if (compare !== 0) {
+            return compare;
+          }
+        }
+        return 0;
+      });
+
+      // Applying limit and skip
+      var limit = self._limit || res.length
+        , skip = self._skip || 0;
+
+      res = res.slice(skip, skip + limit);
+    }
+
+    // Apply projection
+    try {
+      res = self.project(res);
+    } catch (e) {
+      error = e;
+      res = undefined;
+    }
+
+    return callback(error, res);
+  });
+};
+
+Cursor.prototype.exec = function () {
+  this.db.executor.push({ this: this, fn: this._exec, arguments: arguments });
+};
+
+
+
+// Interface
+module.exports = Cursor;

--- a/src/nedb/cursor.js
+++ b/src/nedb/cursor.js
@@ -1,11 +1,8 @@
 /**
  * Manage access to data, be it to find, update or remove it
  */
-var model = require('./model')
-  , _ = require('underscore')
-  ;
-
-
+const model = require('./model')
+const _ = require('underscore')
 
 /**
  * Create a new cursor for this collection
@@ -14,99 +11,95 @@ var model = require('./model')
  * @param {Function} execFn - Handler to be executed after cursor has found the results and before the callback passed to find/findOne/update/remove
  */
 function Cursor (db, query, execFn) {
-  this.db = db;
-  this.query = query || {};
-  if (execFn) { this.execFn = execFn; }
+  this.db = db
+  this.query = query || {}
+  if (execFn) { this.execFn = execFn }
 }
-
 
 /**
  * Set a limit to the number of results
  */
-Cursor.prototype.limit = function(limit) {
-  this._limit = limit;
-  return this;
-};
-
+Cursor.prototype.limit = function (limit) {
+  this._limit = limit
+  return this
+}
 
 /**
  * Skip a the number of results
  */
-Cursor.prototype.skip = function(skip) {
-  this._skip = skip;
-  return this;
-};
-
+Cursor.prototype.skip = function (skip) {
+  this._skip = skip
+  return this
+}
 
 /**
  * Sort results of the query
  * @param {SortQuery} sortQuery - SortQuery is { field: order }, field can use the dot-notation, order is 1 for ascending and -1 for descending
  */
-Cursor.prototype.sort = function(sortQuery) {
-  this._sort = sortQuery;
-  return this;
-};
-
+Cursor.prototype.sort = function (sortQuery) {
+  this._sort = sortQuery
+  return this
+}
 
 /**
  * Add the use of a projection
  * @param {Object} projection - MongoDB-style projection. {} means take all fields. Then it's { key1: 1, key2: 1 } to take only key1 and key2
  *                              { key1: 0, key2: 0 } to omit only key1 and key2. Except _id, you can't mix takes and omits
  */
-Cursor.prototype.projection = function(projection) {
-  this._projection = projection;
-  return this;
-};
-
+Cursor.prototype.projection = function (projection) {
+  this._projection = projection
+  return this
+}
 
 /**
  * Apply the projection
  */
 Cursor.prototype.project = function (candidates) {
-  var res = [], self = this
-    , keepId, action, keys
-    ;
+  const res = []
+  const self = this
+  let keepId
+  let action
+  let keys
 
   if (this._projection === undefined || Object.keys(this._projection).length === 0) {
-    return candidates;
+    return candidates
   }
 
-  keepId = this._projection._id === 0 ? false : true;
-  this._projection = _.omit(this._projection, '_id');
+  keepId = this._projection._id === 0 ? false : true
+  this._projection = _.omit(this._projection, '_id')
 
   // Check for consistency
-  keys = Object.keys(this._projection);
+  keys = Object.keys(this._projection)
   keys.forEach(function (k) {
-    if (action !== undefined && self._projection[k] !== action) { throw new Error("Can't both keep and omit fields except for _id"); }
-    action = self._projection[k];
-  });
+    if (action !== undefined && self._projection[k] !== action) { throw new Error('Can\'t both keep and omit fields except for _id') }
+    action = self._projection[k]
+  })
 
   // Do the actual projection
   candidates.forEach(function (candidate) {
-    var toPush;
+    let toPush
     if (action === 1) {   // pick-type projection
-      toPush = { $set: {} };
+      toPush = { $set: {} }
       keys.forEach(function (k) {
-        toPush.$set[k] = model.getDotValue(candidate, k);
-        if (toPush.$set[k] === undefined) { delete toPush.$set[k]; }
-      });
-      toPush = model.modify({}, toPush);
+        toPush.$set[k] = model.getDotValue(candidate, k)
+        if (toPush.$set[k] === undefined) { delete toPush.$set[k] }
+      })
+      toPush = model.modify({}, toPush)
     } else {   // omit-type projection
-      toPush = { $unset: {} };
-      keys.forEach(function (k) { toPush.$unset[k] = true });
-      toPush = model.modify(candidate, toPush);
+      toPush = { $unset: {} }
+      keys.forEach(function (k) { toPush.$unset[k] = true })
+      toPush = model.modify(candidate, toPush)
     }
     if (keepId) {
-      toPush._id = candidate._id;
+      toPush._id = candidate._id
     } else {
-      delete toPush._id;
+      delete toPush._id
     }
-    res.push(toPush);
-  });
+    res.push(toPush)
+  })
 
-  return res;
-};
-
+  return res
+}
 
 /**
  * Get all matching elements
@@ -115,22 +108,26 @@ Cursor.prototype.project = function (candidates) {
  *
  * @param {Function} callback - Signature: err, results
  */
-Cursor.prototype._exec = function(_callback) {
-  var res = [], added = 0, skipped = 0, self = this
-    , error = null
-    , i, keys, key
-    ;
+Cursor.prototype._exec = function (_callback) {
+  let res = []
+  let added = 0
+  let skipped = 0
+  const self = this
+  let error = null
+  let i
+  let keys
+  let key
 
   function callback (error, res) {
     if (self.execFn) {
-      return self.execFn(error, res, _callback);
+      return self.execFn(error, res, _callback)
     } else {
-      return _callback(error, res);
+      return _callback(error, res)
     }
   }
 
   this.db.getCandidates(this.query, function (err, candidates) {
-    if (err) { return callback(err); }
+    if (err) { return callback(err) }
 
     try {
       for (i = 0; i < candidates.length; i += 1) {
@@ -138,67 +135,67 @@ Cursor.prototype._exec = function(_callback) {
           // If a sort is defined, wait for the results to be sorted before applying limit and skip
           if (!self._sort) {
             if (self._skip && self._skip > skipped) {
-              skipped += 1;
+              skipped += 1
             } else {
-              res.push(candidates[i]);
-              added += 1;
-              if (self._limit && self._limit <= added) { break; }
+              res.push(candidates[i])
+              added += 1
+              if (self._limit && self._limit <= added) { break }
             }
           } else {
-            res.push(candidates[i]);
+            res.push(candidates[i])
           }
         }
       }
     } catch (err) {
-      return callback(err);
+      return callback(err)
     }
 
     // Apply all sorts
     if (self._sort) {
-      keys = Object.keys(self._sort);
+      keys = Object.keys(self._sort)
 
       // Sorting
-      var criteria = [];
+      const criteria = []
       for (i = 0; i < keys.length; i++) {
-        key = keys[i];
-        criteria.push({ key: key, direction: self._sort[key] });
+        key = keys[i]
+        criteria.push({ key: key, direction: self._sort[key] })
       }
-      res.sort(function(a, b) {
-        var criterion, compare, i;
+      res.sort(function (a, b) {
+        let criterion
+        let compare
+        let i
         for (i = 0; i < criteria.length; i++) {
-          criterion = criteria[i];
-          compare = criterion.direction * model.compareThings(model.getDotValue(a, criterion.key), model.getDotValue(b, criterion.key), self.db.compareStrings);
+          criterion = criteria[i]
+          compare = criterion.direction * model.compareThings(model.getDotValue(a, criterion.key), model.getDotValue(b, criterion.key), self.db.compareStrings)
           if (compare !== 0) {
-            return compare;
+            return compare
           }
         }
-        return 0;
-      });
+        return 0
+      })
 
       // Applying limit and skip
-      var limit = self._limit || res.length
-        , skip = self._skip || 0;
+      const limit = self._limit || res.length
+      const skip = self._skip || 0
 
-      res = res.slice(skip, skip + limit);
+      res = res.slice(skip, skip + limit)
     }
 
     // Apply projection
     try {
-      res = self.project(res);
+      res = self.project(res)
     } catch (e) {
-      error = e;
-      res = undefined;
+      error = e
+      res = undefined
     }
 
-    return callback(error, res);
-  });
-};
+    return callback(error, res)
+  })
+}
 
 Cursor.prototype.exec = function () {
-  this.db.executor.push({ this: this, fn: this._exec, arguments: arguments });
-};
-
-
+  this.db.executor.push({ this: this, fn: this._exec, arguments: arguments })
+}
 
 // Interface
-module.exports = Cursor;
+module.exports = Cursor

--- a/src/nedb/customUtils.js
+++ b/src/nedb/customUtils.js
@@ -1,0 +1,22 @@
+var crypto = require('crypto')
+  ;
+
+/**
+ * Return a random alphanumerical string of length len
+ * There is a very small probability (less than 1/1,000,000) for the length to be less than len
+ * (il the base64 conversion yields too many pluses and slashes) but
+ * that's not an issue here
+ * The probability of a collision is extremely small (need 3*10^12 documents to have one chance in a million of a collision)
+ * See http://en.wikipedia.org/wiki/Birthday_problem
+ */
+function uid (len) {
+  return crypto.randomBytes(Math.ceil(Math.max(8, len * 2)))
+    .toString('base64')
+    .replace(/[+\/]/g, '')
+    .slice(0, len);
+}
+
+
+// Interface
+module.exports.uid = uid;
+

--- a/src/nedb/customUtils.js
+++ b/src/nedb/customUtils.js
@@ -1,5 +1,4 @@
-var crypto = require('crypto')
-  ;
+const crypto = require('crypto')
 
 /**
  * Return a random alphanumerical string of length len
@@ -13,10 +12,9 @@ function uid (len) {
   return crypto.randomBytes(Math.ceil(Math.max(8, len * 2)))
     .toString('base64')
     .replace(/[+\/]/g, '')
-    .slice(0, len);
+    .slice(0, len)
 }
 
-
 // Interface
-module.exports.uid = uid;
+module.exports.uid = uid
 

--- a/src/nedb/datastore.js
+++ b/src/nedb/datastore.js
@@ -1,0 +1,705 @@
+var customUtils = require('./customUtils')
+  , model = require('./model')
+  , async = require('async')
+  , Executor = require('./executor')
+  , Index = require('./indexes')
+  , util = require('util')
+  , _ = require('underscore')
+  , Persistence = require('./persistence')
+  , Cursor = require('./cursor')
+  ;
+
+
+/**
+ * Create a new collection
+ * @param {String} options.filename Optional, datastore will be in-memory only if not provided
+ * @param {Boolean} options.timestampData Optional, defaults to false. If set to true, createdAt and updatedAt will be created and populated automatically (if not specified by user)
+ * @param {Boolean} options.inMemoryOnly Optional, defaults to false
+ * @param {String} options.nodeWebkitAppName Optional, specify the name of your NW app if you want options.filename to be relative to the directory where
+ *                                            Node Webkit stores application data such as cookies and local storage (the best place to store data in my opinion)
+ * @param {Boolean} options.autoload Optional, defaults to false
+ * @param {Function} options.onload Optional, if autoload is used this will be called after the load database with the error object as parameter. If you don't pass it the error will be thrown
+ * @param {Function} options.afterSerialization/options.beforeDeserialization Optional, serialization hooks
+ * @param {Number} options.corruptAlertThreshold Optional, threshold after which an alert is thrown if too much data is corrupt
+ * @param {Function} options.compareStrings Optional, string comparison function that overrides default for sorting
+ *
+ * Event Emitter - Events
+ * * compaction.done - Fired whenever a compaction operation was finished
+ */
+function Datastore (options) {
+  var filename;
+
+  // Retrocompatibility with v0.6 and before
+  if (typeof options === 'string') {
+    filename = options;
+    this.inMemoryOnly = false;   // Default
+  } else {
+    options = options || {};
+    filename = options.filename;
+    this.inMemoryOnly = options.inMemoryOnly || false;
+    this.autoload = options.autoload || false;
+    this.timestampData = options.timestampData || false;
+  }
+
+  // Determine whether in memory or persistent
+  if (!filename || typeof filename !== 'string' || filename.length === 0) {
+    this.filename = null;
+    this.inMemoryOnly = true;
+  } else {
+    this.filename = filename;
+  }
+
+  // String comparison function
+  this.compareStrings = options.compareStrings;
+
+  // Persistence handling
+  this.persistence = new Persistence({ db: this, nodeWebkitAppName: options.nodeWebkitAppName
+                                      , afterSerialization: options.afterSerialization
+                                      , beforeDeserialization: options.beforeDeserialization
+                                      , corruptAlertThreshold: options.corruptAlertThreshold
+                                      });
+
+  // This new executor is ready if we don't use persistence
+  // If we do, it will only be ready once loadDatabase is called
+  this.executor = new Executor();
+  if (this.inMemoryOnly) { this.executor.ready = true; }
+
+  // Indexed by field name, dot notation can be used
+  // _id is always indexed and since _ids are generated randomly the underlying
+  // binary is always well-balanced
+  this.indexes = {};
+  this.indexes._id = new Index({ fieldName: '_id', unique: true });
+  this.ttlIndexes = {};
+
+  // Queue a load of the database right away and call the onload handler
+  // By default (no onload handler), if there is an error there, no operation will be possible so warn the user by throwing an exception
+  if (this.autoload) { this.loadDatabase(options.onload || function (err) {
+    if (err) { throw err; }
+  }); }
+}
+
+util.inherits(Datastore, require('events').EventEmitter);
+
+
+/**
+ * Load the database from the datafile, and trigger the execution of buffered commands if any
+ */
+Datastore.prototype.loadDatabase = function () {
+  this.executor.push({ this: this.persistence, fn: this.persistence.loadDatabase, arguments: arguments }, true);
+};
+
+
+/**
+ * Get an array of all the data in the database
+ */
+Datastore.prototype.getAllData = function () {
+  return this.indexes._id.getAll();
+};
+
+
+/**
+ * Reset all currently defined indexes
+ */
+Datastore.prototype.resetIndexes = function (newData) {
+  var self = this;
+
+  Object.keys(this.indexes).forEach(function (i) {
+    self.indexes[i].reset(newData);
+  });
+};
+
+
+/**
+ * Ensure an index is kept for this field. Same parameters as lib/indexes
+ * For now this function is synchronous, we need to test how much time it takes
+ * We use an async API for consistency with the rest of the code
+ * @param {String} options.fieldName
+ * @param {Boolean} options.unique
+ * @param {Boolean} options.sparse
+ * @param {Number} options.expireAfterSeconds - Optional, if set this index becomes a TTL index (only works on Date fields, not arrays of Date)
+ * @param {Function} cb Optional callback, signature: err
+ */
+Datastore.prototype.ensureIndex = function (options, cb) {
+  var err
+    , callback = cb || function () {};
+
+  options = options || {};
+
+  if (!options.fieldName) {
+    err = new Error("Cannot create an index without a fieldName");
+    err.missingFieldName = true;
+    return callback(err);
+  }
+  if (this.indexes[options.fieldName]) { return callback(null); }
+
+  this.indexes[options.fieldName] = new Index(options);
+  if (options.expireAfterSeconds !== undefined) { this.ttlIndexes[options.fieldName] = options.expireAfterSeconds; }   // With this implementation index creation is not necessary to ensure TTL but we stick with MongoDB's API here
+
+  try {
+    this.indexes[options.fieldName].insert(this.getAllData());
+  } catch (e) {
+    delete this.indexes[options.fieldName];
+    return callback(e);
+  }
+
+  // We may want to force all options to be persisted including defaults, not just the ones passed the index creation function
+  this.persistence.persistNewState([{ $$indexCreated: options }], function (err) {
+    if (err) { return callback(err); }
+    return callback(null);
+  });
+};
+
+
+/**
+ * Remove an index
+ * @param {String} fieldName
+ * @param {Function} cb Optional callback, signature: err
+ */
+Datastore.prototype.removeIndex = function (fieldName, cb) {
+  var callback = cb || function () {};
+
+  delete this.indexes[fieldName];
+
+  this.persistence.persistNewState([{ $$indexRemoved: fieldName }], function (err) {
+    if (err) { return callback(err); }
+    return callback(null);
+  });
+};
+
+
+/**
+ * Add one or several document(s) to all indexes
+ */
+Datastore.prototype.addToIndexes = function (doc) {
+  var i, failingIndex, error
+    , keys = Object.keys(this.indexes)
+    ;
+
+  for (i = 0; i < keys.length; i += 1) {
+    try {
+      this.indexes[keys[i]].insert(doc);
+    } catch (e) {
+      failingIndex = i;
+      error = e;
+      break;
+    }
+  }
+
+  // If an error happened, we need to rollback the insert on all other indexes
+  if (error) {
+    for (i = 0; i < failingIndex; i += 1) {
+      this.indexes[keys[i]].remove(doc);
+    }
+
+    throw error;
+  }
+};
+
+
+/**
+ * Remove one or several document(s) from all indexes
+ */
+Datastore.prototype.removeFromIndexes = function (doc) {
+  var self = this;
+
+  Object.keys(this.indexes).forEach(function (i) {
+    self.indexes[i].remove(doc);
+  });
+};
+
+
+/**
+ * Update one or several documents in all indexes
+ * To update multiple documents, oldDoc must be an array of { oldDoc, newDoc } pairs
+ * If one update violates a constraint, all changes are rolled back
+ */
+Datastore.prototype.updateIndexes = function (oldDoc, newDoc) {
+  var i, failingIndex, error
+    , keys = Object.keys(this.indexes)
+    ;
+
+  for (i = 0; i < keys.length; i += 1) {
+    try {
+      this.indexes[keys[i]].update(oldDoc, newDoc);
+    } catch (e) {
+      failingIndex = i;
+      error = e;
+      break;
+    }
+  }
+
+  // If an error happened, we need to rollback the update on all other indexes
+  if (error) {
+    for (i = 0; i < failingIndex; i += 1) {
+      this.indexes[keys[i]].revertUpdate(oldDoc, newDoc);
+    }
+
+    throw error;
+  }
+};
+
+
+/**
+ * Return the list of candidates for a given query
+ * Crude implementation for now, we return the candidates given by the first usable index if any
+ * We try the following query types, in this order: basic match, $in match, comparison match
+ * One way to make it better would be to enable the use of multiple indexes if the first usable index
+ * returns too much data. I may do it in the future.
+ *
+ * Returned candidates will be scanned to find and remove all expired documents
+ *
+ * @param {Query} query
+ * @param {Boolean} dontExpireStaleDocs Optional, defaults to false, if true don't remove stale docs. Useful for the remove function which shouldn't be impacted by expirations
+ * @param {Function} callback Signature err, candidates
+ */
+Datastore.prototype.getCandidates = function (query, dontExpireStaleDocs, callback) {
+  var indexNames = Object.keys(this.indexes)
+    , self = this
+    , usableQueryKeys;
+
+  if (typeof dontExpireStaleDocs === 'function') {
+    callback = dontExpireStaleDocs;
+    dontExpireStaleDocs = false;
+  }
+
+
+  async.waterfall([
+  // STEP 1: get candidates list by checking indexes from most to least frequent usecase
+  function (cb) {
+    // For a basic match
+    usableQueryKeys = [];
+    Object.keys(query).forEach(function (k) {
+      if (typeof query[k] === 'string' || typeof query[k] === 'number' || typeof query[k] === 'boolean' || util.isDate(query[k]) || query[k] === null) {
+        usableQueryKeys.push(k);
+      }
+    });
+    usableQueryKeys = _.intersection(usableQueryKeys, indexNames);
+    if (usableQueryKeys.length > 0) {
+      return cb(null, self.indexes[usableQueryKeys[0]].getMatching(query[usableQueryKeys[0]]));
+    }
+
+    // For a $in match
+    usableQueryKeys = [];
+    Object.keys(query).forEach(function (k) {
+      if (query[k] && query[k].hasOwnProperty('$in')) {
+        usableQueryKeys.push(k);
+      }
+    });
+    usableQueryKeys = _.intersection(usableQueryKeys, indexNames);
+    if (usableQueryKeys.length > 0) {
+      return cb(null, self.indexes[usableQueryKeys[0]].getMatching(query[usableQueryKeys[0]].$in));
+    }
+
+    // For a comparison match
+    usableQueryKeys = [];
+    Object.keys(query).forEach(function (k) {
+      if (query[k] && (query[k].hasOwnProperty('$lt') || query[k].hasOwnProperty('$lte') || query[k].hasOwnProperty('$gt') || query[k].hasOwnProperty('$gte'))) {
+        usableQueryKeys.push(k);
+      }
+    });
+    usableQueryKeys = _.intersection(usableQueryKeys, indexNames);
+    if (usableQueryKeys.length > 0) {
+      return cb(null, self.indexes[usableQueryKeys[0]].getBetweenBounds(query[usableQueryKeys[0]]));
+    }
+
+    // By default, return all the DB data
+    return cb(null, self.getAllData());
+  }
+  // STEP 2: remove all expired documents
+  , function (docs) {
+    if (dontExpireStaleDocs) { return callback(null, docs); }
+
+    var expiredDocsIds = [], validDocs = [], ttlIndexesFieldNames = Object.keys(self.ttlIndexes);
+
+    docs.forEach(function (doc) {
+      var valid = true;
+      ttlIndexesFieldNames.forEach(function (i) {
+        if (doc[i] !== undefined && util.isDate(doc[i]) && Date.now() > doc[i].getTime() + self.ttlIndexes[i] * 1000) {
+          valid = false;
+        }
+      });
+      if (valid) { validDocs.push(doc); } else { expiredDocsIds.push(doc._id); }
+    });
+
+    async.eachSeries(expiredDocsIds, function (_id, cb) {
+      self._remove({ _id: _id }, {}, function (err) {
+        if (err) { return callback(err); }
+        return cb();
+      });
+    }, function (err) {
+      return callback(null, validDocs);
+    });
+  }]);
+};
+
+
+/**
+ * Insert a new document
+ * @param {Function} cb Optional callback, signature: err, insertedDoc
+ *
+ * @api private Use Datastore.insert which has the same signature
+ */
+Datastore.prototype._insert = function (newDoc, cb) {
+  var callback = cb || function () {}
+    , preparedDoc
+    ;
+
+  try {
+    preparedDoc = this.prepareDocumentForInsertion(newDoc)
+    this._insertInCache(preparedDoc);
+  } catch (e) {
+    return callback(e);
+  }
+
+  this.persistence.persistNewState(util.isArray(preparedDoc) ? preparedDoc : [preparedDoc], function (err) {
+    if (err) { return callback(err); }
+    return callback(null, model.deepCopy(preparedDoc));
+  });
+};
+
+/**
+ * Create a new _id that's not already in use
+ */
+Datastore.prototype.createNewId = function () {
+  var tentativeId = customUtils.uid(16);
+  // Try as many times as needed to get an unused _id. As explained in customUtils, the probability of this ever happening is extremely small, so this is O(1)
+  if (this.indexes._id.getMatching(tentativeId).length > 0) {
+    tentativeId = this.createNewId();
+  }
+  return tentativeId;
+};
+
+/**
+ * Prepare a document (or array of documents) to be inserted in a database
+ * Meaning adds _id and timestamps if necessary on a copy of newDoc to avoid any side effect on user input
+ * @api private
+ */
+Datastore.prototype.prepareDocumentForInsertion = function (newDoc) {
+  var preparedDoc, self = this;
+
+  if (util.isArray(newDoc)) {
+    preparedDoc = [];
+    newDoc.forEach(function (doc) { preparedDoc.push(self.prepareDocumentForInsertion(doc)); });
+  } else {
+    preparedDoc = model.deepCopy(newDoc);
+    if (preparedDoc._id === undefined) { preparedDoc._id = this.createNewId(); }
+    var now = new Date();
+    if (this.timestampData && preparedDoc.createdAt === undefined) { preparedDoc.createdAt = now; }
+    if (this.timestampData && preparedDoc.updatedAt === undefined) { preparedDoc.updatedAt = now; }
+    model.checkObject(preparedDoc);
+  }
+
+  return preparedDoc;
+};
+
+/**
+ * If newDoc is an array of documents, this will insert all documents in the cache
+ * @api private
+ */
+Datastore.prototype._insertInCache = function (preparedDoc) {
+  if (util.isArray(preparedDoc)) {
+    this._insertMultipleDocsInCache(preparedDoc);
+  } else {
+    this.addToIndexes(preparedDoc);
+  }
+};
+
+/**
+ * If one insertion fails (e.g. because of a unique constraint), roll back all previous
+ * inserts and throws the error
+ * @api private
+ */
+Datastore.prototype._insertMultipleDocsInCache = function (preparedDocs) {
+  var i, failingI, error;
+
+  for (i = 0; i < preparedDocs.length; i += 1) {
+    try {
+      this.addToIndexes(preparedDocs[i]);
+    } catch (e) {
+      error = e;
+      failingI = i;
+      break;
+    }
+  }
+
+  if (error) {
+    for (i = 0; i < failingI; i += 1) {
+      this.removeFromIndexes(preparedDocs[i]);
+    }
+
+    throw error;
+  }
+};
+
+Datastore.prototype.insert = function () {
+  this.executor.push({ this: this, fn: this._insert, arguments: arguments });
+};
+
+
+/**
+ * Count all documents matching the query
+ * @param {Object} query MongoDB-style query
+ */
+Datastore.prototype.count = function(query, callback) {
+  var cursor = new Cursor(this, query, function(err, docs, callback) {
+    if (err) { return callback(err); }
+    return callback(null, docs.length);
+  });
+
+  if (typeof callback === 'function') {
+    cursor.exec(callback);
+  } else {
+    return cursor;
+  }
+};
+
+
+/**
+ * Find all documents matching the query
+ * If no callback is passed, we return the cursor so that user can limit, skip and finally exec
+ * @param {Object} query MongoDB-style query
+ * @param {Object} projection MongoDB-style projection
+ */
+Datastore.prototype.find = function (query, projection, callback) {
+  switch (arguments.length) {
+    case 1:
+      projection = {};
+      // callback is undefined, will return a cursor
+      break;
+    case 2:
+      if (typeof projection === 'function') {
+        callback = projection;
+        projection = {};
+      }   // If not assume projection is an object and callback undefined
+      break;
+  }
+
+  var cursor = new Cursor(this, query, function(err, docs, callback) {
+    var res = [], i;
+
+    if (err) { return callback(err); }
+
+    for (i = 0; i < docs.length; i += 1) {
+      res.push(model.deepCopy(docs[i]));
+    }
+    return callback(null, res);
+  });
+
+  cursor.projection(projection);
+  if (typeof callback === 'function') {
+    cursor.exec(callback);
+  } else {
+    return cursor;
+  }
+};
+
+
+/**
+ * Find one document matching the query
+ * @param {Object} query MongoDB-style query
+ * @param {Object} projection MongoDB-style projection
+ */
+Datastore.prototype.findOne = function (query, projection, callback) {
+  switch (arguments.length) {
+    case 1:
+      projection = {};
+      // callback is undefined, will return a cursor
+      break;
+    case 2:
+      if (typeof projection === 'function') {
+        callback = projection;
+        projection = {};
+      }   // If not assume projection is an object and callback undefined
+      break;
+  }
+
+  var cursor = new Cursor(this, query, function(err, docs, callback) {
+    if (err) { return callback(err); }
+    if (docs.length === 1) {
+      return callback(null, model.deepCopy(docs[0]));
+    } else {
+      return callback(null, null);
+    }
+  });
+
+  cursor.projection(projection).limit(1);
+  if (typeof callback === 'function') {
+    cursor.exec(callback);
+  } else {
+    return cursor;
+  }
+};
+
+
+/**
+ * Update all docs matching query
+ * @param {Object} query
+ * @param {Object} updateQuery
+ * @param {Object} options Optional options
+ *                 options.multi If true, can update multiple documents (defaults to false)
+ *                 options.upsert If true, document is inserted if the query doesn't match anything
+ *                 options.returnUpdatedDocs Defaults to false, if true return as third argument the array of updated matched documents (even if no change actually took place)
+ * @param {Function} cb Optional callback, signature: (err, numAffected, affectedDocuments, upsert)
+ *                      If update was an upsert, upsert flag is set to true
+ *                      affectedDocuments can be one of the following:
+ *                        * For an upsert, the upserted document
+ *                        * For an update with returnUpdatedDocs option false, null
+ *                        * For an update with returnUpdatedDocs true and multi false, the updated document
+ *                        * For an update with returnUpdatedDocs true and multi true, the array of updated documents
+ *
+ * WARNING: The API was changed between v1.7.4 and v1.8, for consistency and readability reasons. Prior and including to v1.7.4,
+ *          the callback signature was (err, numAffected, updated) where updated was the updated document in case of an upsert
+ *          or the array of updated documents for an update if the returnUpdatedDocs option was true. That meant that the type of
+ *          affectedDocuments in a non multi update depended on whether there was an upsert or not, leaving only two ways for the
+ *          user to check whether an upsert had occured: checking the type of affectedDocuments or running another find query on
+ *          the whole dataset to check its size. Both options being ugly, the breaking change was necessary.
+ *
+ * @api private Use Datastore.update which has the same signature
+ */
+Datastore.prototype._update = function (query, updateQuery, options, cb) {
+  var callback
+    , self = this
+    , numReplaced = 0
+    , multi, upsert
+    , i
+    ;
+
+  if (typeof options === 'function') { cb = options; options = {}; }
+  callback = cb || function () {};
+  multi = options.multi !== undefined ? options.multi : false;
+  upsert = options.upsert !== undefined ? options.upsert : false;
+
+  async.waterfall([
+  function (cb) {   // If upsert option is set, check whether we need to insert the doc
+    if (!upsert) { return cb(); }
+
+    // Need to use an internal function not tied to the executor to avoid deadlock
+    var cursor = new Cursor(self, query);
+    cursor.limit(1)._exec(function (err, docs) {
+      if (err) { return callback(err); }
+      if (docs.length === 1) {
+        return cb();
+      } else {
+        var toBeInserted;
+
+        try {
+          model.checkObject(updateQuery);
+          // updateQuery is a simple object with no modifier, use it as the document to insert
+          toBeInserted = updateQuery;
+        } catch (e) {
+          // updateQuery contains modifiers, use the find query as the base,
+          // strip it from all operators and update it according to updateQuery
+          try {
+            toBeInserted = model.modify(model.deepCopy(query, true), updateQuery);
+          } catch (err) {
+            return callback(err);
+          }
+        }
+
+        return self._insert(toBeInserted, function (err, newDoc) {
+          if (err) { return callback(err); }
+          return callback(null, 1, newDoc, true);
+        });
+      }
+    });
+  }
+  , function () {   // Perform the update
+    var modifiedDoc , modifications = [], createdAt;
+
+    self.getCandidates(query, function (err, candidates) {
+      if (err) { return callback(err); }
+
+      // Preparing update (if an error is thrown here neither the datafile nor
+      // the in-memory indexes are affected)
+      try {
+        for (i = 0; i < candidates.length; i += 1) {
+          if (model.match(candidates[i], query) && (multi || numReplaced === 0)) {
+            numReplaced += 1;
+            if (self.timestampData) { createdAt = candidates[i].createdAt; }
+            modifiedDoc = model.modify(candidates[i], updateQuery);
+            if (self.timestampData) {
+              modifiedDoc.createdAt = createdAt;
+              modifiedDoc.updatedAt = new Date();
+            }
+            modifications.push({ oldDoc: candidates[i], newDoc: modifiedDoc });
+          }
+        }
+      } catch (err) {
+        return callback(err);
+      }
+
+      // Change the docs in memory
+      try {
+        self.updateIndexes(modifications);
+      } catch (err) {
+        return callback(err);
+      }
+
+      // Update the datafile
+      var updatedDocs = _.pluck(modifications, 'newDoc');
+      self.persistence.persistNewState(updatedDocs, function (err) {
+        if (err) { return callback(err); }
+        if (!options.returnUpdatedDocs) {
+          return callback(null, numReplaced);
+        } else {
+          var updatedDocsDC = [];
+          updatedDocs.forEach(function (doc) { updatedDocsDC.push(model.deepCopy(doc)); });
+          if (! multi) { updatedDocsDC = updatedDocsDC[0]; }
+          return callback(null, numReplaced, updatedDocsDC);
+        }
+      });
+    });
+  }]);
+};
+
+Datastore.prototype.update = function () {
+  this.executor.push({ this: this, fn: this._update, arguments: arguments });
+};
+
+
+/**
+ * Remove all docs matching the query
+ * For now very naive implementation (similar to update)
+ * @param {Object} query
+ * @param {Object} options Optional options
+ *                 options.multi If true, can update multiple documents (defaults to false)
+ * @param {Function} cb Optional callback, signature: err, numRemoved
+ *
+ * @api private Use Datastore.remove which has the same signature
+ */
+Datastore.prototype._remove = function (query, options, cb) {
+  var callback
+    , self = this, numRemoved = 0, removedDocs = [], multi
+    ;
+
+  if (typeof options === 'function') { cb = options; options = {}; }
+  callback = cb || function () {};
+  multi = options.multi !== undefined ? options.multi : false;
+
+  this.getCandidates(query, true, function (err, candidates) {
+    if (err) { return callback(err); }
+
+    try {
+      candidates.forEach(function (d) {
+        if (model.match(d, query) && (multi || numRemoved === 0)) {
+          numRemoved += 1;
+          removedDocs.push({ $$deleted: true, _id: d._id });
+          self.removeFromIndexes(d);
+        }
+      });
+    } catch (err) { return callback(err); }
+
+    self.persistence.persistNewState(removedDocs, function (err) {
+      if (err) { return callback(err); }
+      return callback(null, numRemoved);
+    });
+  });
+};
+
+Datastore.prototype.remove = function () {
+  this.executor.push({ this: this, fn: this._remove, arguments: arguments });
+};
+
+
+
+module.exports = Datastore;

--- a/src/nedb/executor.js
+++ b/src/nedb/executor.js
@@ -1,0 +1,78 @@
+/**
+ * Responsible for sequentially executing actions on the database
+ */
+
+var async = require('async')
+  ;
+
+function Executor () {
+  this.buffer = [];
+  this.ready = false;
+
+  // This queue will execute all commands, one-by-one in order
+  this.queue = async.queue(function (task, cb) {
+    var newArguments = [];
+
+    // task.arguments is an array-like object on which adding a new field doesn't work, so we transform it into a real array
+    for (var i = 0; i < task.arguments.length; i += 1) { newArguments.push(task.arguments[i]); }
+    var lastArg = task.arguments[task.arguments.length - 1];
+
+    // Always tell the queue task is complete. Execute callback if any was given.
+    if (typeof lastArg === 'function') {
+      // Callback was supplied
+      newArguments[newArguments.length - 1] = function () {
+        if (typeof setImmediate === 'function') {
+           setImmediate(cb);
+        } else {
+          process.nextTick(cb);
+        }
+        lastArg.apply(null, arguments);
+      };
+    } else if (!lastArg && task.arguments.length !== 0) {
+      // false/undefined/null supplied as callbback
+      newArguments[newArguments.length - 1] = function () { cb(); };
+    } else {
+      // Nothing supplied as callback
+      newArguments.push(function () { cb(); });
+    }
+
+
+    task.fn.apply(task.this, newArguments);
+  }, 1);
+}
+
+
+/**
+ * If executor is ready, queue task (and process it immediately if executor was idle)
+ * If not, buffer task for later processing
+ * @param {Object} task
+ *                 task.this - Object to use as this
+ *                 task.fn - Function to execute
+ *                 task.arguments - Array of arguments, IMPORTANT: only the last argument may be a function (the callback)
+ *                                                                 and the last argument cannot be false/undefined/null
+ * @param {Boolean} forceQueuing Optional (defaults to false) force executor to queue task even if it is not ready
+ */
+Executor.prototype.push = function (task, forceQueuing) {
+  if (this.ready || forceQueuing) {
+    this.queue.push(task);
+  } else {
+    this.buffer.push(task);
+  }
+};
+
+
+/**
+ * Queue all tasks in buffer (in the same order they came in)
+ * Automatically sets executor as ready
+ */
+Executor.prototype.processBuffer = function () {
+  var i;
+  this.ready = true;
+  for (i = 0; i < this.buffer.length; i += 1) { this.queue.push(this.buffer[i]); }
+  this.buffer = [];
+};
+
+
+
+// Interface
+module.exports = Executor;

--- a/src/nedb/executor.js
+++ b/src/nedb/executor.js
@@ -1,46 +1,42 @@
 /**
  * Responsible for sequentially executing actions on the database
  */
-
-var async = require('async')
-  ;
+const async = require('async')
 
 function Executor () {
-  this.buffer = [];
-  this.ready = false;
+  this.buffer = []
+  this.ready = false
 
   // This queue will execute all commands, one-by-one in order
   this.queue = async.queue(function (task, cb) {
-    var newArguments = [];
+    const newArguments = []
 
     // task.arguments is an array-like object on which adding a new field doesn't work, so we transform it into a real array
-    for (var i = 0; i < task.arguments.length; i += 1) { newArguments.push(task.arguments[i]); }
-    var lastArg = task.arguments[task.arguments.length - 1];
+    for (let i = 0; i < task.arguments.length; i += 1) { newArguments.push(task.arguments[i]) }
+    const lastArg = task.arguments[task.arguments.length - 1]
 
     // Always tell the queue task is complete. Execute callback if any was given.
     if (typeof lastArg === 'function') {
       // Callback was supplied
       newArguments[newArguments.length - 1] = function () {
         if (typeof setImmediate === 'function') {
-           setImmediate(cb);
+          setImmediate(cb)
         } else {
-          process.nextTick(cb);
+          process.nextTick(cb)
         }
-        lastArg.apply(null, arguments);
-      };
+        lastArg.apply(null, arguments)
+      }
     } else if (!lastArg && task.arguments.length !== 0) {
       // false/undefined/null supplied as callbback
-      newArguments[newArguments.length - 1] = function () { cb(); };
+      newArguments[newArguments.length - 1] = function () { cb() }
     } else {
       // Nothing supplied as callback
-      newArguments.push(function () { cb(); });
+      newArguments.push(function () { cb() })
     }
 
-
-    task.fn.apply(task.this, newArguments);
-  }, 1);
+    task.fn.apply(task.this, newArguments)
+  }, 1)
 }
-
 
 /**
  * If executor is ready, queue task (and process it immediately if executor was idle)
@@ -54,25 +50,22 @@ function Executor () {
  */
 Executor.prototype.push = function (task, forceQueuing) {
   if (this.ready || forceQueuing) {
-    this.queue.push(task);
+    this.queue.push(task)
   } else {
-    this.buffer.push(task);
+    this.buffer.push(task)
   }
-};
-
+}
 
 /**
  * Queue all tasks in buffer (in the same order they came in)
  * Automatically sets executor as ready
  */
 Executor.prototype.processBuffer = function () {
-  var i;
-  this.ready = true;
-  for (i = 0; i < this.buffer.length; i += 1) { this.queue.push(this.buffer[i]); }
-  this.buffer = [];
-};
-
-
+  let i
+  this.ready = true
+  for (i = 0; i < this.buffer.length; i += 1) { this.queue.push(this.buffer[i]) }
+  this.buffer = []
+}
 
 // Interface
-module.exports = Executor;
+module.exports = Executor

--- a/src/nedb/indexes.js
+++ b/src/nedb/indexes.js
@@ -1,0 +1,294 @@
+var BinarySearchTree = require('binary-search-tree').AVLTree
+  , model = require('./model')
+  , _ = require('underscore')
+  , util = require('util')
+  ;
+
+/**
+ * Two indexed pointers are equal iif they point to the same place
+ */
+function checkValueEquality (a, b) {
+  return a === b;
+}
+
+/**
+ * Type-aware projection
+ */
+function projectForUnique (elt) {
+  if (elt === null) { return '$null'; }
+  if (typeof elt === 'string') { return '$string' + elt; }
+  if (typeof elt === 'boolean') { return '$boolean' + elt; }
+  if (typeof elt === 'number') { return '$number' + elt; }
+  if (util.isArray(elt)) { return '$date' + elt.getTime(); }
+
+  return elt;   // Arrays and objects, will check for pointer equality
+}
+
+
+/**
+ * Create a new index
+ * All methods on an index guarantee that either the whole operation was successful and the index changed
+ * or the operation was unsuccessful and an error is thrown while the index is unchanged
+ * @param {String} options.fieldName On which field should the index apply (can use dot notation to index on sub fields)
+ * @param {Boolean} options.unique Optional, enforce a unique constraint (default: false)
+ * @param {Boolean} options.sparse Optional, allow a sparse index (we can have documents for which fieldName is undefined) (default: false)
+ */
+function Index (options) {
+  this.fieldName = options.fieldName;
+  this.unique = options.unique || false;
+  this.sparse = options.sparse || false;
+
+  this.treeOptions = { unique: this.unique, compareKeys: model.compareThings, checkValueEquality: checkValueEquality };
+
+  this.reset();   // No data in the beginning
+}
+
+
+/**
+ * Reset an index
+ * @param {Document or Array of documents} newData Optional, data to initialize the index with
+ *                                                 If an error is thrown during insertion, the index is not modified
+ */
+Index.prototype.reset = function (newData) {
+  this.tree = new BinarySearchTree(this.treeOptions);
+
+  if (newData) { this.insert(newData); }
+};
+
+
+/**
+ * Insert a new document in the index
+ * If an array is passed, we insert all its elements (if one insertion fails the index is not modified)
+ * O(log(n))
+ */
+Index.prototype.insert = function (doc) {
+  var key, self = this
+    , keys, i, failingI, error
+    ;
+
+  if (util.isArray(doc)) { this.insertMultipleDocs(doc); return; }
+
+  key = model.getDotValue(doc, this.fieldName);
+
+  // We don't index documents that don't contain the field if the index is sparse
+  if (key === undefined && this.sparse) { return; }
+
+  if (!util.isArray(key)) {
+    this.tree.insert(key, doc);
+  } else {
+    // If an insert fails due to a unique constraint, roll back all inserts before it
+    keys = _.uniq(key, projectForUnique);
+
+    for (i = 0; i < keys.length; i += 1) {
+      try {
+        this.tree.insert(keys[i], doc);
+      } catch (e) {
+        error = e;
+        failingI = i;
+        break;
+      }
+    }
+
+    if (error) {
+      for (i = 0; i < failingI; i += 1) {
+        this.tree.delete(keys[i], doc);
+      }
+
+      throw error;
+    }
+  }
+};
+
+
+/**
+ * Insert an array of documents in the index
+ * If a constraint is violated, the changes should be rolled back and an error thrown
+ *
+ * @API private
+ */
+Index.prototype.insertMultipleDocs = function (docs) {
+  var i, error, failingI;
+
+  for (i = 0; i < docs.length; i += 1) {
+    try {
+      this.insert(docs[i]);
+    } catch (e) {
+      error = e;
+      failingI = i;
+      break;
+    }
+  }
+
+  if (error) {
+    for (i = 0; i < failingI; i += 1) {
+      this.remove(docs[i]);
+    }
+
+    throw error;
+  }
+};
+
+
+/**
+ * Remove a document from the index
+ * If an array is passed, we remove all its elements
+ * The remove operation is safe with regards to the 'unique' constraint
+ * O(log(n))
+ */
+Index.prototype.remove = function (doc) {
+  var key, self = this;
+
+  if (util.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
+
+  key = model.getDotValue(doc, this.fieldName);
+
+  if (key === undefined && this.sparse) { return; }
+
+  if (!util.isArray(key)) {
+    this.tree.delete(key, doc);
+  } else {
+    _.uniq(key, projectForUnique).forEach(function (_key) {
+      self.tree.delete(_key, doc);
+    });
+  }
+};
+
+
+/**
+ * Update a document in the index
+ * If a constraint is violated, changes are rolled back and an error thrown
+ * Naive implementation, still in O(log(n))
+ */
+Index.prototype.update = function (oldDoc, newDoc) {
+  if (util.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
+
+  this.remove(oldDoc);
+
+  try {
+    this.insert(newDoc);
+  } catch (e) {
+    this.insert(oldDoc);
+    throw e;
+  }
+};
+
+
+/**
+ * Update multiple documents in the index
+ * If a constraint is violated, the changes need to be rolled back
+ * and an error thrown
+ * @param {Array of oldDoc, newDoc pairs} pairs
+ *
+ * @API private
+ */
+Index.prototype.updateMultipleDocs = function (pairs) {
+  var i, failingI, error;
+
+  for (i = 0; i < pairs.length; i += 1) {
+    this.remove(pairs[i].oldDoc);
+  }
+
+  for (i = 0; i < pairs.length; i += 1) {
+    try {
+      this.insert(pairs[i].newDoc);
+    } catch (e) {
+      error = e;
+      failingI = i;
+      break;
+    }
+  }
+
+  // If an error was raised, roll back changes in the inverse order
+  if (error) {
+    for (i = 0; i < failingI; i += 1) {
+      this.remove(pairs[i].newDoc);
+    }
+
+    for (i = 0; i < pairs.length; i += 1) {
+      this.insert(pairs[i].oldDoc);
+    }
+
+    throw error;
+  }
+};
+
+
+/**
+ * Revert an update
+ */
+Index.prototype.revertUpdate = function (oldDoc, newDoc) {
+  var revert = [];
+
+  if (!util.isArray(oldDoc)) {
+    this.update(newDoc, oldDoc);
+  } else {
+    oldDoc.forEach(function (pair) {
+      revert.push({ oldDoc: pair.newDoc, newDoc: pair.oldDoc });
+    });
+    this.update(revert);
+  }
+};
+
+
+/**
+ * Get all documents in index whose key match value (if it is a Thing) or one of the elements of value (if it is an array of Things)
+ * @param {Thing} value Value to match the key against
+ * @return {Array of documents}
+ */
+Index.prototype.getMatching = function (value) {
+  var self = this;
+
+  if (!util.isArray(value)) {
+    return self.tree.search(value);
+  } else {
+    var _res = {}, res = [];
+
+    value.forEach(function (v) {
+      self.getMatching(v).forEach(function (doc) {
+        _res[doc._id] = doc;
+      });
+    });
+
+    Object.keys(_res).forEach(function (_id) {
+      res.push(_res[_id]);
+    });
+
+    return res;
+  }
+};
+
+
+/**
+ * Get all documents in index whose key is between bounds are they are defined by query
+ * Documents are sorted by key
+ * @param {Query} query
+ * @return {Array of documents}
+ */
+Index.prototype.getBetweenBounds = function (query) {
+  return this.tree.betweenBounds(query);
+};
+
+
+/**
+ * Get all elements in the index
+ * @return {Array of documents}
+ */
+Index.prototype.getAll = function () {
+  var res = [];
+
+  this.tree.executeOnEveryNode(function (node) {
+    var i;
+
+    for (i = 0; i < node.data.length; i += 1) {
+      res.push(node.data[i]);
+    }
+  });
+
+  return res;
+};
+
+
+
+
+// Interface
+module.exports = Index;

--- a/src/nedb/indexes.js
+++ b/src/nedb/indexes.js
@@ -1,29 +1,27 @@
-var BinarySearchTree = require('binary-search-tree').AVLTree
-  , model = require('./model')
-  , _ = require('underscore')
-  , util = require('util')
-  ;
+const BinarySearchTree = require('binary-search-tree').AVLTree
+const model = require('./model')
+const _ = require('underscore')
+const util = require('util')
 
 /**
  * Two indexed pointers are equal iif they point to the same place
  */
 function checkValueEquality (a, b) {
-  return a === b;
+  return a === b
 }
 
 /**
  * Type-aware projection
  */
 function projectForUnique (elt) {
-  if (elt === null) { return '$null'; }
-  if (typeof elt === 'string') { return '$string' + elt; }
-  if (typeof elt === 'boolean') { return '$boolean' + elt; }
-  if (typeof elt === 'number') { return '$number' + elt; }
-  if (util.isArray(elt)) { return '$date' + elt.getTime(); }
+  if (elt === null) { return '$null' }
+  if (typeof elt === 'string') { return '$string' + elt }
+  if (typeof elt === 'boolean') { return '$boolean' + elt }
+  if (typeof elt === 'number') { return '$number' + elt }
+  if (util.isArray(elt)) { return '$date' + elt.getTime() }
 
-  return elt;   // Arrays and objects, will check for pointer equality
+  return elt   // Arrays and objects, will check for pointer equality
 }
-
 
 /**
  * Create a new index
@@ -34,15 +32,14 @@ function projectForUnique (elt) {
  * @param {Boolean} options.sparse Optional, allow a sparse index (we can have documents for which fieldName is undefined) (default: false)
  */
 function Index (options) {
-  this.fieldName = options.fieldName;
-  this.unique = options.unique || false;
-  this.sparse = options.sparse || false;
+  this.fieldName = options.fieldName
+  this.unique = options.unique || false
+  this.sparse = options.sparse || false
 
-  this.treeOptions = { unique: this.unique, compareKeys: model.compareThings, checkValueEquality: checkValueEquality };
+  this.treeOptions = { unique: this.unique, compareKeys: model.compareThings, checkValueEquality: checkValueEquality }
 
-  this.reset();   // No data in the beginning
+  this.reset()   // No data in the beginning
 }
-
 
 /**
  * Reset an index
@@ -50,11 +47,10 @@ function Index (options) {
  *                                                 If an error is thrown during insertion, the index is not modified
  */
 Index.prototype.reset = function (newData) {
-  this.tree = new BinarySearchTree(this.treeOptions);
+  this.tree = new BinarySearchTree(this.treeOptions)
 
-  if (newData) { this.insert(newData); }
-};
-
+  if (newData) { this.insert(newData) }
+}
 
 /**
  * Insert a new document in the index
@@ -62,43 +58,48 @@ Index.prototype.reset = function (newData) {
  * O(log(n))
  */
 Index.prototype.insert = function (doc) {
-  var key, self = this
-    , keys, i, failingI, error
-    ;
+  let key
+  const self = this
+  let keys
+  let i
+  let failingI
+  let error
 
-  if (util.isArray(doc)) { this.insertMultipleDocs(doc); return; }
+  if (util.isArray(doc)) {
+    this.insertMultipleDocs(doc)
+    return
+  }
 
-  key = model.getDotValue(doc, this.fieldName);
+  key = model.getDotValue(doc, this.fieldName)
 
   // We don't index documents that don't contain the field if the index is sparse
-  if (key === undefined && this.sparse) { return; }
+  if (key === undefined && this.sparse) { return }
 
   if (!util.isArray(key)) {
-    this.tree.insert(key, doc);
+    this.tree.insert(key, doc)
   } else {
     // If an insert fails due to a unique constraint, roll back all inserts before it
-    keys = _.uniq(key, projectForUnique);
+    keys = _.uniq(key, projectForUnique)
 
     for (i = 0; i < keys.length; i += 1) {
       try {
-        this.tree.insert(keys[i], doc);
+        this.tree.insert(keys[i], doc)
       } catch (e) {
-        error = e;
-        failingI = i;
-        break;
+        error = e
+        failingI = i
+        break
       }
     }
 
     if (error) {
       for (i = 0; i < failingI; i += 1) {
-        this.tree.delete(keys[i], doc);
+        this.tree.delete(keys[i], doc)
       }
 
-      throw error;
+      throw error
     }
   }
-};
-
+}
 
 /**
  * Insert an array of documents in the index
@@ -107,27 +108,28 @@ Index.prototype.insert = function (doc) {
  * @API private
  */
 Index.prototype.insertMultipleDocs = function (docs) {
-  var i, error, failingI;
+  let i
+  let error
+  let failingI
 
   for (i = 0; i < docs.length; i += 1) {
     try {
-      this.insert(docs[i]);
+      this.insert(docs[i])
     } catch (e) {
-      error = e;
-      failingI = i;
-      break;
+      error = e
+      failingI = i
+      break
     }
   }
 
   if (error) {
     for (i = 0; i < failingI; i += 1) {
-      this.remove(docs[i]);
+      this.remove(docs[i])
     }
 
-    throw error;
+    throw error
   }
-};
-
+}
 
 /**
  * Remove a document from the index
@@ -136,23 +138,26 @@ Index.prototype.insertMultipleDocs = function (docs) {
  * O(log(n))
  */
 Index.prototype.remove = function (doc) {
-  var key, self = this;
+  let key
+  const self = this
 
-  if (util.isArray(doc)) { doc.forEach(function (d) { self.remove(d); }); return; }
+  if (util.isArray(doc)) {
+    doc.forEach(function (d) { self.remove(d) })
+    return
+  }
 
-  key = model.getDotValue(doc, this.fieldName);
+  key = model.getDotValue(doc, this.fieldName)
 
-  if (key === undefined && this.sparse) { return; }
+  if (key === undefined && this.sparse) { return }
 
   if (!util.isArray(key)) {
-    this.tree.delete(key, doc);
+    this.tree.delete(key, doc)
   } else {
     _.uniq(key, projectForUnique).forEach(function (_key) {
-      self.tree.delete(_key, doc);
-    });
+      self.tree.delete(_key, doc)
+    })
   }
-};
-
+}
 
 /**
  * Update a document in the index
@@ -160,18 +165,20 @@ Index.prototype.remove = function (doc) {
  * Naive implementation, still in O(log(n))
  */
 Index.prototype.update = function (oldDoc, newDoc) {
-  if (util.isArray(oldDoc)) { this.updateMultipleDocs(oldDoc); return; }
+  if (util.isArray(oldDoc)) {
+    this.updateMultipleDocs(oldDoc)
+    return
+  }
 
-  this.remove(oldDoc);
+  this.remove(oldDoc)
 
   try {
-    this.insert(newDoc);
+    this.insert(newDoc)
   } catch (e) {
-    this.insert(oldDoc);
-    throw e;
+    this.insert(oldDoc)
+    throw e
   }
-};
-
+}
 
 /**
  * Update multiple documents in the index
@@ -182,53 +189,53 @@ Index.prototype.update = function (oldDoc, newDoc) {
  * @API private
  */
 Index.prototype.updateMultipleDocs = function (pairs) {
-  var i, failingI, error;
+  let i
+  let failingI
+  let error
 
   for (i = 0; i < pairs.length; i += 1) {
-    this.remove(pairs[i].oldDoc);
+    this.remove(pairs[i].oldDoc)
   }
 
   for (i = 0; i < pairs.length; i += 1) {
     try {
-      this.insert(pairs[i].newDoc);
+      this.insert(pairs[i].newDoc)
     } catch (e) {
-      error = e;
-      failingI = i;
-      break;
+      error = e
+      failingI = i
+      break
     }
   }
 
   // If an error was raised, roll back changes in the inverse order
   if (error) {
     for (i = 0; i < failingI; i += 1) {
-      this.remove(pairs[i].newDoc);
+      this.remove(pairs[i].newDoc)
     }
 
     for (i = 0; i < pairs.length; i += 1) {
-      this.insert(pairs[i].oldDoc);
+      this.insert(pairs[i].oldDoc)
     }
 
-    throw error;
+    throw error
   }
-};
-
+}
 
 /**
  * Revert an update
  */
 Index.prototype.revertUpdate = function (oldDoc, newDoc) {
-  var revert = [];
+  const revert = []
 
   if (!util.isArray(oldDoc)) {
-    this.update(newDoc, oldDoc);
+    this.update(newDoc, oldDoc)
   } else {
     oldDoc.forEach(function (pair) {
-      revert.push({ oldDoc: pair.newDoc, newDoc: pair.oldDoc });
-    });
-    this.update(revert);
+      revert.push({ oldDoc: pair.newDoc, newDoc: pair.oldDoc })
+    })
+    this.update(revert)
   }
-};
-
+}
 
 /**
  * Get all documents in index whose key match value (if it is a Thing) or one of the elements of value (if it is an array of Things)
@@ -236,27 +243,27 @@ Index.prototype.revertUpdate = function (oldDoc, newDoc) {
  * @return {Array of documents}
  */
 Index.prototype.getMatching = function (value) {
-  var self = this;
+  const self = this
 
   if (!util.isArray(value)) {
-    return self.tree.search(value);
+    return self.tree.search(value)
   } else {
-    var _res = {}, res = [];
+    const _res = {}
+    const res = []
 
     value.forEach(function (v) {
       self.getMatching(v).forEach(function (doc) {
-        _res[doc._id] = doc;
-      });
-    });
+        _res[doc._id] = doc
+      })
+    })
 
     Object.keys(_res).forEach(function (_id) {
-      res.push(_res[_id]);
-    });
+      res.push(_res[_id])
+    })
 
-    return res;
+    return res
   }
-};
-
+}
 
 /**
  * Get all documents in index whose key is between bounds are they are defined by query
@@ -265,30 +272,26 @@ Index.prototype.getMatching = function (value) {
  * @return {Array of documents}
  */
 Index.prototype.getBetweenBounds = function (query) {
-  return this.tree.betweenBounds(query);
-};
-
+  return this.tree.betweenBounds(query)
+}
 
 /**
  * Get all elements in the index
  * @return {Array of documents}
  */
 Index.prototype.getAll = function () {
-  var res = [];
+  const res = []
 
   this.tree.executeOnEveryNode(function (node) {
-    var i;
+    let i
 
     for (i = 0; i < node.data.length; i += 1) {
-      res.push(node.data[i]);
+      res.push(node.data[i])
     }
-  });
+  })
 
-  return res;
-};
-
-
-
+  return res
+}
 
 // Interface
-module.exports = Index;
+module.exports = Index

--- a/src/nedb/indexes.js
+++ b/src/nedb/indexes.js
@@ -1,4 +1,4 @@
-const BinarySearchTree = require('binary-search-tree').AVLTree
+const BinarySearchTree = require('../binarySearchTree/avltree')
 const model = require('./model')
 const _ = require('underscore')
 const util = require('util')

--- a/src/nedb/model.js
+++ b/src/nedb/model.js
@@ -1,0 +1,835 @@
+/**
+ * Handle models (i.e. docs)
+ * Serialization/deserialization
+ * Copying
+ * Querying, update
+ */
+
+var util = require('util')
+  , _ = require('underscore')
+  , modifierFunctions = {}
+  , lastStepModifierFunctions = {}
+  , comparisonFunctions = {}
+  , logicalOperators = {}
+  , arrayComparisonFunctions = {}
+  ;
+
+
+/**
+ * Check a key, throw an error if the key is non valid
+ * @param {String} k key
+ * @param {Model} v value, needed to treat the Date edge case
+ * Non-treatable edge cases here: if part of the object if of the form { $$date: number } or { $$deleted: true }
+ * Its serialized-then-deserialized version it will transformed into a Date object
+ * But you really need to want it to trigger such behaviour, even when warned not to use '$' at the beginning of the field names...
+ */
+function checkKey (k, v) {
+  if (typeof k === 'number') {
+    k = k.toString();
+  }
+
+  if (k[0] === '$' && !(k === '$$date' && typeof v === 'number') && !(k === '$$deleted' && v === true) && !(k === '$$indexCreated') && !(k === '$$indexRemoved')) {
+    throw new Error('Field names cannot begin with the $ character');
+  }
+
+  if (k.indexOf('.') !== -1) {
+    throw new Error('Field names cannot contain a .');
+  }
+}
+
+
+/**
+ * Check a DB object and throw an error if it's not valid
+ * Works by applying the above checkKey function to all fields recursively
+ */
+function checkObject (obj) {
+  if (util.isArray(obj)) {
+    obj.forEach(function (o) {
+      checkObject(o);
+    });
+  }
+
+  if (typeof obj === 'object' && obj !== null) {
+    Object.keys(obj).forEach(function (k) {
+      checkKey(k, obj[k]);
+      checkObject(obj[k]);
+    });
+  }
+}
+
+
+/**
+ * Serialize an object to be persisted to a one-line string
+ * For serialization/deserialization, we use the native JSON parser and not eval or Function
+ * That gives us less freedom but data entered in the database may come from users
+ * so eval and the like are not safe
+ * Accepted primitive types: Number, String, Boolean, Date, null
+ * Accepted secondary types: Objects, Arrays
+ */
+function serialize (obj) {
+  var res;
+
+  res = JSON.stringify(obj, function (k, v) {
+    checkKey(k, v);
+
+    if (v === undefined) { return undefined; }
+    if (v === null) { return null; }
+
+    // Hackish way of checking if object is Date (this way it works between execution contexts in node-webkit).
+    // We can't use value directly because for dates it is already string in this function (date.toJSON was already called), so we use this
+    if (typeof this[k].getTime === 'function') { return { $$date: this[k].getTime() }; }
+
+    return v;
+  });
+
+  return res;
+}
+
+
+/**
+ * From a one-line representation of an object generate by the serialize function
+ * Return the object itself
+ */
+function deserialize (rawData) {
+  return JSON.parse(rawData, function (k, v) {
+    if (k === '$$date') { return new Date(v); }
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || v === null) { return v; }
+    if (v && v.$$date) { return v.$$date; }
+
+    return v;
+  });
+}
+
+
+/**
+ * Deep copy a DB object
+ * The optional strictKeys flag (defaulting to false) indicates whether to copy everything or only fields
+ * where the keys are valid, i.e. don't begin with $ and don't contain a .
+ */
+function deepCopy (obj, strictKeys) {
+  var res;
+
+  if ( typeof obj === 'boolean' ||
+       typeof obj === 'number' ||
+       typeof obj === 'string' ||
+       obj === null ||
+       (util.isDate(obj)) ) {
+    return obj;
+  }
+
+  if (util.isArray(obj)) {
+    res = [];
+    obj.forEach(function (o) { res.push(deepCopy(o, strictKeys)); });
+    return res;
+  }
+
+  if (typeof obj === 'object') {
+    res = {};
+    Object.keys(obj).forEach(function (k) {
+      if (!strictKeys || (k[0] !== '$' && k.indexOf('.') === -1)) {
+        res[k] = deepCopy(obj[k], strictKeys);
+      }
+    });
+    return res;
+  }
+
+  return undefined;   // For now everything else is undefined. We should probably throw an error instead
+}
+
+
+/**
+ * Tells if an object is a primitive type or a "real" object
+ * Arrays are considered primitive
+ */
+function isPrimitiveType (obj) {
+  return ( typeof obj === 'boolean' ||
+       typeof obj === 'number' ||
+       typeof obj === 'string' ||
+       obj === null ||
+       util.isDate(obj) ||
+       util.isArray(obj));
+}
+
+
+/**
+ * Utility functions for comparing things
+ * Assumes type checking was already done (a and b already have the same type)
+ * compareNSB works for numbers, strings and booleans
+ */
+function compareNSB (a, b) {
+  if (a < b) { return -1; }
+  if (a > b) { return 1; }
+  return 0;
+}
+
+function compareArrays (a, b) {
+  var i, comp;
+
+  for (i = 0; i < Math.min(a.length, b.length); i += 1) {
+    comp = compareThings(a[i], b[i]);
+
+    if (comp !== 0) { return comp; }
+  }
+
+  // Common section was identical, longest one wins
+  return compareNSB(a.length, b.length);
+}
+
+
+/**
+ * Compare { things U undefined }
+ * Things are defined as any native types (string, number, boolean, null, date) and objects
+ * We need to compare with undefined as it will be used in indexes
+ * In the case of objects and arrays, we deep-compare
+ * If two objects dont have the same type, the (arbitrary) type hierarchy is: undefined, null, number, strings, boolean, dates, arrays, objects
+ * Return -1 if a < b, 1 if a > b and 0 if a = b (note that equality here is NOT the same as defined in areThingsEqual!)
+ *
+ * @param {Function} _compareStrings String comparing function, returning -1, 0 or 1, overriding default string comparison (useful for languages with accented letters)
+ */
+function compareThings (a, b, _compareStrings) {
+  var aKeys, bKeys, comp, i
+    , compareStrings = _compareStrings || compareNSB;
+
+  // undefined
+  if (a === undefined) { return b === undefined ? 0 : -1; }
+  if (b === undefined) { return a === undefined ? 0 : 1; }
+
+  // null
+  if (a === null) { return b === null ? 0 : -1; }
+  if (b === null) { return a === null ? 0 : 1; }
+
+  // Numbers
+  if (typeof a === 'number') { return typeof b === 'number' ? compareNSB(a, b) : -1; }
+  if (typeof b === 'number') { return typeof a === 'number' ? compareNSB(a, b) : 1; }
+
+  // Strings
+  if (typeof a === 'string') { return typeof b === 'string' ? compareStrings(a, b) : -1; }
+  if (typeof b === 'string') { return typeof a === 'string' ? compareStrings(a, b) : 1; }
+
+  // Booleans
+  if (typeof a === 'boolean') { return typeof b === 'boolean' ? compareNSB(a, b) : -1; }
+  if (typeof b === 'boolean') { return typeof a === 'boolean' ? compareNSB(a, b) : 1; }
+
+  // Dates
+  if (util.isDate(a)) { return util.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
+  if (util.isDate(b)) { return util.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
+
+  // Arrays (first element is most significant and so on)
+  if (util.isArray(a)) { return util.isArray(b) ? compareArrays(a, b) : -1; }
+  if (util.isArray(b)) { return util.isArray(a) ? compareArrays(a, b) : 1; }
+
+  // Objects
+  aKeys = Object.keys(a).sort();
+  bKeys = Object.keys(b).sort();
+
+  for (i = 0; i < Math.min(aKeys.length, bKeys.length); i += 1) {
+    comp = compareThings(a[aKeys[i]], b[bKeys[i]]);
+
+    if (comp !== 0) { return comp; }
+  }
+
+  return compareNSB(aKeys.length, bKeys.length);
+}
+
+
+
+// ==============================================================
+// Updating documents
+// ==============================================================
+
+/**
+ * The signature of modifier functions is as follows
+ * Their structure is always the same: recursively follow the dot notation while creating
+ * the nested documents if needed, then apply the "last step modifier"
+ * @param {Object} obj The model to modify
+ * @param {String} field Can contain dots, in that case that means we will set a subfield recursively
+ * @param {Model} value
+ */
+
+/**
+ * Set a field to a new value
+ */
+lastStepModifierFunctions.$set = function (obj, field, value) {
+  obj[field] = value;
+};
+
+
+/**
+ * Unset a field
+ */
+lastStepModifierFunctions.$unset = function (obj, field, value) {
+  delete obj[field];
+};
+
+
+/**
+ * Push an element to the end of an array field
+ * Optional modifier $each instead of value to push several values
+ * Optional modifier $slice to slice the resulting array, see https://docs.mongodb.org/manual/reference/operator/update/slice/
+ * Différeence with MongoDB: if $slice is specified and not $each, we act as if value is an empty array
+ */
+lastStepModifierFunctions.$push = function (obj, field, value) {
+  // Create the array if it doesn't exist
+  if (!obj.hasOwnProperty(field)) { obj[field] = []; }
+
+  if (!util.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
+
+  if (value !== null && typeof value === 'object' && value.$slice && value.$each === undefined) {
+    value.$each = [];
+  }
+
+  if (value !== null && typeof value === 'object' && value.$each) {
+    if (Object.keys(value).length >= 3 || (Object.keys(value).length === 2 && value.$slice === undefined)) { throw new Error("Can only use $slice in cunjunction with $each when $push to array"); }
+    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+
+    value.$each.forEach(function (v) {
+      obj[field].push(v);
+    });
+
+    if (value.$slice === undefined || typeof value.$slice !== 'number') { return; }
+
+    if (value.$slice === 0) {
+      obj[field] = [];
+    } else {
+      var start, end, n = obj[field].length;
+      if (value.$slice < 0) {
+        start = Math.max(0, n + value.$slice);
+        end = n;
+      } else if (value.$slice > 0) {
+        start = 0;
+        end = Math.min(n, value.$slice);
+      }
+      obj[field] = obj[field].slice(start, end);
+    }
+  } else {
+    obj[field].push(value);
+  }
+};
+
+
+/**
+ * Add an element to an array field only if it is not already in it
+ * No modification if the element is already in the array
+ * Note that it doesn't check whether the original array contains duplicates
+ */
+lastStepModifierFunctions.$addToSet = function (obj, field, value) {
+  var addToSet = true;
+
+  // Create the array if it doesn't exist
+  if (!obj.hasOwnProperty(field)) { obj[field] = []; }
+
+  if (!util.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
+
+  if (value !== null && typeof value === 'object' && value.$each) {
+    if (Object.keys(value).length > 1) { throw new Error("Can't use another field in conjunction with $each"); }
+    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+
+    value.$each.forEach(function (v) {
+      lastStepModifierFunctions.$addToSet(obj, field, v);
+    });
+  } else {
+    obj[field].forEach(function (v) {
+      if (compareThings(v, value) === 0) { addToSet = false; }
+    });
+    if (addToSet) { obj[field].push(value); }
+  }
+};
+
+
+/**
+ * Remove the first or last element of an array
+ */
+lastStepModifierFunctions.$pop = function (obj, field, value) {
+  if (!util.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
+  if (typeof value !== 'number') { throw new Error(value + " isn't an integer, can't use it with $pop"); }
+  if (value === 0) { return; }
+
+  if (value > 0) {
+    obj[field] = obj[field].slice(0, obj[field].length - 1);
+  } else {
+    obj[field] = obj[field].slice(1);
+  }
+};
+
+
+/**
+ * Removes all instances of a value from an existing array
+ */
+lastStepModifierFunctions.$pull = function (obj, field, value) {
+  var arr, i;
+
+  if (!util.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
+
+  arr = obj[field];
+  for (i = arr.length - 1; i >= 0; i -= 1) {
+    if (match(arr[i], value)) {
+      arr.splice(i, 1);
+    }
+  }
+};
+
+
+/**
+ * Increment a numeric field's value
+ */
+lastStepModifierFunctions.$inc = function (obj, field, value) {
+  if (typeof value !== 'number') { throw new Error(value + " must be a number"); }
+
+  if (typeof obj[field] !== 'number') {
+    if (!_.has(obj, field)) {
+      obj[field] = value;
+    } else {
+      throw new Error("Don't use the $inc modifier on non-number fields");
+    }
+  } else {
+    obj[field] += value;
+  }
+};
+
+/**
+ * Updates the value of the field, only if specified field is greater than the current value of the field
+ */
+lastStepModifierFunctions.$max = function (obj, field, value) {
+  if (typeof obj[field] === 'undefined') {
+    obj[field] = value;
+  } else if (value > obj[field]) {
+    obj[field] = value;
+  }
+};
+
+/**
+ * Updates the value of the field, only if specified field is smaller than the current value of the field
+ */
+lastStepModifierFunctions.$min = function (obj, field, value) {
+  if (typeof obj[field] === 'undefined') { 
+    obj[field] = value;
+  } else if (value < obj[field]) {
+    obj[field] = value;
+  }
+};
+
+// Given its name, create the complete modifier function
+function createModifierFunction (modifier) {
+  return function (obj, field, value) {
+    var fieldParts = typeof field === 'string' ? field.split('.') : field;
+
+    if (fieldParts.length === 1) {
+      lastStepModifierFunctions[modifier](obj, field, value);
+    } else {
+      if (obj[fieldParts[0]] === undefined) {
+        if (modifier === '$unset') { return; }   // Bad looking specific fix, needs to be generalized modifiers that behave like $unset are implemented
+        obj[fieldParts[0]] = {};
+      }
+      modifierFunctions[modifier](obj[fieldParts[0]], fieldParts.slice(1), value);
+    }
+  };
+}
+
+// Actually create all modifier functions
+Object.keys(lastStepModifierFunctions).forEach(function (modifier) {
+  modifierFunctions[modifier] = createModifierFunction(modifier);
+});
+
+
+/**
+ * Modify a DB object according to an update query
+ */
+function modify (obj, updateQuery) {
+  var keys = Object.keys(updateQuery)
+    , firstChars = _.map(keys, function (item) { return item[0]; })
+    , dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; })
+    , newDoc, modifiers
+    ;
+
+  if (keys.indexOf('_id') !== -1 && updateQuery._id !== obj._id) { throw new Error("You cannot change a document's _id"); }
+
+  if (dollarFirstChars.length !== 0 && dollarFirstChars.length !== firstChars.length) {
+    throw new Error("You cannot mix modifiers and normal fields");
+  }
+
+  if (dollarFirstChars.length === 0) {
+    // Simply replace the object with the update query contents
+    newDoc = deepCopy(updateQuery);
+    newDoc._id = obj._id;
+  } else {
+    // Apply modifiers
+    modifiers = _.uniq(keys);
+    newDoc = deepCopy(obj);
+    modifiers.forEach(function (m) {
+      var keys;
+
+      if (!modifierFunctions[m]) { throw new Error("Unknown modifier " + m); }
+
+      // Can't rely on Object.keys throwing on non objects since ES6
+      // Not 100% satisfying as non objects can be interpreted as objects but no false negatives so we can live with it
+      if (typeof updateQuery[m] !== 'object') {
+        throw new Error("Modifier " + m + "'s argument must be an object");
+      }
+
+      keys = Object.keys(updateQuery[m]);
+      keys.forEach(function (k) {
+        modifierFunctions[m](newDoc, k, updateQuery[m][k]);
+      });
+    });
+  }
+
+  // Check result is valid and return it
+  checkObject(newDoc);
+
+  if (obj._id !== newDoc._id) { throw new Error("You can't change a document's _id"); }
+  return newDoc;
+};
+
+
+// ==============================================================
+// Finding documents
+// ==============================================================
+
+/**
+ * Get a value from object with dot notation
+ * @param {Object} obj
+ * @param {String} field
+ */
+function getDotValue (obj, field) {
+  var fieldParts = typeof field === 'string' ? field.split('.') : field
+    , i, objs;
+
+  if (!obj) { return undefined; }   // field cannot be empty so that means we should return undefined so that nothing can match
+
+  if (fieldParts.length === 0) { return obj; }
+
+  if (fieldParts.length === 1) { return obj[fieldParts[0]]; }
+
+  if (util.isArray(obj[fieldParts[0]])) {
+    // If the next field is an integer, return only this item of the array
+    i = parseInt(fieldParts[1], 10);
+    if (typeof i === 'number' && !isNaN(i)) {
+      return getDotValue(obj[fieldParts[0]][i], fieldParts.slice(2))
+    }
+
+    // Return the array of values
+    objs = new Array();
+    for (i = 0; i < obj[fieldParts[0]].length; i += 1) {
+       objs.push(getDotValue(obj[fieldParts[0]][i], fieldParts.slice(1)));
+    }
+    return objs;
+  } else {
+    return getDotValue(obj[fieldParts[0]], fieldParts.slice(1));
+  }
+}
+
+
+/**
+ * Check whether 'things' are equal
+ * Things are defined as any native types (string, number, boolean, null, date) and objects
+ * In the case of object, we check deep equality
+ * Returns true if they are, false otherwise
+ */
+function areThingsEqual (a, b) {
+  var aKeys , bKeys , i;
+
+  // Strings, booleans, numbers, null
+  if (a === null || typeof a === 'string' || typeof a === 'boolean' || typeof a === 'number' ||
+      b === null || typeof b === 'string' || typeof b === 'boolean' || typeof b === 'number') { return a === b; }
+
+  // Dates
+  if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime(); }
+
+  // Arrays (no match since arrays are used as a $in)
+  // undefined (no match since they mean field doesn't exist and can't be serialized)
+  if ((!(util.isArray(a) && util.isArray(b)) && (util.isArray(a) || util.isArray(b))) || a === undefined || b === undefined) { return false; }
+
+  // General objects (check for deep equality)
+  // a and b should be objects at this point
+  try {
+    aKeys = Object.keys(a);
+    bKeys = Object.keys(b);
+  } catch (e) {
+    return false;
+  }
+
+  if (aKeys.length !== bKeys.length) { return false; }
+  for (i = 0; i < aKeys.length; i += 1) {
+    if (bKeys.indexOf(aKeys[i]) === -1) { return false; }
+    if (!areThingsEqual(a[aKeys[i]], b[aKeys[i]])) { return false; }
+  }
+  return true;
+}
+
+
+/**
+ * Check that two values are comparable
+ */
+function areComparable (a, b) {
+  if (typeof a !== 'string' && typeof a !== 'number' && !util.isDate(a) &&
+      typeof b !== 'string' && typeof b !== 'number' && !util.isDate(b)) {
+    return false;
+  }
+
+  if (typeof a !== typeof b) { return false; }
+
+  return true;
+}
+
+
+/**
+ * Arithmetic and comparison operators
+ * @param {Native value} a Value in the object
+ * @param {Native value} b Value in the query
+ */
+comparisonFunctions.$lt = function (a, b) {
+  return areComparable(a, b) && a < b;
+};
+
+comparisonFunctions.$lte = function (a, b) {
+  return areComparable(a, b) && a <= b;
+};
+
+comparisonFunctions.$gt = function (a, b) {
+  return areComparable(a, b) && a > b;
+};
+
+comparisonFunctions.$gte = function (a, b) {
+  return areComparable(a, b) && a >= b;
+};
+
+comparisonFunctions.$ne = function (a, b) {
+  if (a === undefined) { return true; }
+  return !areThingsEqual(a, b);
+};
+
+comparisonFunctions.$in = function (a, b) {
+  var i;
+
+  if (!util.isArray(b)) { throw new Error("$in operator called with a non-array"); }
+
+  for (i = 0; i < b.length; i += 1) {
+    if (areThingsEqual(a, b[i])) { return true; }
+  }
+
+  return false;
+};
+
+comparisonFunctions.$nin = function (a, b) {
+  if (!util.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
+
+  return !comparisonFunctions.$in(a, b);
+};
+
+comparisonFunctions.$regex = function (a, b) {
+  if (!util.isRegExp(b)) { throw new Error("$regex operator called with non regular expression"); }
+
+  if (typeof a !== 'string') {
+    return false
+  } else {
+    return b.test(a);
+  }
+};
+
+comparisonFunctions.$exists = function (value, exists) {
+  if (exists || exists === '') {   // This will be true for all values of exists except false, null, undefined and 0
+    exists = true;                 // That's strange behaviour (we should only use true/false) but that's the way Mongo does it...
+  } else {
+    exists = false;
+  }
+
+  if (value === undefined) {
+    return !exists
+  } else {
+    return exists;
+  }
+};
+
+// Specific to arrays
+comparisonFunctions.$size = function (obj, value) {
+    if (!util.isArray(obj)) { return false; }
+    if (value % 1 !== 0) { throw new Error("$size operator called without an integer"); }
+
+    return (obj.length == value);
+};
+comparisonFunctions.$elemMatch = function (obj, value) {
+  if (!util.isArray(obj)) { return false; }
+  var i = obj.length;
+  var result = false;   // Initialize result
+  while (i--) {
+    if (match(obj[i], value)) {   // If match for array element, return true
+      result = true;
+      break;
+    }
+  }
+  return result;
+};
+arrayComparisonFunctions.$size = true;
+arrayComparisonFunctions.$elemMatch = true;
+
+
+/**
+ * Match any of the subqueries
+ * @param {Model} obj
+ * @param {Array of Queries} query
+ */
+logicalOperators.$or = function (obj, query) {
+  var i;
+
+  if (!util.isArray(query)) { throw new Error("$or operator used without an array"); }
+
+  for (i = 0; i < query.length; i += 1) {
+    if (match(obj, query[i])) { return true; }
+  }
+
+  return false;
+};
+
+
+/**
+ * Match all of the subqueries
+ * @param {Model} obj
+ * @param {Array of Queries} query
+ */
+logicalOperators.$and = function (obj, query) {
+  var i;
+
+  if (!util.isArray(query)) { throw new Error("$and operator used without an array"); }
+
+  for (i = 0; i < query.length; i += 1) {
+    if (!match(obj, query[i])) { return false; }
+  }
+
+  return true;
+};
+
+
+/**
+ * Inverted match of the query
+ * @param {Model} obj
+ * @param {Query} query
+ */
+logicalOperators.$not = function (obj, query) {
+  return !match(obj, query);
+};
+
+
+/**
+ * Use a function to match
+ * @param {Model} obj
+ * @param {Query} query
+ */
+logicalOperators.$where = function (obj, fn) {
+  var result;
+
+  if (!_.isFunction(fn)) { throw new Error("$where operator used without a function"); }
+
+  result = fn.call(obj);
+  if (!_.isBoolean(result)) { throw new Error("$where function must return boolean"); }
+
+  return result;
+};
+
+
+/**
+ * Tell if a given document matches a query
+ * @param {Object} obj Document to check
+ * @param {Object} query
+ */
+function match (obj, query) {
+  var queryKeys, queryKey, queryValue, i;
+
+  // Primitive query against a primitive type
+  // This is a bit of a hack since we construct an object with an arbitrary key only to dereference it later
+  // But I don't have time for a cleaner implementation now
+  if (isPrimitiveType(obj) || isPrimitiveType(query)) {
+    return matchQueryPart({ needAKey: obj }, 'needAKey', query);
+  }
+
+  // Normal query
+  queryKeys = Object.keys(query);
+  for (i = 0; i < queryKeys.length; i += 1) {
+    queryKey = queryKeys[i];
+    queryValue = query[queryKey];
+
+    if (queryKey[0] === '$') {
+      if (!logicalOperators[queryKey]) { throw new Error("Unknown logical operator " + queryKey); }
+      if (!logicalOperators[queryKey](obj, queryValue)) { return false; }
+    } else {
+      if (!matchQueryPart(obj, queryKey, queryValue)) { return false; }
+    }
+  }
+
+  return true;
+};
+
+
+/**
+ * Match an object against a specific { key: value } part of a query
+ * if the treatObjAsValue flag is set, don't try to match every part separately, but the array as a whole
+ */
+function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
+  var objValue = getDotValue(obj, queryKey)
+    , i, keys, firstChars, dollarFirstChars;
+
+  // Check if the value is an array if we don't force a treatment as value
+  if (util.isArray(objValue) && !treatObjAsValue) {
+    // If the queryValue is an array, try to perform an exact match
+    if (util.isArray(queryValue)) {
+      return matchQueryPart(obj, queryKey, queryValue, true);
+    }
+
+    // Check if we are using an array-specific comparison function
+    if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
+      keys = Object.keys(queryValue);
+      for (i = 0; i < keys.length; i += 1) {
+        if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true); }
+      }
+    }
+
+    // If not, treat it as an array of { obj, query } where there needs to be at least one match
+    for (i = 0; i < objValue.length; i += 1) {
+      if (matchQueryPart({ k: objValue[i] }, 'k', queryValue)) { return true; }   // k here could be any string
+    }
+    return false;
+  }
+
+  // queryValue is an actual object. Determine whether it contains comparison operators
+  // or only normal fields. Mixed objects are not allowed
+  if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue) && !util.isArray(queryValue)) {
+    keys = Object.keys(queryValue);
+    firstChars = _.map(keys, function (item) { return item[0]; });
+    dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; });
+
+    if (dollarFirstChars.length !== 0 && dollarFirstChars.length !== firstChars.length) {
+      throw new Error("You cannot mix operators and normal fields");
+    }
+
+    // queryValue is an object of this form: { $comparisonOperator1: value1, ... }
+    if (dollarFirstChars.length > 0) {
+      for (i = 0; i < keys.length; i += 1) {
+        if (!comparisonFunctions[keys[i]]) { throw new Error("Unknown comparison function " + keys[i]); }
+
+        if (!comparisonFunctions[keys[i]](objValue, queryValue[keys[i]])) { return false; }
+      }
+      return true;
+    }
+  }
+
+  // Using regular expressions with basic querying
+  if (util.isRegExp(queryValue)) { return comparisonFunctions.$regex(objValue, queryValue); }
+
+  // queryValue is either a native value or a normal object
+  // Basic matching is possible
+  if (!areThingsEqual(objValue, queryValue)) { return false; }
+
+  return true;
+}
+
+
+// Interface
+module.exports.serialize = serialize;
+module.exports.deserialize = deserialize;
+module.exports.deepCopy = deepCopy;
+module.exports.checkObject = checkObject;
+module.exports.isPrimitiveType = isPrimitiveType;
+module.exports.modify = modify;
+module.exports.getDotValue = getDotValue;
+module.exports.match = match;
+module.exports.areThingsEqual = areThingsEqual;
+module.exports.compareThings = compareThings;

--- a/src/nedb/model.js
+++ b/src/nedb/model.js
@@ -4,16 +4,13 @@
  * Copying
  * Querying, update
  */
-
-var util = require('util')
-  , _ = require('underscore')
-  , modifierFunctions = {}
-  , lastStepModifierFunctions = {}
-  , comparisonFunctions = {}
-  , logicalOperators = {}
-  , arrayComparisonFunctions = {}
-  ;
-
+const util = require('util')
+const _ = require('underscore')
+const modifierFunctions = {}
+const lastStepModifierFunctions = {}
+const comparisonFunctions = {}
+const logicalOperators = {}
+const arrayComparisonFunctions = {}
 
 /**
  * Check a key, throw an error if the key is non valid
@@ -25,18 +22,17 @@ var util = require('util')
  */
 function checkKey (k, v) {
   if (typeof k === 'number') {
-    k = k.toString();
+    k = k.toString()
   }
 
   if (k[0] === '$' && !(k === '$$date' && typeof v === 'number') && !(k === '$$deleted' && v === true) && !(k === '$$indexCreated') && !(k === '$$indexRemoved')) {
-    throw new Error('Field names cannot begin with the $ character');
+    throw new Error('Field names cannot begin with the $ character')
   }
 
   if (k.indexOf('.') !== -1) {
-    throw new Error('Field names cannot contain a .');
+    throw new Error('Field names cannot contain a .')
   }
 }
-
 
 /**
  * Check a DB object and throw an error if it's not valid
@@ -45,18 +41,17 @@ function checkKey (k, v) {
 function checkObject (obj) {
   if (util.isArray(obj)) {
     obj.forEach(function (o) {
-      checkObject(o);
-    });
+      checkObject(o)
+    })
   }
 
   if (typeof obj === 'object' && obj !== null) {
     Object.keys(obj).forEach(function (k) {
-      checkKey(k, obj[k]);
-      checkObject(obj[k]);
-    });
+      checkKey(k, obj[k])
+      checkObject(obj[k])
+    })
   }
 }
-
 
 /**
  * Serialize an object to be persisted to a one-line string
@@ -67,24 +62,23 @@ function checkObject (obj) {
  * Accepted secondary types: Objects, Arrays
  */
 function serialize (obj) {
-  var res;
+  let res
 
   res = JSON.stringify(obj, function (k, v) {
-    checkKey(k, v);
+    checkKey(k, v)
 
-    if (v === undefined) { return undefined; }
-    if (v === null) { return null; }
+    if (v === undefined) { return undefined }
+    if (v === null) { return null }
 
     // Hackish way of checking if object is Date (this way it works between execution contexts in node-webkit).
     // We can't use value directly because for dates it is already string in this function (date.toJSON was already called), so we use this
-    if (typeof this[k].getTime === 'function') { return { $$date: this[k].getTime() }; }
+    if (typeof this[k].getTime === 'function') { return { $$date: this[k].getTime() } }
 
-    return v;
-  });
+    return v
+  })
 
-  return res;
+  return res
 }
-
 
 /**
  * From a one-line representation of an object generate by the serialize function
@@ -92,14 +86,13 @@ function serialize (obj) {
  */
 function deserialize (rawData) {
   return JSON.parse(rawData, function (k, v) {
-    if (k === '$$date') { return new Date(v); }
-    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || v === null) { return v; }
-    if (v && v.$$date) { return v.$$date; }
+    if (k === '$$date') { return new Date(v) }
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || v === null) { return v }
+    if (v && v.$$date) { return v.$$date }
 
-    return v;
-  });
+    return v
+  })
 }
-
 
 /**
  * Deep copy a DB object
@@ -107,49 +100,47 @@ function deserialize (rawData) {
  * where the keys are valid, i.e. don't begin with $ and don't contain a .
  */
 function deepCopy (obj, strictKeys) {
-  var res;
+  let res
 
-  if ( typeof obj === 'boolean' ||
-       typeof obj === 'number' ||
-       typeof obj === 'string' ||
-       obj === null ||
-       (util.isDate(obj)) ) {
-    return obj;
+  if (typeof obj === 'boolean' ||
+    typeof obj === 'number' ||
+    typeof obj === 'string' ||
+    obj === null ||
+    (util.isDate(obj))) {
+    return obj
   }
 
   if (util.isArray(obj)) {
-    res = [];
-    obj.forEach(function (o) { res.push(deepCopy(o, strictKeys)); });
-    return res;
+    res = []
+    obj.forEach(function (o) { res.push(deepCopy(o, strictKeys)) })
+    return res
   }
 
   if (typeof obj === 'object') {
-    res = {};
+    res = {}
     Object.keys(obj).forEach(function (k) {
       if (!strictKeys || (k[0] !== '$' && k.indexOf('.') === -1)) {
-        res[k] = deepCopy(obj[k], strictKeys);
+        res[k] = deepCopy(obj[k], strictKeys)
       }
-    });
-    return res;
+    })
+    return res
   }
 
-  return undefined;   // For now everything else is undefined. We should probably throw an error instead
+  return undefined   // For now everything else is undefined. We should probably throw an error instead
 }
-
 
 /**
  * Tells if an object is a primitive type or a "real" object
  * Arrays are considered primitive
  */
 function isPrimitiveType (obj) {
-  return ( typeof obj === 'boolean' ||
-       typeof obj === 'number' ||
-       typeof obj === 'string' ||
-       obj === null ||
-       util.isDate(obj) ||
-       util.isArray(obj));
+  return (typeof obj === 'boolean' ||
+    typeof obj === 'number' ||
+    typeof obj === 'string' ||
+    obj === null ||
+    util.isDate(obj) ||
+    util.isArray(obj))
 }
-
 
 /**
  * Utility functions for comparing things
@@ -157,24 +148,24 @@ function isPrimitiveType (obj) {
  * compareNSB works for numbers, strings and booleans
  */
 function compareNSB (a, b) {
-  if (a < b) { return -1; }
-  if (a > b) { return 1; }
-  return 0;
+  if (a < b) { return -1 }
+  if (a > b) { return 1 }
+  return 0
 }
 
 function compareArrays (a, b) {
-  var i, comp;
+  let i
+  let comp
 
   for (i = 0; i < Math.min(a.length, b.length); i += 1) {
-    comp = compareThings(a[i], b[i]);
+    comp = compareThings(a[i], b[i])
 
-    if (comp !== 0) { return comp; }
+    if (comp !== 0) { return comp }
   }
 
   // Common section was identical, longest one wins
-  return compareNSB(a.length, b.length);
+  return compareNSB(a.length, b.length)
 }
-
 
 /**
  * Compare { things U undefined }
@@ -187,51 +178,52 @@ function compareArrays (a, b) {
  * @param {Function} _compareStrings String comparing function, returning -1, 0 or 1, overriding default string comparison (useful for languages with accented letters)
  */
 function compareThings (a, b, _compareStrings) {
-  var aKeys, bKeys, comp, i
-    , compareStrings = _compareStrings || compareNSB;
+  let aKeys
+  let bKeys
+  let comp
+  let i
+  const compareStrings = _compareStrings || compareNSB
 
   // undefined
-  if (a === undefined) { return b === undefined ? 0 : -1; }
-  if (b === undefined) { return a === undefined ? 0 : 1; }
+  if (a === undefined) { return b === undefined ? 0 : -1 }
+  if (b === undefined) { return a === undefined ? 0 : 1 }
 
   // null
-  if (a === null) { return b === null ? 0 : -1; }
-  if (b === null) { return a === null ? 0 : 1; }
+  if (a === null) { return b === null ? 0 : -1 }
+  if (b === null) { return a === null ? 0 : 1 }
 
   // Numbers
-  if (typeof a === 'number') { return typeof b === 'number' ? compareNSB(a, b) : -1; }
-  if (typeof b === 'number') { return typeof a === 'number' ? compareNSB(a, b) : 1; }
+  if (typeof a === 'number') { return typeof b === 'number' ? compareNSB(a, b) : -1 }
+  if (typeof b === 'number') { return typeof a === 'number' ? compareNSB(a, b) : 1 }
 
   // Strings
-  if (typeof a === 'string') { return typeof b === 'string' ? compareStrings(a, b) : -1; }
-  if (typeof b === 'string') { return typeof a === 'string' ? compareStrings(a, b) : 1; }
+  if (typeof a === 'string') { return typeof b === 'string' ? compareStrings(a, b) : -1 }
+  if (typeof b === 'string') { return typeof a === 'string' ? compareStrings(a, b) : 1 }
 
   // Booleans
-  if (typeof a === 'boolean') { return typeof b === 'boolean' ? compareNSB(a, b) : -1; }
-  if (typeof b === 'boolean') { return typeof a === 'boolean' ? compareNSB(a, b) : 1; }
+  if (typeof a === 'boolean') { return typeof b === 'boolean' ? compareNSB(a, b) : -1 }
+  if (typeof b === 'boolean') { return typeof a === 'boolean' ? compareNSB(a, b) : 1 }
 
   // Dates
-  if (util.isDate(a)) { return util.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1; }
-  if (util.isDate(b)) { return util.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1; }
+  if (util.isDate(a)) { return util.isDate(b) ? compareNSB(a.getTime(), b.getTime()) : -1 }
+  if (util.isDate(b)) { return util.isDate(a) ? compareNSB(a.getTime(), b.getTime()) : 1 }
 
   // Arrays (first element is most significant and so on)
-  if (util.isArray(a)) { return util.isArray(b) ? compareArrays(a, b) : -1; }
-  if (util.isArray(b)) { return util.isArray(a) ? compareArrays(a, b) : 1; }
+  if (util.isArray(a)) { return util.isArray(b) ? compareArrays(a, b) : -1 }
+  if (util.isArray(b)) { return util.isArray(a) ? compareArrays(a, b) : 1 }
 
   // Objects
-  aKeys = Object.keys(a).sort();
-  bKeys = Object.keys(b).sort();
+  aKeys = Object.keys(a).sort()
+  bKeys = Object.keys(b).sort()
 
   for (i = 0; i < Math.min(aKeys.length, bKeys.length); i += 1) {
-    comp = compareThings(a[aKeys[i]], b[bKeys[i]]);
+    comp = compareThings(a[aKeys[i]], b[bKeys[i]])
 
-    if (comp !== 0) { return comp; }
+    if (comp !== 0) { return comp }
   }
 
-  return compareNSB(aKeys.length, bKeys.length);
+  return compareNSB(aKeys.length, bKeys.length)
 }
-
-
 
 // ==============================================================
 // Updating documents
@@ -250,17 +242,15 @@ function compareThings (a, b, _compareStrings) {
  * Set a field to a new value
  */
 lastStepModifierFunctions.$set = function (obj, field, value) {
-  obj[field] = value;
-};
-
+  obj[field] = value
+}
 
 /**
  * Unset a field
  */
 lastStepModifierFunctions.$unset = function (obj, field, value) {
-  delete obj[field];
-};
-
+  delete obj[field]
+}
 
 /**
  * Push an element to the end of an array field
@@ -270,42 +260,43 @@ lastStepModifierFunctions.$unset = function (obj, field, value) {
  */
 lastStepModifierFunctions.$push = function (obj, field, value) {
   // Create the array if it doesn't exist
-  if (!obj.hasOwnProperty(field)) { obj[field] = []; }
+  if (!obj.hasOwnProperty(field)) { obj[field] = [] }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $push an element on non-array values"); }
+  if (!util.isArray(obj[field])) { throw new Error('Can\'t $push an element on non-array values') }
 
   if (value !== null && typeof value === 'object' && value.$slice && value.$each === undefined) {
-    value.$each = [];
+    value.$each = []
   }
 
   if (value !== null && typeof value === 'object' && value.$each) {
-    if (Object.keys(value).length >= 3 || (Object.keys(value).length === 2 && value.$slice === undefined)) { throw new Error("Can only use $slice in cunjunction with $each when $push to array"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (Object.keys(value).length >= 3 || (Object.keys(value).length === 2 && value.$slice === undefined)) { throw new Error('Can only use $slice in cunjunction with $each when $push to array') }
+    if (!util.isArray(value.$each)) { throw new Error('$each requires an array value') }
 
     value.$each.forEach(function (v) {
-      obj[field].push(v);
-    });
+      obj[field].push(v)
+    })
 
-    if (value.$slice === undefined || typeof value.$slice !== 'number') { return; }
+    if (value.$slice === undefined || typeof value.$slice !== 'number') { return }
 
     if (value.$slice === 0) {
-      obj[field] = [];
+      obj[field] = []
     } else {
-      var start, end, n = obj[field].length;
+      let start
+      let end
+      const n = obj[field].length
       if (value.$slice < 0) {
-        start = Math.max(0, n + value.$slice);
-        end = n;
+        start = Math.max(0, n + value.$slice)
+        end = n
       } else if (value.$slice > 0) {
-        start = 0;
-        end = Math.min(n, value.$slice);
+        start = 0
+        end = Math.min(n, value.$slice)
       }
-      obj[field] = obj[field].slice(start, end);
+      obj[field] = obj[field].slice(start, end)
     }
   } else {
-    obj[field].push(value);
+    obj[field].push(value)
   }
-};
-
+}
 
 /**
  * Add an element to an array field only if it is not already in it
@@ -313,173 +304,169 @@ lastStepModifierFunctions.$push = function (obj, field, value) {
  * Note that it doesn't check whether the original array contains duplicates
  */
 lastStepModifierFunctions.$addToSet = function (obj, field, value) {
-  var addToSet = true;
+  let addToSet = true
 
   // Create the array if it doesn't exist
-  if (!obj.hasOwnProperty(field)) { obj[field] = []; }
+  if (!obj.hasOwnProperty(field)) { obj[field] = [] }
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $addToSet an element on non-array values"); }
+  if (!util.isArray(obj[field])) { throw new Error('Can\'t $addToSet an element on non-array values') }
 
   if (value !== null && typeof value === 'object' && value.$each) {
-    if (Object.keys(value).length > 1) { throw new Error("Can't use another field in conjunction with $each"); }
-    if (!util.isArray(value.$each)) { throw new Error("$each requires an array value"); }
+    if (Object.keys(value).length > 1) { throw new Error('Can\'t use another field in conjunction with $each') }
+    if (!util.isArray(value.$each)) { throw new Error('$each requires an array value') }
 
     value.$each.forEach(function (v) {
-      lastStepModifierFunctions.$addToSet(obj, field, v);
-    });
+      lastStepModifierFunctions.$addToSet(obj, field, v)
+    })
   } else {
     obj[field].forEach(function (v) {
-      if (compareThings(v, value) === 0) { addToSet = false; }
-    });
-    if (addToSet) { obj[field].push(value); }
+      if (compareThings(v, value) === 0) { addToSet = false }
+    })
+    if (addToSet) { obj[field].push(value) }
   }
-};
-
+}
 
 /**
  * Remove the first or last element of an array
  */
 lastStepModifierFunctions.$pop = function (obj, field, value) {
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pop an element from non-array values"); }
-  if (typeof value !== 'number') { throw new Error(value + " isn't an integer, can't use it with $pop"); }
-  if (value === 0) { return; }
+  if (!util.isArray(obj[field])) { throw new Error('Can\'t $pop an element from non-array values') }
+  if (typeof value !== 'number') { throw new Error(value + ' isn\'t an integer, can\'t use it with $pop') }
+  if (value === 0) { return }
 
   if (value > 0) {
-    obj[field] = obj[field].slice(0, obj[field].length - 1);
+    obj[field] = obj[field].slice(0, obj[field].length - 1)
   } else {
-    obj[field] = obj[field].slice(1);
+    obj[field] = obj[field].slice(1)
   }
-};
-
+}
 
 /**
  * Removes all instances of a value from an existing array
  */
 lastStepModifierFunctions.$pull = function (obj, field, value) {
-  var arr, i;
+  let arr
+  let i
 
-  if (!util.isArray(obj[field])) { throw new Error("Can't $pull an element from non-array values"); }
+  if (!util.isArray(obj[field])) { throw new Error('Can\'t $pull an element from non-array values') }
 
-  arr = obj[field];
+  arr = obj[field]
   for (i = arr.length - 1; i >= 0; i -= 1) {
     if (match(arr[i], value)) {
-      arr.splice(i, 1);
+      arr.splice(i, 1)
     }
   }
-};
-
+}
 
 /**
  * Increment a numeric field's value
  */
 lastStepModifierFunctions.$inc = function (obj, field, value) {
-  if (typeof value !== 'number') { throw new Error(value + " must be a number"); }
+  if (typeof value !== 'number') { throw new Error(value + ' must be a number') }
 
   if (typeof obj[field] !== 'number') {
     if (!_.has(obj, field)) {
-      obj[field] = value;
+      obj[field] = value
     } else {
-      throw new Error("Don't use the $inc modifier on non-number fields");
+      throw new Error('Don\'t use the $inc modifier on non-number fields')
     }
   } else {
-    obj[field] += value;
+    obj[field] += value
   }
-};
+}
 
 /**
  * Updates the value of the field, only if specified field is greater than the current value of the field
  */
 lastStepModifierFunctions.$max = function (obj, field, value) {
   if (typeof obj[field] === 'undefined') {
-    obj[field] = value;
+    obj[field] = value
   } else if (value > obj[field]) {
-    obj[field] = value;
+    obj[field] = value
   }
-};
+}
 
 /**
  * Updates the value of the field, only if specified field is smaller than the current value of the field
  */
 lastStepModifierFunctions.$min = function (obj, field, value) {
-  if (typeof obj[field] === 'undefined') { 
-    obj[field] = value;
+  if (typeof obj[field] === 'undefined') {
+    obj[field] = value
   } else if (value < obj[field]) {
-    obj[field] = value;
+    obj[field] = value
   }
-};
+}
 
 // Given its name, create the complete modifier function
 function createModifierFunction (modifier) {
   return function (obj, field, value) {
-    var fieldParts = typeof field === 'string' ? field.split('.') : field;
+    const fieldParts = typeof field === 'string' ? field.split('.') : field
 
     if (fieldParts.length === 1) {
-      lastStepModifierFunctions[modifier](obj, field, value);
+      lastStepModifierFunctions[modifier](obj, field, value)
     } else {
       if (obj[fieldParts[0]] === undefined) {
-        if (modifier === '$unset') { return; }   // Bad looking specific fix, needs to be generalized modifiers that behave like $unset are implemented
-        obj[fieldParts[0]] = {};
+        if (modifier === '$unset') { return }   // Bad looking specific fix, needs to be generalized modifiers that behave like $unset are implemented
+        obj[fieldParts[0]] = {}
       }
-      modifierFunctions[modifier](obj[fieldParts[0]], fieldParts.slice(1), value);
+      modifierFunctions[modifier](obj[fieldParts[0]], fieldParts.slice(1), value)
     }
-  };
+  }
 }
 
 // Actually create all modifier functions
 Object.keys(lastStepModifierFunctions).forEach(function (modifier) {
-  modifierFunctions[modifier] = createModifierFunction(modifier);
-});
-
+  modifierFunctions[modifier] = createModifierFunction(modifier)
+})
 
 /**
  * Modify a DB object according to an update query
  */
 function modify (obj, updateQuery) {
-  var keys = Object.keys(updateQuery)
-    , firstChars = _.map(keys, function (item) { return item[0]; })
-    , dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; })
-    , newDoc, modifiers
-    ;
+  const keys = Object.keys(updateQuery)
+  const firstChars = _.map(keys, function (item) { return item[0] })
+  const dollarFirstChars = _.filter(firstChars, function (c) { return c === '$' })
+  let newDoc
+  let modifiers
 
-  if (keys.indexOf('_id') !== -1 && updateQuery._id !== obj._id) { throw new Error("You cannot change a document's _id"); }
+  if (keys.indexOf('_id') !== -1 && updateQuery._id !== obj._id) { throw new Error('You cannot change a document\'s _id') }
 
   if (dollarFirstChars.length !== 0 && dollarFirstChars.length !== firstChars.length) {
-    throw new Error("You cannot mix modifiers and normal fields");
+    throw new Error('You cannot mix modifiers and normal fields')
   }
 
   if (dollarFirstChars.length === 0) {
     // Simply replace the object with the update query contents
-    newDoc = deepCopy(updateQuery);
-    newDoc._id = obj._id;
+    newDoc = deepCopy(updateQuery)
+    newDoc._id = obj._id
   } else {
     // Apply modifiers
-    modifiers = _.uniq(keys);
-    newDoc = deepCopy(obj);
+    modifiers = _.uniq(keys)
+    newDoc = deepCopy(obj)
     modifiers.forEach(function (m) {
-      var keys;
+      let keys
 
-      if (!modifierFunctions[m]) { throw new Error("Unknown modifier " + m); }
+      if (!modifierFunctions[m]) { throw new Error('Unknown modifier ' + m) }
 
       // Can't rely on Object.keys throwing on non objects since ES6
       // Not 100% satisfying as non objects can be interpreted as objects but no false negatives so we can live with it
       if (typeof updateQuery[m] !== 'object') {
-        throw new Error("Modifier " + m + "'s argument must be an object");
+        throw new Error('Modifier ' + m + '\'s argument must be an object')
       }
 
-      keys = Object.keys(updateQuery[m]);
+      keys = Object.keys(updateQuery[m])
       keys.forEach(function (k) {
-        modifierFunctions[m](newDoc, k, updateQuery[m][k]);
-      });
-    });
+        modifierFunctions[m](newDoc, k, updateQuery[m][k])
+      })
+    })
   }
 
   // Check result is valid and return it
-  checkObject(newDoc);
+  checkObject(newDoc)
 
-  if (obj._id !== newDoc._id) { throw new Error("You can't change a document's _id"); }
-  return newDoc;
-};
-
+  if (obj._id !== newDoc._id) { throw new Error('You can\'t change a document\'s _id') }
+  return newDoc
+}
 
 // ==============================================================
 // Finding documents
@@ -491,33 +478,33 @@ function modify (obj, updateQuery) {
  * @param {String} field
  */
 function getDotValue (obj, field) {
-  var fieldParts = typeof field === 'string' ? field.split('.') : field
-    , i, objs;
+  const fieldParts = typeof field === 'string' ? field.split('.') : field
+  let i
+  let objs
 
-  if (!obj) { return undefined; }   // field cannot be empty so that means we should return undefined so that nothing can match
+  if (!obj) { return undefined }   // field cannot be empty so that means we should return undefined so that nothing can match
 
-  if (fieldParts.length === 0) { return obj; }
+  if (fieldParts.length === 0) { return obj }
 
-  if (fieldParts.length === 1) { return obj[fieldParts[0]]; }
+  if (fieldParts.length === 1) { return obj[fieldParts[0]] }
 
   if (util.isArray(obj[fieldParts[0]])) {
     // If the next field is an integer, return only this item of the array
-    i = parseInt(fieldParts[1], 10);
+    i = parseInt(fieldParts[1], 10)
     if (typeof i === 'number' && !isNaN(i)) {
       return getDotValue(obj[fieldParts[0]][i], fieldParts.slice(2))
     }
 
     // Return the array of values
-    objs = new Array();
+    objs = new Array()
     for (i = 0; i < obj[fieldParts[0]].length; i += 1) {
-       objs.push(getDotValue(obj[fieldParts[0]][i], fieldParts.slice(1)));
+      objs.push(getDotValue(obj[fieldParts[0]][i], fieldParts.slice(1)))
     }
-    return objs;
+    return objs
   } else {
-    return getDotValue(obj[fieldParts[0]], fieldParts.slice(1));
+    return getDotValue(obj[fieldParts[0]], fieldParts.slice(1))
   }
 }
-
 
 /**
  * Check whether 'things' are equal
@@ -526,51 +513,51 @@ function getDotValue (obj, field) {
  * Returns true if they are, false otherwise
  */
 function areThingsEqual (a, b) {
-  var aKeys , bKeys , i;
+  let aKeys
+  let bKeys
+  let i
 
   // Strings, booleans, numbers, null
   if (a === null || typeof a === 'string' || typeof a === 'boolean' || typeof a === 'number' ||
-      b === null || typeof b === 'string' || typeof b === 'boolean' || typeof b === 'number') { return a === b; }
+    b === null || typeof b === 'string' || typeof b === 'boolean' || typeof b === 'number') { return a === b }
 
   // Dates
-  if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime(); }
+  if (util.isDate(a) || util.isDate(b)) { return util.isDate(a) && util.isDate(b) && a.getTime() === b.getTime() }
 
   // Arrays (no match since arrays are used as a $in)
   // undefined (no match since they mean field doesn't exist and can't be serialized)
-  if ((!(util.isArray(a) && util.isArray(b)) && (util.isArray(a) || util.isArray(b))) || a === undefined || b === undefined) { return false; }
+  if ((!(util.isArray(a) && util.isArray(b)) && (util.isArray(a) || util.isArray(b))) || a === undefined || b === undefined) { return false }
 
   // General objects (check for deep equality)
   // a and b should be objects at this point
   try {
-    aKeys = Object.keys(a);
-    bKeys = Object.keys(b);
+    aKeys = Object.keys(a)
+    bKeys = Object.keys(b)
   } catch (e) {
-    return false;
+    return false
   }
 
-  if (aKeys.length !== bKeys.length) { return false; }
+  if (aKeys.length !== bKeys.length) { return false }
   for (i = 0; i < aKeys.length; i += 1) {
-    if (bKeys.indexOf(aKeys[i]) === -1) { return false; }
-    if (!areThingsEqual(a[aKeys[i]], b[aKeys[i]])) { return false; }
+    if (bKeys.indexOf(aKeys[i]) === -1) { return false }
+    if (!areThingsEqual(a[aKeys[i]], b[aKeys[i]])) { return false }
   }
-  return true;
+  return true
 }
-
 
 /**
  * Check that two values are comparable
  */
 function areComparable (a, b) {
   if (typeof a !== 'string' && typeof a !== 'number' && !util.isDate(a) &&
-      typeof b !== 'string' && typeof b !== 'number' && !util.isDate(b)) {
-    return false;
+    typeof b !== 'string' && typeof b !== 'number' && !util.isDate(b)) {
+    return false
   }
 
-  if (typeof a !== typeof b) { return false; }
+  if (typeof a !== typeof b) { return false }
 
-  return true;
+  return true
 }
-
 
 /**
  * Arithmetic and comparison operators
@@ -578,90 +565,89 @@ function areComparable (a, b) {
  * @param {Native value} b Value in the query
  */
 comparisonFunctions.$lt = function (a, b) {
-  return areComparable(a, b) && a < b;
-};
+  return areComparable(a, b) && a < b
+}
 
 comparisonFunctions.$lte = function (a, b) {
-  return areComparable(a, b) && a <= b;
-};
+  return areComparable(a, b) && a <= b
+}
 
 comparisonFunctions.$gt = function (a, b) {
-  return areComparable(a, b) && a > b;
-};
+  return areComparable(a, b) && a > b
+}
 
 comparisonFunctions.$gte = function (a, b) {
-  return areComparable(a, b) && a >= b;
-};
+  return areComparable(a, b) && a >= b
+}
 
 comparisonFunctions.$ne = function (a, b) {
-  if (a === undefined) { return true; }
-  return !areThingsEqual(a, b);
-};
+  if (a === undefined) { return true }
+  return !areThingsEqual(a, b)
+}
 
 comparisonFunctions.$in = function (a, b) {
-  var i;
+  let i
 
-  if (!util.isArray(b)) { throw new Error("$in operator called with a non-array"); }
+  if (!util.isArray(b)) { throw new Error('$in operator called with a non-array') }
 
   for (i = 0; i < b.length; i += 1) {
-    if (areThingsEqual(a, b[i])) { return true; }
+    if (areThingsEqual(a, b[i])) { return true }
   }
 
-  return false;
-};
+  return false
+}
 
 comparisonFunctions.$nin = function (a, b) {
-  if (!util.isArray(b)) { throw new Error("$nin operator called with a non-array"); }
+  if (!util.isArray(b)) { throw new Error('$nin operator called with a non-array') }
 
-  return !comparisonFunctions.$in(a, b);
-};
+  return !comparisonFunctions.$in(a, b)
+}
 
 comparisonFunctions.$regex = function (a, b) {
-  if (!util.isRegExp(b)) { throw new Error("$regex operator called with non regular expression"); }
+  if (!util.isRegExp(b)) { throw new Error('$regex operator called with non regular expression') }
 
   if (typeof a !== 'string') {
     return false
   } else {
-    return b.test(a);
+    return b.test(a)
   }
-};
+}
 
 comparisonFunctions.$exists = function (value, exists) {
   if (exists || exists === '') {   // This will be true for all values of exists except false, null, undefined and 0
-    exists = true;                 // That's strange behaviour (we should only use true/false) but that's the way Mongo does it...
+    exists = true                 // That's strange behaviour (we should only use true/false) but that's the way Mongo does it...
   } else {
-    exists = false;
+    exists = false
   }
 
   if (value === undefined) {
     return !exists
   } else {
-    return exists;
+    return exists
   }
-};
+}
 
 // Specific to arrays
 comparisonFunctions.$size = function (obj, value) {
-    if (!util.isArray(obj)) { return false; }
-    if (value % 1 !== 0) { throw new Error("$size operator called without an integer"); }
+  if (!util.isArray(obj)) { return false }
+  if (value % 1 !== 0) { throw new Error('$size operator called without an integer') }
 
-    return (obj.length == value);
-};
+  return (obj.length == value)
+}
 comparisonFunctions.$elemMatch = function (obj, value) {
-  if (!util.isArray(obj)) { return false; }
-  var i = obj.length;
-  var result = false;   // Initialize result
+  if (!util.isArray(obj)) { return false }
+  let i = obj.length
+  let result = false    // Initialize result
   while (i--) {
     if (match(obj[i], value)) {   // If match for array element, return true
-      result = true;
-      break;
+      result = true
+      break
     }
   }
-  return result;
-};
-arrayComparisonFunctions.$size = true;
-arrayComparisonFunctions.$elemMatch = true;
-
+  return result
+}
+arrayComparisonFunctions.$size = true
+arrayComparisonFunctions.$elemMatch = true
 
 /**
  * Match any of the subqueries
@@ -669,17 +655,16 @@ arrayComparisonFunctions.$elemMatch = true;
  * @param {Array of Queries} query
  */
 logicalOperators.$or = function (obj, query) {
-  var i;
+  let i
 
-  if (!util.isArray(query)) { throw new Error("$or operator used without an array"); }
+  if (!util.isArray(query)) { throw new Error('$or operator used without an array') }
 
   for (i = 0; i < query.length; i += 1) {
-    if (match(obj, query[i])) { return true; }
+    if (match(obj, query[i])) { return true }
   }
 
-  return false;
-};
-
+  return false
+}
 
 /**
  * Match all of the subqueries
@@ -687,17 +672,16 @@ logicalOperators.$or = function (obj, query) {
  * @param {Array of Queries} query
  */
 logicalOperators.$and = function (obj, query) {
-  var i;
+  let i
 
-  if (!util.isArray(query)) { throw new Error("$and operator used without an array"); }
+  if (!util.isArray(query)) { throw new Error('$and operator used without an array') }
 
   for (i = 0; i < query.length; i += 1) {
-    if (!match(obj, query[i])) { return false; }
+    if (!match(obj, query[i])) { return false }
   }
 
-  return true;
-};
-
+  return true
+}
 
 /**
  * Inverted match of the query
@@ -705,9 +689,8 @@ logicalOperators.$and = function (obj, query) {
  * @param {Query} query
  */
 logicalOperators.$not = function (obj, query) {
-  return !match(obj, query);
-};
-
+  return !match(obj, query)
+}
 
 /**
  * Use a function to match
@@ -715,16 +698,15 @@ logicalOperators.$not = function (obj, query) {
  * @param {Query} query
  */
 logicalOperators.$where = function (obj, fn) {
-  var result;
+  let result
 
-  if (!_.isFunction(fn)) { throw new Error("$where operator used without a function"); }
+  if (!_.isFunction(fn)) { throw new Error('$where operator used without a function') }
 
-  result = fn.call(obj);
-  if (!_.isBoolean(result)) { throw new Error("$where function must return boolean"); }
+  result = fn.call(obj)
+  if (!_.isBoolean(result)) { throw new Error('$where function must return boolean') }
 
-  return result;
-};
-
+  return result
+}
 
 /**
  * Tell if a given document matches a query
@@ -732,104 +714,108 @@ logicalOperators.$where = function (obj, fn) {
  * @param {Object} query
  */
 function match (obj, query) {
-  var queryKeys, queryKey, queryValue, i;
+  let queryKeys
+  let queryKey
+  let queryValue
+  let i
 
   // Primitive query against a primitive type
   // This is a bit of a hack since we construct an object with an arbitrary key only to dereference it later
   // But I don't have time for a cleaner implementation now
   if (isPrimitiveType(obj) || isPrimitiveType(query)) {
-    return matchQueryPart({ needAKey: obj }, 'needAKey', query);
+    return matchQueryPart({ needAKey: obj }, 'needAKey', query)
   }
 
   // Normal query
-  queryKeys = Object.keys(query);
+  queryKeys = Object.keys(query)
   for (i = 0; i < queryKeys.length; i += 1) {
-    queryKey = queryKeys[i];
-    queryValue = query[queryKey];
+    queryKey = queryKeys[i]
+    queryValue = query[queryKey]
 
     if (queryKey[0] === '$') {
-      if (!logicalOperators[queryKey]) { throw new Error("Unknown logical operator " + queryKey); }
-      if (!logicalOperators[queryKey](obj, queryValue)) { return false; }
+      if (!logicalOperators[queryKey]) { throw new Error('Unknown logical operator ' + queryKey) }
+      if (!logicalOperators[queryKey](obj, queryValue)) { return false }
     } else {
-      if (!matchQueryPart(obj, queryKey, queryValue)) { return false; }
+      if (!matchQueryPart(obj, queryKey, queryValue)) { return false }
     }
   }
 
-  return true;
-};
-
+  return true
+}
 
 /**
  * Match an object against a specific { key: value } part of a query
  * if the treatObjAsValue flag is set, don't try to match every part separately, but the array as a whole
  */
 function matchQueryPart (obj, queryKey, queryValue, treatObjAsValue) {
-  var objValue = getDotValue(obj, queryKey)
-    , i, keys, firstChars, dollarFirstChars;
+  const objValue = getDotValue(obj, queryKey)
+  let i
+  let keys
+  let firstChars
+  let dollarFirstChars
 
   // Check if the value is an array if we don't force a treatment as value
   if (util.isArray(objValue) && !treatObjAsValue) {
     // If the queryValue is an array, try to perform an exact match
     if (util.isArray(queryValue)) {
-      return matchQueryPart(obj, queryKey, queryValue, true);
+      return matchQueryPart(obj, queryKey, queryValue, true)
     }
 
     // Check if we are using an array-specific comparison function
     if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue)) {
-      keys = Object.keys(queryValue);
+      keys = Object.keys(queryValue)
       for (i = 0; i < keys.length; i += 1) {
-        if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true); }
+        if (arrayComparisonFunctions[keys[i]]) { return matchQueryPart(obj, queryKey, queryValue, true) }
       }
     }
 
     // If not, treat it as an array of { obj, query } where there needs to be at least one match
     for (i = 0; i < objValue.length; i += 1) {
-      if (matchQueryPart({ k: objValue[i] }, 'k', queryValue)) { return true; }   // k here could be any string
+      if (matchQueryPart({ k: objValue[i] }, 'k', queryValue)) { return true }   // k here could be any string
     }
-    return false;
+    return false
   }
 
   // queryValue is an actual object. Determine whether it contains comparison operators
   // or only normal fields. Mixed objects are not allowed
   if (queryValue !== null && typeof queryValue === 'object' && !util.isRegExp(queryValue) && !util.isArray(queryValue)) {
-    keys = Object.keys(queryValue);
-    firstChars = _.map(keys, function (item) { return item[0]; });
-    dollarFirstChars = _.filter(firstChars, function (c) { return c === '$'; });
+    keys = Object.keys(queryValue)
+    firstChars = _.map(keys, function (item) { return item[0] })
+    dollarFirstChars = _.filter(firstChars, function (c) { return c === '$' })
 
     if (dollarFirstChars.length !== 0 && dollarFirstChars.length !== firstChars.length) {
-      throw new Error("You cannot mix operators and normal fields");
+      throw new Error('You cannot mix operators and normal fields')
     }
 
     // queryValue is an object of this form: { $comparisonOperator1: value1, ... }
     if (dollarFirstChars.length > 0) {
       for (i = 0; i < keys.length; i += 1) {
-        if (!comparisonFunctions[keys[i]]) { throw new Error("Unknown comparison function " + keys[i]); }
+        if (!comparisonFunctions[keys[i]]) { throw new Error('Unknown comparison function ' + keys[i]) }
 
-        if (!comparisonFunctions[keys[i]](objValue, queryValue[keys[i]])) { return false; }
+        if (!comparisonFunctions[keys[i]](objValue, queryValue[keys[i]])) { return false }
       }
-      return true;
+      return true
     }
   }
 
   // Using regular expressions with basic querying
-  if (util.isRegExp(queryValue)) { return comparisonFunctions.$regex(objValue, queryValue); }
+  if (util.isRegExp(queryValue)) { return comparisonFunctions.$regex(objValue, queryValue) }
 
   // queryValue is either a native value or a normal object
   // Basic matching is possible
-  if (!areThingsEqual(objValue, queryValue)) { return false; }
+  if (!areThingsEqual(objValue, queryValue)) { return false }
 
-  return true;
+  return true
 }
 
-
 // Interface
-module.exports.serialize = serialize;
-module.exports.deserialize = deserialize;
-module.exports.deepCopy = deepCopy;
-module.exports.checkObject = checkObject;
-module.exports.isPrimitiveType = isPrimitiveType;
-module.exports.modify = modify;
-module.exports.getDotValue = getDotValue;
-module.exports.match = match;
-module.exports.areThingsEqual = areThingsEqual;
-module.exports.compareThings = compareThings;
+module.exports.serialize = serialize
+module.exports.deserialize = deserialize
+module.exports.deepCopy = deepCopy
+module.exports.checkObject = checkObject
+module.exports.isPrimitiveType = isPrimitiveType
+module.exports.modify = modify
+module.exports.getDotValue = getDotValue
+module.exports.match = match
+module.exports.areThingsEqual = areThingsEqual
+module.exports.compareThings = compareThings

--- a/src/nedb/persistence.js
+++ b/src/nedb/persistence.js
@@ -1,0 +1,314 @@
+/**
+ * Handle every persistence-related task
+ * The interface Datastore expects to be implemented is
+ * * Persistence.loadDatabase(callback) and callback has signature err
+ * * Persistence.persistNewState(newDocs, callback) where newDocs is an array of documents and callback has signature err
+ */
+
+var storage = require('./storage')
+  , path = require('path')
+  , model = require('./model')
+  , async = require('async')
+  , customUtils = require('./customUtils')
+  , Index = require('./indexes')
+  ;
+
+
+/**
+ * Create a new Persistence object for database options.db
+ * @param {Datastore} options.db
+ * @param {Boolean} options.nodeWebkitAppName Optional, specify the name of your NW app if you want options.filename to be relative to the directory where
+ *                                            Node Webkit stores application data such as cookies and local storage (the best place to store data in my opinion)
+ */
+function Persistence (options) {
+  var i, j, randomString;
+
+  this.db = options.db;
+  this.inMemoryOnly = this.db.inMemoryOnly;
+  this.filename = this.db.filename;
+  this.corruptAlertThreshold = options.corruptAlertThreshold !== undefined ? options.corruptAlertThreshold : 0.1;
+
+  if (!this.inMemoryOnly && this.filename && this.filename.charAt(this.filename.length - 1) === '~') {
+    throw new Error("The datafile name can't end with a ~, which is reserved for crash safe backup files");
+  }
+
+  // After serialization and before deserialization hooks with some basic sanity checks
+  if (options.afterSerialization && !options.beforeDeserialization) {
+    throw new Error("Serialization hook defined but deserialization hook undefined, cautiously refusing to start NeDB to prevent dataloss");
+  }
+  if (!options.afterSerialization && options.beforeDeserialization) {
+    throw new Error("Serialization hook undefined but deserialization hook defined, cautiously refusing to start NeDB to prevent dataloss");
+  }
+  this.afterSerialization = options.afterSerialization || function (s) { return s; };
+  this.beforeDeserialization = options.beforeDeserialization || function (s) { return s; };
+  for (i = 1; i < 30; i += 1) {
+    for (j = 0; j < 10; j += 1) {
+      randomString = customUtils.uid(i);
+      if (this.beforeDeserialization(this.afterSerialization(randomString)) !== randomString) {
+        throw new Error("beforeDeserialization is not the reverse of afterSerialization, cautiously refusing to start NeDB to prevent dataloss");
+      }
+    }
+  }
+
+  // For NW apps, store data in the same directory where NW stores application data
+  if (this.filename && options.nodeWebkitAppName) {
+    console.log("==================================================================");
+    console.log("WARNING: The nodeWebkitAppName option is deprecated");
+    console.log("To get the path to the directory where Node Webkit stores the data");
+    console.log("for your app, use the internal nw.gui module like this");
+    console.log("require('nw.gui').App.dataPath");
+    console.log("See https://github.com/rogerwang/node-webkit/issues/500");
+    console.log("==================================================================");
+    this.filename = Persistence.getNWAppFilename(options.nodeWebkitAppName, this.filename);
+  }
+};
+
+
+/**
+ * Check if a directory exists and create it on the fly if it is not the case
+ * cb is optional, signature: err
+ */
+Persistence.ensureDirectoryExists = function (dir, cb) {
+  var callback = cb || function () {}
+    ;
+
+  storage.mkdirp(dir, function (err) { return callback(err); });
+};
+
+
+
+
+/**
+ * Return the path the datafile if the given filename is relative to the directory where Node Webkit stores
+ * data for this application. Probably the best place to store data
+ */
+Persistence.getNWAppFilename = function (appName, relativeFilename) {
+  var home;
+
+  switch (process.platform) {
+    case 'win32':
+    case 'win64':
+      home = process.env.LOCALAPPDATA || process.env.APPDATA;
+      if (!home) { throw new Error("Couldn't find the base application data folder"); }
+      home = path.join(home, appName);
+      break;
+    case 'darwin':
+      home = process.env.HOME;
+      if (!home) { throw new Error("Couldn't find the base application data directory"); }
+      home = path.join(home, 'Library', 'Application Support', appName);
+      break;
+    case 'linux':
+      home = process.env.HOME;
+      if (!home) { throw new Error("Couldn't find the base application data directory"); }
+      home = path.join(home, '.config', appName);
+      break;
+    default:
+      throw new Error("Can't use the Node Webkit relative path for platform " + process.platform);
+      break;
+  }
+
+  return path.join(home, 'nedb-data', relativeFilename);
+}
+
+
+/**
+ * Persist cached database
+ * This serves as a compaction function since the cache always contains only the number of documents in the collection
+ * while the data file is append-only so it may grow larger
+ * @param {Function} cb Optional callback, signature: err
+ */
+Persistence.prototype.persistCachedDatabase = function (cb) {
+  var callback = cb || function () {}
+    , toPersist = ''
+    , self = this
+    ;
+
+  if (this.inMemoryOnly) { return callback(null); }
+
+  this.db.getAllData().forEach(function (doc) {
+    toPersist += self.afterSerialization(model.serialize(doc)) + '\n';
+  });
+  Object.keys(this.db.indexes).forEach(function (fieldName) {
+    if (fieldName != "_id") {   // The special _id index is managed by datastore.js, the others need to be persisted
+      toPersist += self.afterSerialization(model.serialize({ $$indexCreated: { fieldName: fieldName, unique: self.db.indexes[fieldName].unique, sparse: self.db.indexes[fieldName].sparse }})) + '\n';
+    }
+  });
+
+  storage.crashSafeWriteFile(this.filename, toPersist, function (err) {
+    if (err) { return callback(err); }
+    self.db.emit('compaction.done');
+    return callback(null);
+  });
+};
+
+
+/**
+ * Queue a rewrite of the datafile
+ */
+Persistence.prototype.compactDatafile = function () {
+  this.db.executor.push({ this: this, fn: this.persistCachedDatabase, arguments: [] });
+};
+
+
+/**
+ * Set automatic compaction every interval ms
+ * @param {Number} interval in milliseconds, with an enforced minimum of 5 seconds
+ */
+Persistence.prototype.setAutocompactionInterval = function (interval) {
+  var self = this
+    , minInterval = 5000
+    , realInterval = Math.max(interval || 0, minInterval)
+    ;
+
+  this.stopAutocompaction();
+
+  this.autocompactionIntervalId = setInterval(function () {
+    self.compactDatafile();
+  }, realInterval);
+};
+
+
+/**
+ * Stop autocompaction (do nothing if autocompaction was not running)
+ */
+Persistence.prototype.stopAutocompaction = function () {
+  if (this.autocompactionIntervalId) { clearInterval(this.autocompactionIntervalId); }
+};
+
+
+/**
+ * Persist new state for the given newDocs (can be insertion, update or removal)
+ * Use an append-only format
+ * @param {Array} newDocs Can be empty if no doc was updated/removed
+ * @param {Function} cb Optional, signature: err
+ */
+Persistence.prototype.persistNewState = function (newDocs, cb) {
+  var self = this
+    , toPersist = ''
+    , callback = cb || function () {}
+    ;
+
+  // In-memory only datastore
+  if (self.inMemoryOnly) { return callback(null); }
+
+  newDocs.forEach(function (doc) {
+    toPersist += self.afterSerialization(model.serialize(doc)) + '\n';
+  });
+
+  if (toPersist.length === 0) { return callback(null); }
+
+  storage.appendFile(self.filename, toPersist, 'utf8', function (err) {
+    return callback(err);
+  });
+};
+
+
+/**
+ * From a database's raw data, return the corresponding
+ * machine understandable collection
+ */
+Persistence.prototype.treatRawData = function (rawData) {
+  var data = rawData.split('\n')
+    , dataById = {}
+    , tdata = []
+    , i
+    , indexes = {}
+    , corruptItems = -1   // Last line of every data file is usually blank so not really corrupt
+    ;
+
+  for (i = 0; i < data.length; i += 1) {
+    var doc;
+
+    try {
+      doc = model.deserialize(this.beforeDeserialization(data[i]));
+      if (doc._id) {
+        if (doc.$$deleted === true) {
+          delete dataById[doc._id];
+        } else {
+          dataById[doc._id] = doc;
+        }
+      } else if (doc.$$indexCreated && doc.$$indexCreated.fieldName != undefined) {
+        indexes[doc.$$indexCreated.fieldName] = doc.$$indexCreated;
+      } else if (typeof doc.$$indexRemoved === "string") {
+        delete indexes[doc.$$indexRemoved];
+      }
+    } catch (e) {
+      corruptItems += 1;
+    }
+  }
+
+  // A bit lenient on corruption
+  if (data.length > 0 && corruptItems / data.length > this.corruptAlertThreshold) {
+    throw new Error("More than " + Math.floor(100 * this.corruptAlertThreshold) + "% of the data file is corrupt, the wrong beforeDeserialization hook may be used. Cautiously refusing to start NeDB to prevent dataloss");
+  }
+
+  Object.keys(dataById).forEach(function (k) {
+    tdata.push(dataById[k]);
+  });
+
+  return { data: tdata, indexes: indexes };
+};
+
+
+/**
+ * Load the database
+ * 1) Create all indexes
+ * 2) Insert all data
+ * 3) Compact the database
+ * This means pulling data out of the data file or creating it if it doesn't exist
+ * Also, all data is persisted right away, which has the effect of compacting the database file
+ * This operation is very quick at startup for a big collection (60ms for ~10k docs)
+ * @param {Function} cb Optional callback, signature: err
+ */
+Persistence.prototype.loadDatabase = function (cb) {
+  var callback = cb || function () {}
+    , self = this
+    ;
+
+  self.db.resetIndexes();
+
+  // In-memory only datastore
+  if (self.inMemoryOnly) { return callback(null); }
+
+  async.waterfall([
+    function (cb) {
+      Persistence.ensureDirectoryExists(path.dirname(self.filename), function (err) {
+        storage.ensureDatafileIntegrity(self.filename, function (err) {
+          storage.readFile(self.filename, 'utf8', function (err, rawData) {
+            if (err) { return cb(err); }
+
+            try {
+              var treatedData = self.treatRawData(rawData);
+            } catch (e) {
+              return cb(e);
+            }
+
+            // Recreate all indexes in the datafile
+            Object.keys(treatedData.indexes).forEach(function (key) {
+              self.db.indexes[key] = new Index(treatedData.indexes[key]);
+            });
+
+            // Fill cached database (i.e. all indexes) with data
+            try {
+              self.db.resetIndexes(treatedData.data);
+            } catch (e) {
+              self.db.resetIndexes();   // Rollback any index which didn't fail
+              return cb(e);
+            }
+
+            self.db.persistence.persistCachedDatabase(cb);
+          });
+        });
+      });
+    }
+  ], function (err) {
+       if (err) { return callback(err); }
+
+       self.db.executor.processBuffer();
+       return callback(null);
+     });
+};
+
+
+// Interface
+module.exports = Persistence;

--- a/src/nedb/persistence.js
+++ b/src/nedb/persistence.js
@@ -4,15 +4,12 @@
  * * Persistence.loadDatabase(callback) and callback has signature err
  * * Persistence.persistNewState(newDocs, callback) where newDocs is an array of documents and callback has signature err
  */
-
-var storage = require('./storage')
-  , path = require('path')
-  , model = require('./model')
-  , async = require('async')
-  , customUtils = require('./customUtils')
-  , Index = require('./indexes')
-  ;
-
+const storage = require('./storage')
+const path = require('path')
+const model = require('./model')
+const async = require('async')
+const customUtils = require('./customUtils')
+const Index = require('./indexes')
 
 /**
  * Create a new Persistence object for database options.db
@@ -21,95 +18,91 @@ var storage = require('./storage')
  *                                            Node Webkit stores application data such as cookies and local storage (the best place to store data in my opinion)
  */
 function Persistence (options) {
-  var i, j, randomString;
+  let i
+  let j
+  let randomString
 
-  this.db = options.db;
-  this.inMemoryOnly = this.db.inMemoryOnly;
-  this.filename = this.db.filename;
-  this.corruptAlertThreshold = options.corruptAlertThreshold !== undefined ? options.corruptAlertThreshold : 0.1;
+  this.db = options.db
+  this.inMemoryOnly = this.db.inMemoryOnly
+  this.filename = this.db.filename
+  this.corruptAlertThreshold = options.corruptAlertThreshold !== undefined ? options.corruptAlertThreshold : 0.1
 
   if (!this.inMemoryOnly && this.filename && this.filename.charAt(this.filename.length - 1) === '~') {
-    throw new Error("The datafile name can't end with a ~, which is reserved for crash safe backup files");
+    throw new Error('The datafile name can\'t end with a ~, which is reserved for crash safe backup files')
   }
 
   // After serialization and before deserialization hooks with some basic sanity checks
   if (options.afterSerialization && !options.beforeDeserialization) {
-    throw new Error("Serialization hook defined but deserialization hook undefined, cautiously refusing to start NeDB to prevent dataloss");
+    throw new Error('Serialization hook defined but deserialization hook undefined, cautiously refusing to start NeDB to prevent dataloss')
   }
   if (!options.afterSerialization && options.beforeDeserialization) {
-    throw new Error("Serialization hook undefined but deserialization hook defined, cautiously refusing to start NeDB to prevent dataloss");
+    throw new Error('Serialization hook undefined but deserialization hook defined, cautiously refusing to start NeDB to prevent dataloss')
   }
-  this.afterSerialization = options.afterSerialization || function (s) { return s; };
-  this.beforeDeserialization = options.beforeDeserialization || function (s) { return s; };
+  this.afterSerialization = options.afterSerialization || function (s) { return s }
+  this.beforeDeserialization = options.beforeDeserialization || function (s) { return s }
   for (i = 1; i < 30; i += 1) {
     for (j = 0; j < 10; j += 1) {
-      randomString = customUtils.uid(i);
+      randomString = customUtils.uid(i)
       if (this.beforeDeserialization(this.afterSerialization(randomString)) !== randomString) {
-        throw new Error("beforeDeserialization is not the reverse of afterSerialization, cautiously refusing to start NeDB to prevent dataloss");
+        throw new Error('beforeDeserialization is not the reverse of afterSerialization, cautiously refusing to start NeDB to prevent dataloss')
       }
     }
   }
 
   // For NW apps, store data in the same directory where NW stores application data
   if (this.filename && options.nodeWebkitAppName) {
-    console.log("==================================================================");
-    console.log("WARNING: The nodeWebkitAppName option is deprecated");
-    console.log("To get the path to the directory where Node Webkit stores the data");
-    console.log("for your app, use the internal nw.gui module like this");
-    console.log("require('nw.gui').App.dataPath");
-    console.log("See https://github.com/rogerwang/node-webkit/issues/500");
-    console.log("==================================================================");
-    this.filename = Persistence.getNWAppFilename(options.nodeWebkitAppName, this.filename);
+    console.log('==================================================================')
+    console.log('WARNING: The nodeWebkitAppName option is deprecated')
+    console.log('To get the path to the directory where Node Webkit stores the data')
+    console.log('for your app, use the internal nw.gui module like this')
+    console.log('require(\'nw.gui\').App.dataPath')
+    console.log('See https://github.com/rogerwang/node-webkit/issues/500')
+    console.log('==================================================================')
+    this.filename = Persistence.getNWAppFilename(options.nodeWebkitAppName, this.filename)
   }
-};
-
+}
 
 /**
  * Check if a directory exists and create it on the fly if it is not the case
  * cb is optional, signature: err
  */
 Persistence.ensureDirectoryExists = function (dir, cb) {
-  var callback = cb || function () {}
-    ;
+  const callback = cb || function () {}
 
-  storage.mkdirp(dir, function (err) { return callback(err); });
-};
-
-
-
+  storage.mkdirp(dir, function (err) { return callback(err) })
+}
 
 /**
  * Return the path the datafile if the given filename is relative to the directory where Node Webkit stores
  * data for this application. Probably the best place to store data
  */
 Persistence.getNWAppFilename = function (appName, relativeFilename) {
-  var home;
+  let home
 
   switch (process.platform) {
     case 'win32':
     case 'win64':
-      home = process.env.LOCALAPPDATA || process.env.APPDATA;
-      if (!home) { throw new Error("Couldn't find the base application data folder"); }
-      home = path.join(home, appName);
-      break;
+      home = process.env.LOCALAPPDATA || process.env.APPDATA
+      if (!home) { throw new Error('Couldn\'t find the base application data folder') }
+      home = path.join(home, appName)
+      break
     case 'darwin':
-      home = process.env.HOME;
-      if (!home) { throw new Error("Couldn't find the base application data directory"); }
-      home = path.join(home, 'Library', 'Application Support', appName);
-      break;
+      home = process.env.HOME
+      if (!home) { throw new Error('Couldn\'t find the base application data directory') }
+      home = path.join(home, 'Library', 'Application Support', appName)
+      break
     case 'linux':
-      home = process.env.HOME;
-      if (!home) { throw new Error("Couldn't find the base application data directory"); }
-      home = path.join(home, '.config', appName);
-      break;
+      home = process.env.HOME
+      if (!home) { throw new Error('Couldn\'t find the base application data directory') }
+      home = path.join(home, '.config', appName)
+      break
     default:
-      throw new Error("Can't use the Node Webkit relative path for platform " + process.platform);
-      break;
+      throw new Error('Can\'t use the Node Webkit relative path for platform ' + process.platform)
+      break
   }
 
-  return path.join(home, 'nedb-data', relativeFilename);
+  return path.join(home, 'nedb-data', relativeFilename)
 }
-
 
 /**
  * Persist cached database
@@ -118,63 +111,63 @@ Persistence.getNWAppFilename = function (appName, relativeFilename) {
  * @param {Function} cb Optional callback, signature: err
  */
 Persistence.prototype.persistCachedDatabase = function (cb) {
-  var callback = cb || function () {}
-    , toPersist = ''
-    , self = this
-    ;
+  const callback = cb || function () {}
+  let toPersist = ''
+  const self = this
 
-  if (this.inMemoryOnly) { return callback(null); }
+  if (this.inMemoryOnly) { return callback(null) }
 
   this.db.getAllData().forEach(function (doc) {
-    toPersist += self.afterSerialization(model.serialize(doc)) + '\n';
-  });
+    toPersist += self.afterSerialization(model.serialize(doc)) + '\n'
+  })
   Object.keys(this.db.indexes).forEach(function (fieldName) {
-    if (fieldName != "_id") {   // The special _id index is managed by datastore.js, the others need to be persisted
-      toPersist += self.afterSerialization(model.serialize({ $$indexCreated: { fieldName: fieldName, unique: self.db.indexes[fieldName].unique, sparse: self.db.indexes[fieldName].sparse }})) + '\n';
+    if (fieldName != '_id') {   // The special _id index is managed by datastore.js, the others need to be persisted
+      toPersist += self.afterSerialization(model.serialize({
+        $$indexCreated: {
+          fieldName: fieldName,
+          unique: self.db.indexes[fieldName].unique,
+          sparse: self.db.indexes[fieldName].sparse
+        }
+      })) + '\n'
     }
-  });
+  })
 
   storage.crashSafeWriteFile(this.filename, toPersist, function (err) {
-    if (err) { return callback(err); }
-    self.db.emit('compaction.done');
-    return callback(null);
-  });
-};
-
+    if (err) { return callback(err) }
+    self.db.emit('compaction.done')
+    return callback(null)
+  })
+}
 
 /**
  * Queue a rewrite of the datafile
  */
 Persistence.prototype.compactDatafile = function () {
-  this.db.executor.push({ this: this, fn: this.persistCachedDatabase, arguments: [] });
-};
-
+  this.db.executor.push({ this: this, fn: this.persistCachedDatabase, arguments: [] })
+}
 
 /**
  * Set automatic compaction every interval ms
  * @param {Number} interval in milliseconds, with an enforced minimum of 5 seconds
  */
 Persistence.prototype.setAutocompactionInterval = function (interval) {
-  var self = this
-    , minInterval = 5000
-    , realInterval = Math.max(interval || 0, minInterval)
-    ;
+  const self = this
+  const minInterval = 5000
+  const realInterval = Math.max(interval || 0, minInterval)
 
-  this.stopAutocompaction();
+  this.stopAutocompaction()
 
   this.autocompactionIntervalId = setInterval(function () {
-    self.compactDatafile();
-  }, realInterval);
-};
-
+    self.compactDatafile()
+  }, realInterval)
+}
 
 /**
  * Stop autocompaction (do nothing if autocompaction was not running)
  */
 Persistence.prototype.stopAutocompaction = function () {
-  if (this.autocompactionIntervalId) { clearInterval(this.autocompactionIntervalId); }
-};
-
+  if (this.autocompactionIntervalId) { clearInterval(this.autocompactionIntervalId) }
+}
 
 /**
  * Persist new state for the given newDocs (can be insertion, update or removal)
@@ -183,72 +176,68 @@ Persistence.prototype.stopAutocompaction = function () {
  * @param {Function} cb Optional, signature: err
  */
 Persistence.prototype.persistNewState = function (newDocs, cb) {
-  var self = this
-    , toPersist = ''
-    , callback = cb || function () {}
-    ;
+  const self = this
+  let toPersist = ''
+  const callback = cb || function () {}
 
   // In-memory only datastore
-  if (self.inMemoryOnly) { return callback(null); }
+  if (self.inMemoryOnly) { return callback(null) }
 
   newDocs.forEach(function (doc) {
-    toPersist += self.afterSerialization(model.serialize(doc)) + '\n';
-  });
+    toPersist += self.afterSerialization(model.serialize(doc)) + '\n'
+  })
 
-  if (toPersist.length === 0) { return callback(null); }
+  if (toPersist.length === 0) { return callback(null) }
 
   storage.appendFile(self.filename, toPersist, 'utf8', function (err) {
-    return callback(err);
-  });
-};
-
+    return callback(err)
+  })
+}
 
 /**
  * From a database's raw data, return the corresponding
  * machine understandable collection
  */
 Persistence.prototype.treatRawData = function (rawData) {
-  var data = rawData.split('\n')
-    , dataById = {}
-    , tdata = []
-    , i
-    , indexes = {}
-    , corruptItems = -1   // Last line of every data file is usually blank so not really corrupt
-    ;
+  const data = rawData.split('\n')
+  const dataById = {}
+  const tdata = []
+  let i
+  const indexes = {}
+  let corruptItems = -1
 
   for (i = 0; i < data.length; i += 1) {
-    var doc;
+    let doc
 
     try {
-      doc = model.deserialize(this.beforeDeserialization(data[i]));
+      doc = model.deserialize(this.beforeDeserialization(data[i]))
       if (doc._id) {
         if (doc.$$deleted === true) {
-          delete dataById[doc._id];
+          delete dataById[doc._id]
         } else {
-          dataById[doc._id] = doc;
+          dataById[doc._id] = doc
         }
       } else if (doc.$$indexCreated && doc.$$indexCreated.fieldName != undefined) {
-        indexes[doc.$$indexCreated.fieldName] = doc.$$indexCreated;
-      } else if (typeof doc.$$indexRemoved === "string") {
-        delete indexes[doc.$$indexRemoved];
+        indexes[doc.$$indexCreated.fieldName] = doc.$$indexCreated
+      } else if (typeof doc.$$indexRemoved === 'string') {
+        delete indexes[doc.$$indexRemoved]
       }
     } catch (e) {
-      corruptItems += 1;
+      corruptItems += 1
     }
   }
 
   // A bit lenient on corruption
   if (data.length > 0 && corruptItems / data.length > this.corruptAlertThreshold) {
-    throw new Error("More than " + Math.floor(100 * this.corruptAlertThreshold) + "% of the data file is corrupt, the wrong beforeDeserialization hook may be used. Cautiously refusing to start NeDB to prevent dataloss");
+    throw new Error('More than ' + Math.floor(100 * this.corruptAlertThreshold) + '% of the data file is corrupt, the wrong beforeDeserialization hook may be used. Cautiously refusing to start NeDB to prevent dataloss')
   }
 
   Object.keys(dataById).forEach(function (k) {
-    tdata.push(dataById[k]);
-  });
+    tdata.push(dataById[k])
+  })
 
-  return { data: tdata, indexes: indexes };
-};
-
+  return { data: tdata, indexes: indexes }
+}
 
 /**
  * Load the database
@@ -261,54 +250,52 @@ Persistence.prototype.treatRawData = function (rawData) {
  * @param {Function} cb Optional callback, signature: err
  */
 Persistence.prototype.loadDatabase = function (cb) {
-  var callback = cb || function () {}
-    , self = this
-    ;
+  const callback = cb || function () {}
+  const self = this
 
-  self.db.resetIndexes();
+  self.db.resetIndexes()
 
   // In-memory only datastore
-  if (self.inMemoryOnly) { return callback(null); }
+  if (self.inMemoryOnly) { return callback(null) }
 
   async.waterfall([
     function (cb) {
       Persistence.ensureDirectoryExists(path.dirname(self.filename), function (err) {
         storage.ensureDatafileIntegrity(self.filename, function (err) {
           storage.readFile(self.filename, 'utf8', function (err, rawData) {
-            if (err) { return cb(err); }
-
+            if (err) { return cb(err) }
+            let treatedData
             try {
-              var treatedData = self.treatRawData(rawData);
+              treatedData = self.treatRawData(rawData)
             } catch (e) {
-              return cb(e);
+              return cb(e)
             }
 
             // Recreate all indexes in the datafile
             Object.keys(treatedData.indexes).forEach(function (key) {
-              self.db.indexes[key] = new Index(treatedData.indexes[key]);
-            });
+              self.db.indexes[key] = new Index(treatedData.indexes[key])
+            })
 
             // Fill cached database (i.e. all indexes) with data
             try {
-              self.db.resetIndexes(treatedData.data);
+              self.db.resetIndexes(treatedData.data)
             } catch (e) {
-              self.db.resetIndexes();   // Rollback any index which didn't fail
-              return cb(e);
+              self.db.resetIndexes()   // Rollback any index which didn't fail
+              return cb(e)
             }
 
-            self.db.persistence.persistCachedDatabase(cb);
-          });
-        });
-      });
+            self.db.persistence.persistCachedDatabase(cb)
+          })
+        })
+      })
     }
   ], function (err) {
-       if (err) { return callback(err); }
+    if (err) { return callback(err) }
 
-       self.db.executor.processBuffer();
-       return callback(null);
-     });
-};
-
+    self.db.executor.processBuffer()
+    return callback(null)
+  })
+}
 
 // Interface
-module.exports = Persistence;
+module.exports = Persistence

--- a/src/nedb/persistence.js
+++ b/src/nedb/persistence.js
@@ -69,7 +69,7 @@ function Persistence (options) {
 Persistence.ensureDirectoryExists = function (dir, cb) {
   const callback = cb || function () {}
 
-  storage.mkdirp(dir, function (err) { return callback(err) })
+  storage.mkdirp(dir).then(() => callback(), err => callback(err))
 }
 
 /**

--- a/src/nedb/storage.js
+++ b/src/nedb/storage.js
@@ -1,0 +1,136 @@
+/**
+ * Way data is stored for this database
+ * For a Node.js/Node Webkit database it's the file system
+ * For a browser-side database it's localforage which chooses the best option depending on user browser (IndexedDB then WebSQL then localStorage)
+ *
+ * This version is the Node.js/Node Webkit version
+ * It's essentially fs, mkdirp and crash safe write and read functions
+ */
+
+var fs = require('fs')
+  , mkdirp = require('mkdirp')
+  , async = require('async')
+  , path = require('path')
+  , storage = {}
+  ;
+
+storage.exists = fs.exists;
+storage.rename = fs.rename;
+storage.writeFile = fs.writeFile;
+storage.unlink = fs.unlink;
+storage.appendFile = fs.appendFile;
+storage.readFile = fs.readFile;
+storage.mkdirp = mkdirp;
+
+
+/**
+ * Explicit name ...
+ */
+storage.ensureFileDoesntExist = function (file, callback) {
+  storage.exists(file, function (exists) {
+    if (!exists) { return callback(null); }
+
+    storage.unlink(file, function (err) { return callback(err); });
+  });
+};
+
+
+/**
+ * Flush data in OS buffer to storage if corresponding option is set
+ * @param {String} options.filename
+ * @param {Boolean} options.isDir Optional, defaults to false
+ * If options is a string, it is assumed that the flush of the file (not dir) called options was requested
+ */
+storage.flushToStorage = function (options, callback) {
+  var filename, flags;
+  if (typeof options === 'string') {
+    filename = options;
+    flags = 'r+';
+  } else {
+    filename = options.filename;
+    flags = options.isDir ? 'r' : 'r+';
+  }
+
+  // Windows can't fsync (FlushFileBuffers) directories. We can live with this as it cannot cause 100% dataloss
+  // except in the very rare event of the first time database is loaded and a crash happens
+  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) { return callback(null); }
+
+  fs.open(filename, flags, function (err, fd) {
+    if (err) { return callback(err); }
+    fs.fsync(fd, function (errFS) {
+      fs.close(fd, function (errC) {
+        if (errFS || errC) {
+          var e = new Error('Failed to flush to storage');
+          e.errorOnFsync = errFS;
+          e.errorOnClose = errC;
+          return callback(e);
+        } else {
+          return callback(null);
+        }
+      });
+    });
+  });
+};
+
+
+/**
+ * Fully write or rewrite the datafile, immune to crashes during the write operation (data will not be lost)
+ * @param {String} filename
+ * @param {String} data
+ * @param {Function} cb Optional callback, signature: err
+ */
+storage.crashSafeWriteFile = function (filename, data, cb) {
+  var callback = cb || function () {}
+    , tempFilename = filename + '~';
+
+  async.waterfall([
+    async.apply(storage.flushToStorage, { filename: path.dirname(filename), isDir: true })
+  , function (cb) {
+      storage.exists(filename, function (exists) {
+        if (exists) {
+          storage.flushToStorage(filename, function (err) { return cb(err); });
+        } else {
+          return cb();
+        }
+      });
+    }
+  , function (cb) {
+      storage.writeFile(tempFilename, data, function (err) { return cb(err); });
+    }
+  , async.apply(storage.flushToStorage, tempFilename)
+  , function (cb) {
+      storage.rename(tempFilename, filename, function (err) { return cb(err); });
+    }
+  , async.apply(storage.flushToStorage, { filename: path.dirname(filename), isDir: true })
+  ], function (err) { return callback(err); })
+};
+
+
+/**
+ * Ensure the datafile contains all the data, even if there was a crash during a full file write
+ * @param {String} filename
+ * @param {Function} callback signature: err
+ */
+storage.ensureDatafileIntegrity = function (filename, callback) {
+  var tempFilename = filename + '~';
+
+  storage.exists(filename, function (filenameExists) {
+    // Write was successful
+    if (filenameExists) { return callback(null); }
+
+    storage.exists(tempFilename, function (oldFilenameExists) {
+      // New database
+      if (!oldFilenameExists) {
+        return storage.writeFile(filename, '', 'utf8', function (err) { callback(err); });
+      }
+
+      // Write failed, use old version
+      storage.rename(tempFilename, filename, function (err) { return callback(err); });
+    });
+  });
+};
+
+
+
+// Interface
+module.exports = storage;

--- a/src/nedb/storage.js
+++ b/src/nedb/storage.js
@@ -6,34 +6,30 @@
  * This version is the Node.js/Node Webkit version
  * It's essentially fs, mkdirp and crash safe write and read functions
  */
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+const async = require('async')
+const path = require('path')
+const storage = {}
 
-var fs = require('fs')
-  , mkdirp = require('mkdirp')
-  , async = require('async')
-  , path = require('path')
-  , storage = {}
-  ;
-
-storage.exists = fs.exists;
-storage.rename = fs.rename;
-storage.writeFile = fs.writeFile;
-storage.unlink = fs.unlink;
-storage.appendFile = fs.appendFile;
-storage.readFile = fs.readFile;
-storage.mkdirp = mkdirp;
-
+storage.exists = fs.exists
+storage.rename = fs.rename
+storage.writeFile = fs.writeFile
+storage.unlink = fs.unlink
+storage.appendFile = fs.appendFile
+storage.readFile = fs.readFile
+storage.mkdirp = mkdirp
 
 /**
  * Explicit name ...
  */
 storage.ensureFileDoesntExist = function (file, callback) {
   storage.exists(file, function (exists) {
-    if (!exists) { return callback(null); }
+    if (!exists) { return callback(null) }
 
-    storage.unlink(file, function (err) { return callback(err); });
-  });
-};
-
+    storage.unlink(file, function (err) { return callback(err) })
+  })
+}
 
 /**
  * Flush data in OS buffer to storage if corresponding option is set
@@ -42,36 +38,36 @@ storage.ensureFileDoesntExist = function (file, callback) {
  * If options is a string, it is assumed that the flush of the file (not dir) called options was requested
  */
 storage.flushToStorage = function (options, callback) {
-  var filename, flags;
+  let filename
+  let flags
   if (typeof options === 'string') {
-    filename = options;
-    flags = 'r+';
+    filename = options
+    flags = 'r+'
   } else {
-    filename = options.filename;
-    flags = options.isDir ? 'r' : 'r+';
+    filename = options.filename
+    flags = options.isDir ? 'r' : 'r+'
   }
 
   // Windows can't fsync (FlushFileBuffers) directories. We can live with this as it cannot cause 100% dataloss
   // except in the very rare event of the first time database is loaded and a crash happens
-  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) { return callback(null); }
+  if (flags === 'r' && (process.platform === 'win32' || process.platform === 'win64')) { return callback(null) }
 
   fs.open(filename, flags, function (err, fd) {
-    if (err) { return callback(err); }
+    if (err) { return callback(err) }
     fs.fsync(fd, function (errFS) {
       fs.close(fd, function (errC) {
         if (errFS || errC) {
-          var e = new Error('Failed to flush to storage');
-          e.errorOnFsync = errFS;
-          e.errorOnClose = errC;
-          return callback(e);
+          const e = new Error('Failed to flush to storage')
+          e.errorOnFsync = errFS
+          e.errorOnClose = errC
+          return callback(e)
         } else {
-          return callback(null);
+          return callback(null)
         }
-      });
-    });
-  });
-};
-
+      })
+    })
+  })
+}
 
 /**
  * Fully write or rewrite the datafile, immune to crashes during the write operation (data will not be lost)
@@ -80,31 +76,30 @@ storage.flushToStorage = function (options, callback) {
  * @param {Function} cb Optional callback, signature: err
  */
 storage.crashSafeWriteFile = function (filename, data, cb) {
-  var callback = cb || function () {}
-    , tempFilename = filename + '~';
+  const callback = cb || function () {}
+  const tempFilename = filename + '~'
 
   async.waterfall([
     async.apply(storage.flushToStorage, { filename: path.dirname(filename), isDir: true })
-  , function (cb) {
+    , function (cb) {
       storage.exists(filename, function (exists) {
         if (exists) {
-          storage.flushToStorage(filename, function (err) { return cb(err); });
+          storage.flushToStorage(filename, function (err) { return cb(err) })
         } else {
-          return cb();
+          return cb()
         }
-      });
+      })
     }
-  , function (cb) {
-      storage.writeFile(tempFilename, data, function (err) { return cb(err); });
+    , function (cb) {
+      storage.writeFile(tempFilename, data, function (err) { return cb(err) })
     }
-  , async.apply(storage.flushToStorage, tempFilename)
-  , function (cb) {
-      storage.rename(tempFilename, filename, function (err) { return cb(err); });
+    , async.apply(storage.flushToStorage, tempFilename)
+    , function (cb) {
+      storage.rename(tempFilename, filename, function (err) { return cb(err) })
     }
-  , async.apply(storage.flushToStorage, { filename: path.dirname(filename), isDir: true })
-  ], function (err) { return callback(err); })
-};
-
+    , async.apply(storage.flushToStorage, { filename: path.dirname(filename), isDir: true })
+  ], function (err) { return callback(err) })
+}
 
 /**
  * Ensure the datafile contains all the data, even if there was a crash during a full file write
@@ -112,25 +107,23 @@ storage.crashSafeWriteFile = function (filename, data, cb) {
  * @param {Function} callback signature: err
  */
 storage.ensureDatafileIntegrity = function (filename, callback) {
-  var tempFilename = filename + '~';
+  const tempFilename = filename + '~'
 
   storage.exists(filename, function (filenameExists) {
     // Write was successful
-    if (filenameExists) { return callback(null); }
+    if (filenameExists) { return callback(null) }
 
     storage.exists(tempFilename, function (oldFilenameExists) {
       // New database
       if (!oldFilenameExists) {
-        return storage.writeFile(filename, '', 'utf8', function (err) { callback(err); });
+        return storage.writeFile(filename, '', 'utf8', function (err) { callback(err) })
       }
 
       // Write failed, use old version
-      storage.rename(tempFilename, filename, function (err) { return callback(err); });
-    });
-  });
-};
-
-
+      storage.rename(tempFilename, filename, function (err) { return callback(err) })
+    })
+  })
+}
 
 // Interface
-module.exports = storage;
+module.exports = storage

--- a/test/avltree.test.js
+++ b/test/avltree.test.js
@@ -375,9 +375,9 @@ describe('AVL tree', function () {
     })
 
     it('Can search for data between two bounds', function () {
-      const avlt = new AVLTree()
+      const avlt = new AVLTree();
 
-      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         avlt.insert(k, 'data ' + k)
       })
 
@@ -386,9 +386,9 @@ describe('AVL tree', function () {
     })
 
     it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
-      const avlt = new AVLTree()
+      const avlt = new AVLTree();
 
-      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         avlt.insert(k, 'data ' + k)
       })
 
@@ -402,9 +402,9 @@ describe('AVL tree', function () {
     })
 
     it('Bounded search can work when one or both boundaries are missing', function () {
-      const avlt = new AVLTree()
+      const avlt = new AVLTree();
 
-      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         avlt.insert(k, 'data ' + k)
       })
 
@@ -437,9 +437,9 @@ describe('AVL tree', function () {
     })
 
     it('Deleting a non-existent key doesnt have any effect', function () {
-      const avlt = new AVLTree()
+      const avlt = new AVLTree();
 
-      [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
         avlt.insert(k, 'some ' + k)
       })
 
@@ -660,7 +660,7 @@ describe('AVL tree', function () {
     })
 
     it('Can delete the root if it has 2 children', function () {
-      let avlt = new AVLTree()
+      let avlt = new AVLTree();
 
       // No rebalancing needed
       [10, 5, 15, 3, 8, 12, 37].forEach(function (k) {

--- a/test/avltree.test.js
+++ b/test/avltree.test.js
@@ -1,502 +1,507 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , AVLTree = require('../src/binarySearchTree/avltree')
-  , _ = require('underscore')
-  , customUtils = require('../src/binarySearchTree/customUtils')
-  ;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const AVLTree = require('../src/binarySearchTree/avltree')
+const _ = require('underscore')
+const customUtils = require('../src/binarySearchTree/customUtils')
 
 describe('AVL tree', function () {
 
   describe('Sanity checks', function () {
 
     it('Checking that all nodes heights are correct', function () {
-      var _AVLTree = AVLTree._AVLTree
-        , avlt = new _AVLTree({ key: 10 })
-        , l = new _AVLTree({ key: 5 })
-        , r = new _AVLTree({ key: 15 })
-        , ll = new _AVLTree({ key: 3 })
-        , lr = new _AVLTree({ key: 8 })
-        , rl = new _AVLTree({ key: 13 })
-        , rr = new _AVLTree({ key: 18 })
-        , lrl = new _AVLTree({ key: 7 })
-        , lrll = new _AVLTree({ key: 6 })
-        ;
-
+      const _AVLTree = AVLTree._AVLTree
+      const avlt = new _AVLTree({ key: 10 })
+      const l = new _AVLTree({ key: 5 })
+      const r = new _AVLTree({ key: 15 })
+      const ll = new _AVLTree({ key: 3 })
+      const lr = new _AVLTree({ key: 8 })
+      const rl = new _AVLTree({ key: 13 })
+      const rr = new _AVLTree({ key: 18 })
+      const lrl = new _AVLTree({ key: 7 })
+      const lrll = new _AVLTree({ key: 6 })
 
       // With a balanced tree
-      avlt.left = l;
-      avlt.right = r;
-      l.left = ll;
-      l.right = lr;
-      r.left = rl;
+      avlt.left = l
+      avlt.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
       r.right = rr;
 
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       avlt.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       l.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       r.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       ll.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lr.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       rl.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       rr.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       avlt.height = 2;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       l.height = 2;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       r.height = 2;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
-      avlt.height = 3;
-      avlt.checkHeightCorrect();   // Correct
+      (function () { avlt.checkHeightCorrect() }).should.throw()
+      avlt.height = 3
+      avlt.checkHeightCorrect()   // Correct
 
       // With an unbalanced tree
       lr.left = lrl;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lrl.left = lrll;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lrl.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lrll.height = 1;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lrl.height = 2;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       lr.height = 3;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
+      (function () { avlt.checkHeightCorrect() }).should.throw()
       l.height = 4;
-      (function () { avlt.checkHeightCorrect() }).should.throw();
-      avlt.height = 5;
-      avlt.checkHeightCorrect();   // Correct
-    });
+      (function () { avlt.checkHeightCorrect() }).should.throw()
+      avlt.height = 5
+      avlt.checkHeightCorrect()   // Correct
+    })
 
     it('Calculate the balance factor', function () {
-      var _AVLTree = AVLTree._AVLTree
-        , avlt = new _AVLTree({ key: 10 })
-        , l = new _AVLTree({ key: 5 })
-        , r = new _AVLTree({ key: 15 })
-        , ll = new _AVLTree({ key: 3 })
-        , lr = new _AVLTree({ key: 8 })
-        , rl = new _AVLTree({ key: 13 })
-        , rr = new _AVLTree({ key: 18 })
-        , lrl = new _AVLTree({ key: 7 })
-        , lrll = new _AVLTree({ key: 6 })
-        ;
-
+      const _AVLTree = AVLTree._AVLTree
+      const avlt = new _AVLTree({ key: 10 })
+      const l = new _AVLTree({ key: 5 })
+      const r = new _AVLTree({ key: 15 })
+      const ll = new _AVLTree({ key: 3 })
+      const lr = new _AVLTree({ key: 8 })
+      const rl = new _AVLTree({ key: 13 })
+      const rr = new _AVLTree({ key: 18 })
+      const lrl = new _AVLTree({ key: 7 })
+      const lrll = new _AVLTree({ key: 6 })
 
       // With a balanced tree
-      avlt.left = l;
-      avlt.right = r;
-      l.left = ll;
-      l.right = lr;
-      r.left = rl;
-      r.right = rr;
+      avlt.left = l
+      avlt.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr
 
-      ll.height = 1;
-      rl.height = 1;
-      rr.height = 1;
-      avlt.height = 2;
-      r.height = 2;
-      lr.left = lrl;
-      lrl.left = lrll;
-      lrl.height = 1;
-      lrll.height = 1;
-      lrl.height = 2;
-      lr.height = 3;
-      l.height = 4;
-      avlt.height = 5;
-      avlt.checkHeightCorrect();   // Correct
+      ll.height = 1
+      rl.height = 1
+      rr.height = 1
+      avlt.height = 2
+      r.height = 2
+      lr.left = lrl
+      lrl.left = lrll
+      lrl.height = 1
+      lrll.height = 1
+      lrl.height = 2
+      lr.height = 3
+      l.height = 4
+      avlt.height = 5
+      avlt.checkHeightCorrect()   // Correct
 
-      lrll.balanceFactor().should.equal(0);
-      lrl.balanceFactor().should.equal(1);
-      ll.balanceFactor().should.equal(0);
-      lr.balanceFactor().should.equal(2);
-      rl.balanceFactor().should.equal(0);
-      rr.balanceFactor().should.equal(0);
-      l.balanceFactor().should.equal(-2);
-      r.balanceFactor().should.equal(0);
-      avlt.balanceFactor().should.equal(2);
-    });
+      lrll.balanceFactor().should.equal(0)
+      lrl.balanceFactor().should.equal(1)
+      ll.balanceFactor().should.equal(0)
+      lr.balanceFactor().should.equal(2)
+      rl.balanceFactor().should.equal(0)
+      rr.balanceFactor().should.equal(0)
+      l.balanceFactor().should.equal(-2)
+      r.balanceFactor().should.equal(0)
+      avlt.balanceFactor().should.equal(2)
+    })
 
     it('Can check that a tree is balanced', function () {
-      var _AVLTree = AVLTree._AVLTree
-        , avlt = new _AVLTree({ key: 10 })
-        , l = new _AVLTree({ key: 5 })
-        , r = new _AVLTree({ key: 15 })
-        , ll = new _AVLTree({ key: 3 })
-        , lr = new _AVLTree({ key: 8 })
-        , rl = new _AVLTree({ key: 13 })
-        , rr = new _AVLTree({ key: 18 })
+      const _AVLTree = AVLTree._AVLTree
+      const avlt = new _AVLTree({ key: 10 })
+      const l = new _AVLTree({ key: 5 })
+      const r = new _AVLTree({ key: 15 })
+      const ll = new _AVLTree({ key: 3 })
+      const lr = new _AVLTree({ key: 8 })
+      const rl = new _AVLTree({ key: 13 })
+      const rr = new _AVLTree({ key: 18 })
 
-      avlt.left = l;
-      avlt.right = r;
-      l.left = ll;
-      l.right = lr;
-      r.left = rl;
-      r.right = rr;
+      avlt.left = l
+      avlt.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr
 
-      ll.height = 1;
-      lr.height = 1;
-      rl.height = 1;
-      rr.height = 1;
-      l.height = 2;
-      r.height = 2;
-      avlt.height = 3;
-      avlt.checkBalanceFactors();
+      ll.height = 1
+      lr.height = 1
+      rl.height = 1
+      rr.height = 1
+      l.height = 2
+      r.height = 2
+      avlt.height = 3
+      avlt.checkBalanceFactors()
 
       r.height = 0;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      (function () { avlt.checkBalanceFactors() }).should.throw()
       r.height = 4;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
-      r.height = 2;
-      avlt.checkBalanceFactors();
+      (function () { avlt.checkBalanceFactors() }).should.throw()
+      r.height = 2
+      avlt.checkBalanceFactors()
 
       ll.height = -1;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      (function () { avlt.checkBalanceFactors() }).should.throw()
       ll.height = 3;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
-      ll.height = 1;
-      avlt.checkBalanceFactors();
+      (function () { avlt.checkBalanceFactors() }).should.throw()
+      ll.height = 1
+      avlt.checkBalanceFactors()
 
       rl.height = -1;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      (function () { avlt.checkBalanceFactors() }).should.throw()
       rl.height = 3;
-      (function () { avlt.checkBalanceFactors(); }).should.throw();
-      rl.height = 1;
-      avlt.checkBalanceFactors();
-    });
+      (function () { avlt.checkBalanceFactors() }).should.throw()
+      rl.height = 1
+      avlt.checkBalanceFactors()
+    })
 
-  });   // ==== End of 'Sanity checks' ==== //
-
+  })   // ==== End of 'Sanity checks' ==== //
 
   describe('Insertion', function () {
 
     it('The root has a height of 1', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'root');
-      avlt.tree.height.should.equal(1);
-    });
-
+      avlt.insert(10, 'root')
+      avlt.tree.height.should.equal(1)
+    })
 
     it('Insert at the root if its the first insertion', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'some data');
+      avlt.insert(10, 'some data')
 
-      avlt.checkIsAVLT();
-      avlt.tree.key.should.equal(10);
-      _.isEqual(avlt.tree.data, ['some data']).should.equal(true);
-      assert.isNull(avlt.tree.left);
-      assert.isNull(avlt.tree.right);
-    });
+      avlt.checkIsAVLT()
+      avlt.tree.key.should.equal(10)
+      _.isEqual(avlt.tree.data, ['some data']).should.equal(true)
+      assert.isNull(avlt.tree.left)
+      assert.isNull(avlt.tree.right)
+    })
 
     it('If uniqueness constraint not enforced, we can insert different data for same key', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'some data');
-      avlt.insert(3, 'hello');
-      avlt.insert(3, 'world');
+      avlt.insert(10, 'some data')
+      avlt.insert(3, 'hello')
+      avlt.insert(3, 'world')
 
-      avlt.checkIsAVLT();
-      _.isEqual(avlt.search(3), ['hello', 'world']).should.equal(true);
+      avlt.checkIsAVLT()
+      _.isEqual(avlt.search(3), ['hello', 'world']).should.equal(true)
 
-      avlt.insert(12, 'a');
-      avlt.insert(12, 'b');
+      avlt.insert(12, 'a')
+      avlt.insert(12, 'b')
 
-      avlt.checkIsAVLT();
-      _.isEqual(avlt.search(12), ['a', 'b']).should.equal(true);
-    });
+      avlt.checkIsAVLT()
+      _.isEqual(avlt.search(12), ['a', 'b']).should.equal(true)
+    })
 
     it('If uniqueness constraint is enforced, we cannot insert different data for same key', function () {
-      var avlt = new AVLTree({ unique: true });
+      var avlt = new AVLTree({ unique: true })
 
-      avlt.insert(10, 'some data');
-      avlt.insert(3, 'hello');
+      avlt.insert(10, 'some data')
+      avlt.insert(3, 'hello')
       try {
-        avlt.insert(3, 'world');
+        avlt.insert(3, 'world')
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
-        e.key.should.equal(3);
+        e.errorType.should.equal('uniqueViolated')
+        e.key.should.equal(3)
       }
 
-      avlt.checkIsAVLT();
-      _.isEqual(avlt.search(3), ['hello']).should.equal(true);
+      avlt.checkIsAVLT()
+      _.isEqual(avlt.search(3), ['hello']).should.equal(true)
 
-      avlt.insert(12, 'a');
+      avlt.insert(12, 'a')
       try {
-        avlt.insert(12, 'world');
+        avlt.insert(12, 'world')
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
-        e.key.should.equal(12);
+        e.errorType.should.equal('uniqueViolated')
+        e.key.should.equal(12)
       }
 
-      avlt.checkIsAVLT();
-      _.isEqual(avlt.search(12), ['a']).should.equal(true);
-    });
+      avlt.checkIsAVLT()
+      _.isEqual(avlt.search(12), ['a']).should.equal(true)
+    })
 
     it('Can insert 0 or the empty string', function () {
-      var avlt = new AVLTree();
+      let avlt = new AVLTree()
 
-      avlt.insert(0, 'some data');
+      avlt.insert(0, 'some data')
 
-      avlt.checkIsAVLT();
-      avlt.tree.key.should.equal(0);
-      _.isEqual(avlt.tree.data, ['some data']).should.equal(true);
+      avlt.checkIsAVLT()
+      avlt.tree.key.should.equal(0)
+      _.isEqual(avlt.tree.data, ['some data']).should.equal(true)
 
-      avlt = new AVLTree();
+      avlt = new AVLTree()
 
-      avlt.insert('', 'some other data');
+      avlt.insert('', 'some other data')
 
-      avlt.checkIsAVLT();
-      avlt.tree.key.should.equal('');
-      _.isEqual(avlt.tree.data, ['some other data']).should.equal(true);
-    });
+      avlt.checkIsAVLT()
+      avlt.tree.key.should.equal('')
+      _.isEqual(avlt.tree.data, ['some other data']).should.equal(true)
+    })
 
     it('Auto-balancing insertions', function () {
-      var avlt = new AVLTree()
-        , avlt2 = new AVLTree()
-        , avlt3 = new AVLTree()
-        ;
+      const avlt = new AVLTree()
+      const avlt2 = new AVLTree()
+      const avlt3 = new AVLTree()
 
       // Balancing insertions on the left
-      avlt.tree.getNumberOfKeys().should.equal(0);
-      avlt.insert(18);
-      avlt.tree.getNumberOfKeys().should.equal(1);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(15);
-      avlt.tree.getNumberOfKeys().should.equal(2);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(13);
-      avlt.tree.getNumberOfKeys().should.equal(3);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(10);
-      avlt.tree.getNumberOfKeys().should.equal(4);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(8);
-      avlt.tree.getNumberOfKeys().should.equal(5);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(5);
-      avlt.tree.getNumberOfKeys().should.equal(6);
-      avlt.tree.checkIsAVLT();
-      avlt.insert(3);
-      avlt.tree.getNumberOfKeys().should.equal(7);
-      avlt.tree.checkIsAVLT();
+      avlt.tree.getNumberOfKeys().should.equal(0)
+      avlt.insert(18)
+      avlt.tree.getNumberOfKeys().should.equal(1)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(15)
+      avlt.tree.getNumberOfKeys().should.equal(2)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(13)
+      avlt.tree.getNumberOfKeys().should.equal(3)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(10)
+      avlt.tree.getNumberOfKeys().should.equal(4)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(8)
+      avlt.tree.getNumberOfKeys().should.equal(5)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(5)
+      avlt.tree.getNumberOfKeys().should.equal(6)
+      avlt.tree.checkIsAVLT()
+      avlt.insert(3)
+      avlt.tree.getNumberOfKeys().should.equal(7)
+      avlt.tree.checkIsAVLT()
 
       // Balancing insertions on the right
-      avlt2.tree.getNumberOfKeys().should.equal(0);
-      avlt2.insert(3);
-      avlt2.tree.getNumberOfKeys().should.equal(1);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(5);
-      avlt2.tree.getNumberOfKeys().should.equal(2);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(8);
-      avlt2.tree.getNumberOfKeys().should.equal(3);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(10);
-      avlt2.tree.getNumberOfKeys().should.equal(4);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(13);
-      avlt2.tree.getNumberOfKeys().should.equal(5);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(15);
-      avlt2.tree.getNumberOfKeys().should.equal(6);
-      avlt2.tree.checkIsAVLT();
-      avlt2.insert(18);
-      avlt2.tree.getNumberOfKeys().should.equal(7);
-      avlt2.tree.checkIsAVLT();
+      avlt2.tree.getNumberOfKeys().should.equal(0)
+      avlt2.insert(3)
+      avlt2.tree.getNumberOfKeys().should.equal(1)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(5)
+      avlt2.tree.getNumberOfKeys().should.equal(2)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(8)
+      avlt2.tree.getNumberOfKeys().should.equal(3)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(10)
+      avlt2.tree.getNumberOfKeys().should.equal(4)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(13)
+      avlt2.tree.getNumberOfKeys().should.equal(5)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(15)
+      avlt2.tree.getNumberOfKeys().should.equal(6)
+      avlt2.tree.checkIsAVLT()
+      avlt2.insert(18)
+      avlt2.tree.getNumberOfKeys().should.equal(7)
+      avlt2.tree.checkIsAVLT()
 
       // Balancing already-balanced insertions
-      avlt3.tree.getNumberOfKeys().should.equal(0);
-      avlt3.insert(10);
-      avlt3.tree.getNumberOfKeys().should.equal(1);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(5);
-      avlt3.tree.getNumberOfKeys().should.equal(2);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(15);
-      avlt3.tree.getNumberOfKeys().should.equal(3);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(3);
-      avlt3.tree.getNumberOfKeys().should.equal(4);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(8);
-      avlt3.tree.getNumberOfKeys().should.equal(5);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(13);
-      avlt3.tree.getNumberOfKeys().should.equal(6);
-      avlt3.tree.checkIsAVLT();
-      avlt3.insert(18);
-      avlt3.tree.getNumberOfKeys().should.equal(7);
-      avlt3.tree.checkIsAVLT();
-    });
+      avlt3.tree.getNumberOfKeys().should.equal(0)
+      avlt3.insert(10)
+      avlt3.tree.getNumberOfKeys().should.equal(1)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(5)
+      avlt3.tree.getNumberOfKeys().should.equal(2)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(15)
+      avlt3.tree.getNumberOfKeys().should.equal(3)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(3)
+      avlt3.tree.getNumberOfKeys().should.equal(4)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(8)
+      avlt3.tree.getNumberOfKeys().should.equal(5)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(13)
+      avlt3.tree.getNumberOfKeys().should.equal(6)
+      avlt3.tree.checkIsAVLT()
+      avlt3.insert(18)
+      avlt3.tree.getNumberOfKeys().should.equal(7)
+      avlt3.tree.checkIsAVLT()
+    })
 
     it('Can insert a lot of keys and still get an AVLT (sanity check)', function () {
-      var avlt = new AVLTree({ unique: true });
+      const avlt = new AVLTree({ unique: true })
 
       customUtils.getRandomArray(1000).forEach(function (n) {
-        avlt.insert(n, 'some data');
-        avlt.checkIsAVLT();
-      });
+        avlt.insert(n, 'some data')
+        avlt.checkIsAVLT()
+      })
 
-    });
+    })
 
-  });   // ==== End of 'Insertion' ==== //
-
+  })   // ==== End of 'Insertion' ==== //
 
   describe('Search', function () {
 
     it('Can find data in an AVLT', function () {
-      var avlt = new AVLTree()
-        , i;
+      const avlt = new AVLTree()
+      let i
 
       customUtils.getRandomArray(100).forEach(function (n) {
-        avlt.insert(n, 'some data for ' + n);
-      });
+        avlt.insert(n, 'some data for ' + n)
+      })
 
-      avlt.checkIsAVLT();
+      avlt.checkIsAVLT()
 
       for (i = 0; i < 100; i += 1) {
-        _.isEqual(avlt.search(i), ['some data for ' + i]).should.equal(true);
+        _.isEqual(avlt.search(i), ['some data for ' + i]).should.equal(true)
       }
-    });
+    })
 
     it('If no data can be found, return an empty array', function () {
-      var avlt = new AVLTree();
+      var avlt = new AVLTree()
 
       customUtils.getRandomArray(100).forEach(function (n) {
         if (n !== 63) {
-          avlt.insert(n, 'some data for ' + n);
+          avlt.insert(n, 'some data for ' + n)
         }
-      });
+      })
 
-      avlt.checkIsAVLT();
+      avlt.checkIsAVLT()
 
-      avlt.search(-2).length.should.equal(0);
-      avlt.search(100).length.should.equal(0);
-      avlt.search(101).length.should.equal(0);
-      avlt.search(63).length.should.equal(0);
-    });
+      avlt.search(-2).length.should.equal(0)
+      avlt.search(100).length.should.equal(0)
+      avlt.search(101).length.should.equal(0)
+      avlt.search(63).length.should.equal(0)
+    })
 
     it('Can search for data between two bounds', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        avlt.insert(k, 'data ' + k);
-      });
+        avlt.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-      assert.deepEqual(avlt.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13']);
-    });
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+      assert.deepEqual(avlt.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13'])
+    })
 
     it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        avlt.insert(k, 'data ' + k);
-      });
+        avlt.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(avlt.betweenBounds({ $gt:8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
-      assert.deepEqual(avlt.betweenBounds({ $gt:5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-      assert.deepEqual(avlt.betweenBounds({ $gt:8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+      assert.deepEqual(avlt.betweenBounds({ $gt: 8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15'])
+      assert.deepEqual(avlt.betweenBounds({ $gt: 5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+      assert.deepEqual(avlt.betweenBounds({ $gt: 8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15'])
 
-      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
-      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
-      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-    });
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13'])
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13'])
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+    })
 
     it('Bounded search can work when one or both boundaries are missing', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        avlt.insert(k, 'data ' + k);
-      });
+        avlt.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(avlt.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18']);
-      assert.deepEqual(avlt.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8']);
-    });
+      assert.deepEqual(avlt.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18'])
+      assert.deepEqual(avlt.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8'])
+    })
 
-  });   /// ==== End of 'Search' ==== //
-
+  })   /// ==== End of 'Search' ==== //
 
   describe('Deletion', function () {
 
     it('Deletion does nothing on an empty tree', function () {
-      var avlt = new AVLTree()
-        , avltu = new AVLTree({ unique: true });
+      const avlt = new AVLTree()
+      const avltu = new AVLTree({ unique: true })
 
-      avlt.getNumberOfKeys().should.equal(0);
-      avltu.getNumberOfKeys().should.equal(0);
+      avlt.getNumberOfKeys().should.equal(0)
+      avltu.getNumberOfKeys().should.equal(0)
 
-      avlt.delete(5);
-      avltu.delete(5);
+      avlt.delete(5)
+      avltu.delete(5)
 
-      avlt.tree.hasOwnProperty('key').should.equal(false);
-      avltu.tree.hasOwnProperty('key').should.equal(false);
+      avlt.tree.hasOwnProperty('key').should.equal(false)
+      avltu.tree.hasOwnProperty('key').should.equal(false)
 
-      avlt.tree.data.length.should.equal(0);
-      avltu.tree.data.length.should.equal(0);
+      avlt.tree.data.length.should.equal(0)
+      avltu.tree.data.length.should.equal(0)
 
-      avlt.getNumberOfKeys().should.equal(0);
-      avltu.getNumberOfKeys().should.equal(0);
-    });
+      avlt.getNumberOfKeys().should.equal(0)
+      avltu.getNumberOfKeys().should.equal(0)
+    })
 
     it('Deleting a non-existent key doesnt have any effect', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
       [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
+        avlt.insert(k, 'some ' + k)
+      })
 
       function checkavlt () {
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-          _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
-        });
+          _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
+        })
       }
 
-      checkavlt();
-      avlt.getNumberOfKeys().should.equal(7);
+      checkavlt()
+      avlt.getNumberOfKeys().should.equal(7)
 
-      avlt.delete(2);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(4);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(9);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(6);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(11);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(14);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(20);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(200);
-      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
-    });
+      avlt.delete(2)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(4)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(9)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(6)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(11)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(14)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(20)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(200)
+      checkavlt()
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(7)
+    })
 
     it('Able to delete the root if it is also a leaf', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'hello');
-      avlt.tree.key.should.equal(10);
-      _.isEqual(avlt.tree.data, ['hello']).should.equal(true);
-      avlt.getNumberOfKeys().should.equal(1);
+      avlt.insert(10, 'hello')
+      avlt.tree.key.should.equal(10)
+      _.isEqual(avlt.tree.data, ['hello']).should.equal(true)
+      avlt.getNumberOfKeys().should.equal(1)
 
-      avlt.delete(10);
-      avlt.tree.hasOwnProperty('key').should.equal(false);
-      avlt.tree.data.length.should.equal(0);
-      avlt.getNumberOfKeys().should.equal(0);
-    });
+      avlt.delete(10)
+      avlt.tree.hasOwnProperty('key').should.equal(false)
+      avlt.tree.data.length.should.equal(0)
+      avlt.getNumberOfKeys().should.equal(0)
+    })
 
     it('Able to delete leaf nodes that are non-root', function () {
-      var avlt;
+      let avlt
 
       // This will create an AVL tree with leaves 3, 8, 12, 37
       // (do a pretty print to see this)
@@ -504,507 +509,501 @@ describe('AVL tree', function () {
         avlt = new AVLTree();
 
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-          avlt.insert(k, 'some ' + k);
-        });
+          avlt.insert(k, 'some ' + k)
+        })
 
-        avlt.getNumberOfKeys().should.equal(7);
+        avlt.getNumberOfKeys().should.equal(7)
       }
 
       // Check that only keys in array theRemoved were removed
       function checkRemoved (theRemoved) {
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
           if (theRemoved.indexOf(k) !== -1) {
-            avlt.search(k).length.should.equal(0);
+            avlt.search(k).length.should.equal(0)
           } else {
-            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
           }
-        });
+        })
 
-        avlt.getNumberOfKeys().should.equal(7 - theRemoved.length);
+        avlt.getNumberOfKeys().should.equal(7 - theRemoved.length)
       }
 
-      recreateavlt();
-      avlt.delete(3);
-      avlt.checkIsAVLT();
-      checkRemoved([3]);
+      recreateavlt()
+      avlt.delete(3)
+      avlt.checkIsAVLT()
+      checkRemoved([3])
 
-      recreateavlt();
-      avlt.delete(8);
-      avlt.checkIsAVLT();
-      checkRemoved([8]);
+      recreateavlt()
+      avlt.delete(8)
+      avlt.checkIsAVLT()
+      checkRemoved([8])
 
-      recreateavlt();
-      avlt.delete(12);
-      avlt.checkIsAVLT();
-      checkRemoved([12]);
+      recreateavlt()
+      avlt.delete(12)
+      avlt.checkIsAVLT()
+      checkRemoved([12])
 
       // Delete all leaves in a way that makes the tree unbalanced
-      recreateavlt();
-      avlt.delete(37);
-      avlt.checkIsAVLT();
-      checkRemoved([37]);
+      recreateavlt()
+      avlt.delete(37)
+      avlt.checkIsAVLT()
+      checkRemoved([37])
 
-      avlt.delete(12);
-      avlt.checkIsAVLT();
-      checkRemoved([12, 37]);
+      avlt.delete(12)
+      avlt.checkIsAVLT()
+      checkRemoved([12, 37])
 
-      avlt.delete(15);
-      avlt.checkIsAVLT();
-      checkRemoved([12, 15, 37]);
+      avlt.delete(15)
+      avlt.checkIsAVLT()
+      checkRemoved([12, 15, 37])
 
-      avlt.delete(3);
-      avlt.checkIsAVLT();
-      checkRemoved([3, 12, 15, 37]);
+      avlt.delete(3)
+      avlt.checkIsAVLT()
+      checkRemoved([3, 12, 15, 37])
 
-      avlt.delete(5);
-      avlt.checkIsAVLT();
-      checkRemoved([3, 5, 12, 15, 37]);
+      avlt.delete(5)
+      avlt.checkIsAVLT()
+      checkRemoved([3, 5, 12, 15, 37])
 
-      avlt.delete(10);
-      avlt.checkIsAVLT();
-      checkRemoved([3, 5, 10, 12, 15, 37]);
+      avlt.delete(10)
+      avlt.checkIsAVLT()
+      checkRemoved([3, 5, 10, 12, 15, 37])
 
-      avlt.delete(8);
-      avlt.checkIsAVLT();
-      checkRemoved([3, 5, 8, 10, 12, 15, 37]);
-    });
+      avlt.delete(8)
+      avlt.checkIsAVLT()
+      checkRemoved([3, 5, 8, 10, 12, 15, 37])
+    })
 
     it('Able to delete the root if it has only one child', function () {
-      var avlt;
+      let avlt
 
       // Root has only one child, on the left
       avlt = new AVLTree();
       [10, 5].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(2);
-      avlt.delete(10);
-      avlt.checkIsAVLT();
-      avlt.getNumberOfKeys().should.equal(1);
-      _.isEqual(avlt.search(5), ['some 5']).should.equal(true);
-      avlt.search(10).length.should.equal(0);
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(2)
+      avlt.delete(10)
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(1)
+      _.isEqual(avlt.search(5), ['some 5']).should.equal(true)
+      avlt.search(10).length.should.equal(0)
 
       // Root has only one child, on the right
       avlt = new AVLTree();
       [10, 15].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(2);
-      avlt.delete(10);
-      avlt.checkIsAVLT();
-      avlt.getNumberOfKeys().should.equal(1);
-      _.isEqual(avlt.search(15), ['some 15']).should.equal(true);
-      avlt.search(10).length.should.equal(0);
-    });
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(2)
+      avlt.delete(10)
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(1)
+      _.isEqual(avlt.search(15), ['some 15']).should.equal(true)
+      avlt.search(10).length.should.equal(0)
+    })
 
     it('Able to delete non root nodes that have only one child', function () {
-      var avlt = new AVLTree()
-        , firstSet = [10, 5, 15, 3, 1, 4, 20]
-        , secondSet = [10, 5, 15, 3, 1, 4, 20, 17, 25]
-        ;
+      let avlt = new AVLTree()
+      const firstSet = [10, 5, 15, 3, 1, 4, 20]
+      const secondSet = [10, 5, 15, 3, 1, 4, 20, 17, 25]
 
       // Check that only keys in array theRemoved were removed
       function checkRemoved (set, theRemoved) {
         set.forEach(function (k) {
           if (theRemoved.indexOf(k) !== -1) {
-            avlt.search(k).length.should.equal(0);
+            avlt.search(k).length.should.equal(0)
           } else {
-            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
           }
-        });
+        })
 
-        avlt.getNumberOfKeys().should.equal(set.length - theRemoved.length);
+        avlt.getNumberOfKeys().should.equal(set.length - theRemoved.length)
       }
 
       // First set: no rebalancing necessary
       firstSet.forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
+        avlt.insert(k, 'some ' + k)
+      })
 
-      avlt.getNumberOfKeys().should.equal(7);
-      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.checkIsAVLT()
 
-      avlt.delete(4);   // Leaf
-      avlt.checkIsAVLT();
-      checkRemoved(firstSet, [4]);
+      avlt.delete(4)   // Leaf
+      avlt.checkIsAVLT()
+      checkRemoved(firstSet, [4])
 
-      avlt.delete(3);   // Node with only one child (on the left)
-      avlt.checkIsAVLT();
-      checkRemoved(firstSet, [3, 4]);
+      avlt.delete(3)   // Node with only one child (on the left)
+      avlt.checkIsAVLT()
+      checkRemoved(firstSet, [3, 4])
 
-      avlt.delete(10);   // Leaf
-      avlt.checkIsAVLT();
-      checkRemoved(firstSet, [3, 4, 10]);
+      avlt.delete(10)   // Leaf
+      avlt.checkIsAVLT()
+      checkRemoved(firstSet, [3, 4, 10])
 
-      avlt.delete(15);   // Node with only one child (on the right)
-      avlt.checkIsAVLT();
-      checkRemoved(firstSet, [3, 4, 10, 15]);
+      avlt.delete(15)   // Node with only one child (on the right)
+      avlt.checkIsAVLT()
+      checkRemoved(firstSet, [3, 4, 10, 15])
 
       // Second set: some rebalancing necessary
-      avlt = new AVLTree();
+      avlt = new AVLTree()
       secondSet.forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
+        avlt.insert(k, 'some ' + k)
+      })
 
-      avlt.delete(4);   // Leaf
-      avlt.checkIsAVLT();
-      checkRemoved(secondSet, [4]);
+      avlt.delete(4)   // Leaf
+      avlt.checkIsAVLT()
+      checkRemoved(secondSet, [4])
 
-      avlt.delete(3);   // Node with only one child (on the left), causes rebalancing
-      avlt.checkIsAVLT();
-      checkRemoved(secondSet, [3, 4]);
-    });
+      avlt.delete(3)   // Node with only one child (on the left), causes rebalancing
+      avlt.checkIsAVLT()
+      checkRemoved(secondSet, [3, 4])
+    })
 
     it('Can delete the root if it has 2 children', function () {
-      var avlt = new AVLTree();
+      let avlt = new AVLTree()
 
       // No rebalancing needed
       [10, 5, 15, 3, 8, 12, 37].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(10);
-      avlt.checkIsAVLT();
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(10)
+      avlt.checkIsAVLT()
       avlt.getNumberOfKeys().should.equal(6);
       [5, 3, 8, 15, 12, 37].forEach(function (k) {
-        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
-      });
-      avlt.search(10).length.should.equal(0);
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
+      })
+      avlt.search(10).length.should.equal(0)
 
       // Rebalancing needed
       avlt = new AVLTree();
       [10, 5, 15, 8, 12, 37, 42].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(7);
-      avlt.delete(10);
-      avlt.checkIsAVLT();
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(7)
+      avlt.delete(10)
+      avlt.checkIsAVLT()
       avlt.getNumberOfKeys().should.equal(6);
       [5, 8, 15, 12, 37, 42].forEach(function (k) {
-        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
-      });
-      avlt.search(10).length.should.equal(0);
-    });
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
+      })
+      avlt.search(10).length.should.equal(0)
+    })
 
     it('Can delete a non-root node that has two children', function () {
-      var avlt;
+      let avlt
 
       // On the left
       avlt = new AVLTree();
       [10, 5, 15, 3, 8, 12, 20, 1, 4, 6, 9, 11, 13, 19, 42, 3.5].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(16);
-      avlt.delete(5);
-      avlt.checkIsAVLT();
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(16)
+      avlt.delete(5)
+      avlt.checkIsAVLT()
       avlt.getNumberOfKeys().should.equal(15);
       [10, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42, 3.5].forEach(function (k) {
-        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
-      });
-      avlt.search(5).length.should.equal(0);
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
+      })
+      avlt.search(5).length.should.equal(0)
 
       // On the right
       avlt = new AVLTree();
       [10, 5, 15, 3, 8, 12, 20, 1, 4, 6, 9, 11, 13, 19, 42, 12.5].forEach(function (k) {
-        avlt.insert(k, 'some ' + k);
-      });
-      avlt.getNumberOfKeys().should.equal(16);
-      avlt.delete(15);
-      avlt.checkIsAVLT();
+        avlt.insert(k, 'some ' + k)
+      })
+      avlt.getNumberOfKeys().should.equal(16)
+      avlt.delete(15)
+      avlt.checkIsAVLT()
       avlt.getNumberOfKeys().should.equal(15);
       [10, 3, 1, 4, 8, 6, 9, 5, 12, 11, 13, 20, 19, 42, 12.5].forEach(function (k) {
-        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
-      });
-      avlt.search(15).length.should.equal(0);
-    });
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true)
+      })
+      avlt.search(15).length.should.equal(0)
+    })
 
     it('If no value is provided, it will delete the entire node even if there are multiple pieces of data', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'yes');
-      avlt.insert(5, 'hello');
-      avlt.insert(3, 'yes');
-      avlt.insert(5, 'world');
-      avlt.insert(8, 'yes');
+      avlt.insert(10, 'yes')
+      avlt.insert(5, 'hello')
+      avlt.insert(3, 'yes')
+      avlt.insert(5, 'world')
+      avlt.insert(8, 'yes')
 
-      assert.deepEqual(avlt.search(5), ['hello', 'world']);
-      avlt.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(avlt.search(5), ['hello', 'world'])
+      avlt.getNumberOfKeys().should.equal(4)
 
-      avlt.delete(5);
-      avlt.checkIsAVLT();
-      avlt.search(5).length.should.equal(0);
-      avlt.getNumberOfKeys().should.equal(3);
-    });
+      avlt.delete(5)
+      avlt.checkIsAVLT()
+      avlt.search(5).length.should.equal(0)
+      avlt.getNumberOfKeys().should.equal(3)
+    })
 
     it('Can remove only one value from an array', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'yes');
-      avlt.insert(5, 'hello');
-      avlt.insert(3, 'yes');
-      avlt.insert(5, 'world');
-      avlt.insert(8, 'yes');
+      avlt.insert(10, 'yes')
+      avlt.insert(5, 'hello')
+      avlt.insert(3, 'yes')
+      avlt.insert(5, 'world')
+      avlt.insert(8, 'yes')
 
-      assert.deepEqual(avlt.search(5), ['hello', 'world']);
-      avlt.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(avlt.search(5), ['hello', 'world'])
+      avlt.getNumberOfKeys().should.equal(4)
 
-      avlt.delete(5, 'hello');
-      avlt.checkIsAVLT();
-      assert.deepEqual(avlt.search(5), ['world']);
-      avlt.getNumberOfKeys().should.equal(4);
-    });
+      avlt.delete(5, 'hello')
+      avlt.checkIsAVLT()
+      assert.deepEqual(avlt.search(5), ['world'])
+      avlt.getNumberOfKeys().should.equal(4)
+    })
 
     it('Removes nothing if value doesnt match', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'yes');
-      avlt.insert(5, 'hello');
-      avlt.insert(3, 'yes');
-      avlt.insert(5, 'world');
-      avlt.insert(8, 'yes');
+      avlt.insert(10, 'yes')
+      avlt.insert(5, 'hello')
+      avlt.insert(3, 'yes')
+      avlt.insert(5, 'world')
+      avlt.insert(8, 'yes')
 
-      assert.deepEqual(avlt.search(5), ['hello', 'world']);
-      avlt.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(avlt.search(5), ['hello', 'world'])
+      avlt.getNumberOfKeys().should.equal(4)
 
-      avlt.delete(5, 'nope');
-      avlt.checkIsAVLT();
-      assert.deepEqual(avlt.search(5), ['hello', 'world']);
-      avlt.getNumberOfKeys().should.equal(4);
-    });
+      avlt.delete(5, 'nope')
+      avlt.checkIsAVLT()
+      assert.deepEqual(avlt.search(5), ['hello', 'world'])
+      avlt.getNumberOfKeys().should.equal(4)
+    })
 
     it('If value provided but node contains only one value, remove entire node', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'yes');
-      avlt.insert(5, 'hello');
-      avlt.insert(3, 'yes2');
-      avlt.insert(5, 'world');
-      avlt.insert(8, 'yes3');
+      avlt.insert(10, 'yes')
+      avlt.insert(5, 'hello')
+      avlt.insert(3, 'yes2')
+      avlt.insert(5, 'world')
+      avlt.insert(8, 'yes3')
 
-      assert.deepEqual(avlt.search(3), ['yes2']);
-      avlt.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(avlt.search(3), ['yes2'])
+      avlt.getNumberOfKeys().should.equal(4)
 
-      avlt.delete(3, 'yes2');
-      avlt.checkIsAVLT();
-      avlt.search(3).length.should.equal(0);
-      avlt.getNumberOfKeys().should.equal(3);
-    });
+      avlt.delete(3, 'yes2')
+      avlt.checkIsAVLT()
+      avlt.search(3).length.should.equal(0)
+      avlt.getNumberOfKeys().should.equal(3)
+    })
 
     it('Can remove the root from a tree with height 2 when the root has two children (special case)', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'maybe');
-      avlt.insert(5, 'no');
-      avlt.insert(15, 'yes');
-      avlt.getNumberOfKeys().should.equal(3);
+      avlt.insert(10, 'maybe')
+      avlt.insert(5, 'no')
+      avlt.insert(15, 'yes')
+      avlt.getNumberOfKeys().should.equal(3)
 
-      avlt.delete(10);
-      avlt.checkIsAVLT();
-      avlt.getNumberOfKeys().should.equal(2);
-      assert.deepEqual(avlt.search(5), ['no']);
-      assert.deepEqual(avlt.search(15), ['yes']);
-    });
+      avlt.delete(10)
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(2)
+      assert.deepEqual(avlt.search(5), ['no'])
+      assert.deepEqual(avlt.search(15), ['yes'])
+    })
 
     it('Can remove the root from a tree with height 3 when the root has two children (special case where the two children themselves have children)', function () {
-      var avlt = new AVLTree();
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 'maybe');
-      avlt.insert(5, 'no');
-      avlt.insert(15, 'yes');
-      avlt.insert(2, 'no');
-      avlt.insert(35, 'yes');
-      avlt.getNumberOfKeys().should.equal(5);
+      avlt.insert(10, 'maybe')
+      avlt.insert(5, 'no')
+      avlt.insert(15, 'yes')
+      avlt.insert(2, 'no')
+      avlt.insert(35, 'yes')
+      avlt.getNumberOfKeys().should.equal(5)
 
-      avlt.delete(10);
-      avlt.checkIsAVLT();
-      avlt.getNumberOfKeys().should.equal(4);
-      assert.deepEqual(avlt.search(5), ['no']);
-      assert.deepEqual(avlt.search(15), ['yes']);
-    });
+      avlt.delete(10)
+      avlt.checkIsAVLT()
+      avlt.getNumberOfKeys().should.equal(4)
+      assert.deepEqual(avlt.search(5), ['no'])
+      assert.deepEqual(avlt.search(15), ['yes'])
+    })
 
-    it("Removing falsy values does not delete the entire key", function () {
-      var avlt = new AVLTree();
+    it('Removing falsy values does not delete the entire key', function () {
+      const avlt = new AVLTree()
 
-      avlt.insert(10, 2);
-      avlt.insert(10, 1);
-      assert.deepEqual(avlt.search(10), [2, 1]);
+      avlt.insert(10, 2)
+      avlt.insert(10, 1)
+      assert.deepEqual(avlt.search(10), [2, 1])
 
-      avlt.delete(10, 2);
-      assert.deepEqual(avlt.search(10), [1]);
+      avlt.delete(10, 2)
+      assert.deepEqual(avlt.search(10), [1])
 
-      avlt.insert(10, 0);
-      assert.deepEqual(avlt.search(10), [1, 0]);
+      avlt.insert(10, 0)
+      assert.deepEqual(avlt.search(10), [1, 0])
 
-      avlt.delete(10, 0);
-      assert.deepEqual(avlt.search(10), [1]);
-    });
+      avlt.delete(10, 0)
+      assert.deepEqual(avlt.search(10), [1])
+    })
 
-  });   // ==== End of 'Deletion' ==== //
-
+  })   // ==== End of 'Deletion' ==== //
 
   it('Can use undefined as key and value', function () {
     function compareKeys (a, b) {
-      if (a === undefined && b === undefined) { return 0; }
-      if (a === undefined) { return -1; }
-      if (b === undefined) { return 1; }
+      if (a === undefined && b === undefined) { return 0 }
+      if (a === undefined) { return -1 }
+      if (b === undefined) { return 1 }
 
-      if (a < b) { return -1; }
-      if (a > b) { return 1; }
-      if (a === b) { return 0; }
+      if (a < b) { return -1 }
+      if (a > b) { return 1 }
+      if (a === b) { return 0 }
     }
 
-    var avlt = new AVLTree({ compareKeys: compareKeys });
+    const avlt = new AVLTree({ compareKeys: compareKeys })
 
-    avlt.insert(2, undefined);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(undefined), []);
+    avlt.insert(2, undefined)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(undefined), [])
 
-    avlt.insert(undefined, 'hello');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(undefined), ['hello']);
+    avlt.insert(undefined, 'hello')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(undefined), ['hello'])
 
-    avlt.insert(undefined, 'world');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(undefined), ['hello', 'world']);
+    avlt.insert(undefined, 'world')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(undefined), ['hello', 'world'])
 
-    avlt.insert(4, undefined);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(4), [undefined]);
-    assert.deepEqual(avlt.search(undefined), ['hello', 'world']);
+    avlt.insert(4, undefined)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(4), [undefined])
+    assert.deepEqual(avlt.search(undefined), ['hello', 'world'])
 
-    avlt.delete(undefined, 'hello');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(4), [undefined]);
-    assert.deepEqual(avlt.search(undefined), ['world']);
+    avlt.delete(undefined, 'hello')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(4), [undefined])
+    assert.deepEqual(avlt.search(undefined), ['world'])
 
-    avlt.delete(undefined);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [undefined]);
-    assert.deepEqual(avlt.search(4), [undefined]);
-    assert.deepEqual(avlt.search(undefined), []);
+    avlt.delete(undefined)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [undefined])
+    assert.deepEqual(avlt.search(4), [undefined])
+    assert.deepEqual(avlt.search(undefined), [])
 
-    avlt.delete(2, undefined);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(avlt.search(2), []);
-    assert.deepEqual(avlt.search(4), [undefined]);
-    assert.deepEqual(avlt.search(undefined), []);
+    avlt.delete(2, undefined)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(avlt.search(2), [])
+    assert.deepEqual(avlt.search(4), [undefined])
+    assert.deepEqual(avlt.search(undefined), [])
 
-    avlt.delete(4);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(0);
-    assert.deepEqual(avlt.search(2), []);
-    assert.deepEqual(avlt.search(4), []);
-    assert.deepEqual(avlt.search(undefined), []);
-  });
-
+    avlt.delete(4)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(0)
+    assert.deepEqual(avlt.search(2), [])
+    assert.deepEqual(avlt.search(4), [])
+    assert.deepEqual(avlt.search(undefined), [])
+  })
 
   it('Can use null as key and value', function () {
     function compareKeys (a, b) {
-      if (a === null && b === null) { return 0; }
-      if (a === null) { return -1; }
-      if (b === null) { return 1; }
+      if (a === null && b === null) { return 0 }
+      if (a === null) { return -1 }
+      if (b === null) { return 1 }
 
-      if (a < b) { return -1; }
-      if (a > b) { return 1; }
-      if (a === b) { return 0; }
+      if (a < b) { return -1 }
+      if (a > b) { return 1 }
+      if (a === b) { return 0 }
     }
 
-    var avlt = new AVLTree({ compareKeys: compareKeys });
+    var avlt = new AVLTree({ compareKeys: compareKeys })
 
-    avlt.insert(2, null);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(null), []);
+    avlt.insert(2, null)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(null), [])
 
-    avlt.insert(null, 'hello');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(null), ['hello']);
+    avlt.insert(null, 'hello')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(null), ['hello'])
 
-    avlt.insert(null, 'world');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(null), ['hello', 'world']);
+    avlt.insert(null, 'world')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(null), ['hello', 'world'])
 
-    avlt.insert(4, null);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(4), [null]);
-    assert.deepEqual(avlt.search(null), ['hello', 'world']);
+    avlt.insert(4, null)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(4), [null])
+    assert.deepEqual(avlt.search(null), ['hello', 'world'])
 
-    avlt.delete(null, 'hello');
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(4), [null]);
-    assert.deepEqual(avlt.search(null), ['world']);
+    avlt.delete(null, 'hello')
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(4), [null])
+    assert.deepEqual(avlt.search(null), ['world'])
 
-    avlt.delete(null);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(avlt.search(2), [null]);
-    assert.deepEqual(avlt.search(4), [null]);
-    assert.deepEqual(avlt.search(null), []);
+    avlt.delete(null)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(avlt.search(2), [null])
+    assert.deepEqual(avlt.search(4), [null])
+    assert.deepEqual(avlt.search(null), [])
 
-    avlt.delete(2, null);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(avlt.search(2), []);
-    assert.deepEqual(avlt.search(4), [null]);
-    assert.deepEqual(avlt.search(null), []);
+    avlt.delete(2, null)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(avlt.search(2), [])
+    assert.deepEqual(avlt.search(4), [null])
+    assert.deepEqual(avlt.search(null), [])
 
-    avlt.delete(4);
-    avlt.checkIsAVLT();
-    avlt.getNumberOfKeys().should.equal(0);
-    assert.deepEqual(avlt.search(2), []);
-    assert.deepEqual(avlt.search(4), []);
-    assert.deepEqual(avlt.search(null), []);
-  });
-
+    avlt.delete(4)
+    avlt.checkIsAVLT()
+    avlt.getNumberOfKeys().should.equal(0)
+    assert.deepEqual(avlt.search(2), [])
+    assert.deepEqual(avlt.search(4), [])
+    assert.deepEqual(avlt.search(null), [])
+  })
 
   describe('Execute on every node (=tree traversal)', function () {
 
     it('Can execute a function on every node', function () {
-      var avlt = new AVLTree()
-        , keys = []
-        , executed = 0
-        ;
+      const avlt = new AVLTree()
+      const keys = []
+      let executed = 0
 
-      avlt.insert(10, 'yes');
-      avlt.insert(5, 'hello');
-      avlt.insert(3, 'yes2');
-      avlt.insert(8, 'yes3');
-      avlt.insert(15, 'yes3');
-      avlt.insert(159, 'yes3');
-      avlt.insert(11, 'yes3');
+      avlt.insert(10, 'yes')
+      avlt.insert(5, 'hello')
+      avlt.insert(3, 'yes2')
+      avlt.insert(8, 'yes3')
+      avlt.insert(15, 'yes3')
+      avlt.insert(159, 'yes3')
+      avlt.insert(11, 'yes3')
 
       avlt.executeOnEveryNode(function (node) {
-        keys.push(node.key);
-        executed += 1;
-      });
+        keys.push(node.key)
+        executed += 1
+      })
 
-      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159]);
-      executed.should.equal(7);
-    });
+      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159])
+      executed.should.equal(7)
+    })
 
-  });   // ==== End of 'Execute on every node' ==== //
-
+  })   // ==== End of 'Execute on every node' ==== //
 
   // This test performs several inserts and deletes at random, always checking the content
   // of the tree are as expected and the binary search tree constraint is respected
@@ -1012,83 +1011,83 @@ describe('AVL tree', function () {
   // By their nature, BSTs can be hard to test (many possible cases, bug at one operation whose
   // effect begins to be felt only after several operations etc.)
   describe('Randomized test (takes much longer than the rest of the test suite)', function () {
-    var avlt = new AVLTree()
-      , data = {};
+    const avlt = new AVLTree()
+    const data = {}
 
     // Check a avlt against a simple key => [data] object
     function checkDataIsTheSame (avlt, data) {
-      var avltDataElems = [];
+      const avltDataElems = []
 
       // avltDataElems is a simple array containing every piece of data in the tree
       avlt.executeOnEveryNode(function (node) {
-        var i;
+        let i
         for (i = 0; i < node.data.length; i += 1) {
-          avltDataElems.push(node.data[i]);
+          avltDataElems.push(node.data[i])
         }
-      });
+      })
 
       // Number of key and number of pieces of data match
-      avlt.getNumberOfKeys().should.equal(Object.keys(data).length);
-      _.reduce(_.map(data, function (d) { return d.length; }), function (memo, n) { return memo + n; }, 0).should.equal(avltDataElems.length);
+      avlt.getNumberOfKeys().should.equal(Object.keys(data).length)
+      _.reduce(_.map(data, function (d) { return d.length }), function (memo, n) { return memo + n }, 0).should.equal(avltDataElems.length)
 
       // Compare data
       Object.keys(data).forEach(function (key) {
-        checkDataEquality(avlt.search(key), data[key]);
-      });
+        checkDataEquality(avlt.search(key), data[key])
+      })
     }
 
     // Check two pieces of data coming from the avlt and data are the same
     function checkDataEquality (fromavlt, fromData) {
       if (fromavlt.length === 0) {
-        if (fromData) { fromData.length.should.equal(0); }
+        if (fromData) { fromData.length.should.equal(0) }
       }
 
-      assert.deepEqual(fromavlt, fromData);
+      assert.deepEqual(fromavlt, fromData)
     }
 
     // Tests the tree structure (deletions concern the whole tree, deletion of some data in a node is well tested above)
     it('Inserting and deleting entire nodes', function () {
       // You can skew to be more insertive or deletive, to test all cases
       function launchRandomTest (nTests, proba) {
-        var i, key, dataPiece, possibleKeys;
+        let i, key, dataPiece, possibleKeys
 
         for (i = 0; i < nTests; i += 1) {
           if (Math.random() > proba) {   // Deletion
-            possibleKeys = Object.keys(data);
+            possibleKeys = Object.keys(data)
 
             if (possibleKeys.length > 0) {
-              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()];
+              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()]
             } else {
-              key = Math.floor(70 * Math.random()).toString();
+              key = Math.floor(70 * Math.random()).toString()
             }
 
-            delete data[key];
-            avlt.delete(key);
+            delete data[key]
+            avlt.delete(key)
           } else {   // Insertion
-            key = Math.floor(70 * Math.random()).toString();
-            dataPiece = Math.random().toString().substring(0, 6);
+            key = Math.floor(70 * Math.random()).toString()
+            dataPiece = Math.random().toString().substring(0, 6)
 
-            avlt.insert(key, dataPiece);
+            avlt.insert(key, dataPiece)
             if (data[key]) {
-              data[key].push(dataPiece);
+              data[key].push(dataPiece)
             } else {
-              data[key] = [dataPiece];
+              data[key] = [dataPiece]
             }
           }
 
           // Check the avlt constraint are still met and the data is correct
-          avlt.checkIsAVLT();
-          checkDataIsTheSame(avlt, data);
+          avlt.checkIsAVLT()
+          checkDataIsTheSame(avlt, data)
         }
       }
 
-      launchRandomTest(1000, 0.65);
-      launchRandomTest(2000, 0.35);
-    });
+      launchRandomTest(1000, 0.65)
+      launchRandomTest(2000, 0.35)
+    })
 
-  });   // ==== End of 'Randomized test' ==== //
+  })   // ==== End of 'Randomized test' ==== //
 
-});
+})
 
 
 

--- a/test/avltree.test.js
+++ b/test/avltree.test.js
@@ -1,0 +1,1100 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , AVLTree = require('../src/binarySearchTree/avltree')
+  , _ = require('underscore')
+  , customUtils = require('../src/binarySearchTree/customUtils')
+  ;
+
+
+describe('AVL tree', function () {
+
+  describe('Sanity checks', function () {
+
+    it('Checking that all nodes heights are correct', function () {
+      var _AVLTree = AVLTree._AVLTree
+        , avlt = new _AVLTree({ key: 10 })
+        , l = new _AVLTree({ key: 5 })
+        , r = new _AVLTree({ key: 15 })
+        , ll = new _AVLTree({ key: 3 })
+        , lr = new _AVLTree({ key: 8 })
+        , rl = new _AVLTree({ key: 13 })
+        , rr = new _AVLTree({ key: 18 })
+        , lrl = new _AVLTree({ key: 7 })
+        , lrll = new _AVLTree({ key: 6 })
+        ;
+
+
+      // With a balanced tree
+      avlt.left = l;
+      avlt.right = r;
+      l.left = ll;
+      l.right = lr;
+      r.left = rl;
+      r.right = rr;
+
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      avlt.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      l.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      r.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      ll.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lr.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      rl.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      rr.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      avlt.height = 2;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      l.height = 2;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      r.height = 2;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      avlt.height = 3;
+      avlt.checkHeightCorrect();   // Correct
+
+      // With an unbalanced tree
+      lr.left = lrl;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lrl.left = lrll;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lrl.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lrll.height = 1;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lrl.height = 2;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      lr.height = 3;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      l.height = 4;
+      (function () { avlt.checkHeightCorrect() }).should.throw();
+      avlt.height = 5;
+      avlt.checkHeightCorrect();   // Correct
+    });
+
+    it('Calculate the balance factor', function () {
+      var _AVLTree = AVLTree._AVLTree
+        , avlt = new _AVLTree({ key: 10 })
+        , l = new _AVLTree({ key: 5 })
+        , r = new _AVLTree({ key: 15 })
+        , ll = new _AVLTree({ key: 3 })
+        , lr = new _AVLTree({ key: 8 })
+        , rl = new _AVLTree({ key: 13 })
+        , rr = new _AVLTree({ key: 18 })
+        , lrl = new _AVLTree({ key: 7 })
+        , lrll = new _AVLTree({ key: 6 })
+        ;
+
+
+      // With a balanced tree
+      avlt.left = l;
+      avlt.right = r;
+      l.left = ll;
+      l.right = lr;
+      r.left = rl;
+      r.right = rr;
+
+      ll.height = 1;
+      rl.height = 1;
+      rr.height = 1;
+      avlt.height = 2;
+      r.height = 2;
+      lr.left = lrl;
+      lrl.left = lrll;
+      lrl.height = 1;
+      lrll.height = 1;
+      lrl.height = 2;
+      lr.height = 3;
+      l.height = 4;
+      avlt.height = 5;
+      avlt.checkHeightCorrect();   // Correct
+
+      lrll.balanceFactor().should.equal(0);
+      lrl.balanceFactor().should.equal(1);
+      ll.balanceFactor().should.equal(0);
+      lr.balanceFactor().should.equal(2);
+      rl.balanceFactor().should.equal(0);
+      rr.balanceFactor().should.equal(0);
+      l.balanceFactor().should.equal(-2);
+      r.balanceFactor().should.equal(0);
+      avlt.balanceFactor().should.equal(2);
+    });
+
+    it('Can check that a tree is balanced', function () {
+      var _AVLTree = AVLTree._AVLTree
+        , avlt = new _AVLTree({ key: 10 })
+        , l = new _AVLTree({ key: 5 })
+        , r = new _AVLTree({ key: 15 })
+        , ll = new _AVLTree({ key: 3 })
+        , lr = new _AVLTree({ key: 8 })
+        , rl = new _AVLTree({ key: 13 })
+        , rr = new _AVLTree({ key: 18 })
+
+      avlt.left = l;
+      avlt.right = r;
+      l.left = ll;
+      l.right = lr;
+      r.left = rl;
+      r.right = rr;
+
+      ll.height = 1;
+      lr.height = 1;
+      rl.height = 1;
+      rr.height = 1;
+      l.height = 2;
+      r.height = 2;
+      avlt.height = 3;
+      avlt.checkBalanceFactors();
+
+      r.height = 0;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      r.height = 4;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      r.height = 2;
+      avlt.checkBalanceFactors();
+
+      ll.height = -1;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      ll.height = 3;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      ll.height = 1;
+      avlt.checkBalanceFactors();
+
+      rl.height = -1;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      rl.height = 3;
+      (function () { avlt.checkBalanceFactors(); }).should.throw();
+      rl.height = 1;
+      avlt.checkBalanceFactors();
+    });
+
+  });   // ==== End of 'Sanity checks' ==== //
+
+
+  describe('Insertion', function () {
+
+    it('The root has a height of 1', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'root');
+      avlt.tree.height.should.equal(1);
+    });
+
+
+    it('Insert at the root if its the first insertion', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'some data');
+
+      avlt.checkIsAVLT();
+      avlt.tree.key.should.equal(10);
+      _.isEqual(avlt.tree.data, ['some data']).should.equal(true);
+      assert.isNull(avlt.tree.left);
+      assert.isNull(avlt.tree.right);
+    });
+
+    it('If uniqueness constraint not enforced, we can insert different data for same key', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'some data');
+      avlt.insert(3, 'hello');
+      avlt.insert(3, 'world');
+
+      avlt.checkIsAVLT();
+      _.isEqual(avlt.search(3), ['hello', 'world']).should.equal(true);
+
+      avlt.insert(12, 'a');
+      avlt.insert(12, 'b');
+
+      avlt.checkIsAVLT();
+      _.isEqual(avlt.search(12), ['a', 'b']).should.equal(true);
+    });
+
+    it('If uniqueness constraint is enforced, we cannot insert different data for same key', function () {
+      var avlt = new AVLTree({ unique: true });
+
+      avlt.insert(10, 'some data');
+      avlt.insert(3, 'hello');
+      try {
+        avlt.insert(3, 'world');
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+        e.key.should.equal(3);
+      }
+
+      avlt.checkIsAVLT();
+      _.isEqual(avlt.search(3), ['hello']).should.equal(true);
+
+      avlt.insert(12, 'a');
+      try {
+        avlt.insert(12, 'world');
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+        e.key.should.equal(12);
+      }
+
+      avlt.checkIsAVLT();
+      _.isEqual(avlt.search(12), ['a']).should.equal(true);
+    });
+
+    it('Can insert 0 or the empty string', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(0, 'some data');
+
+      avlt.checkIsAVLT();
+      avlt.tree.key.should.equal(0);
+      _.isEqual(avlt.tree.data, ['some data']).should.equal(true);
+
+      avlt = new AVLTree();
+
+      avlt.insert('', 'some other data');
+
+      avlt.checkIsAVLT();
+      avlt.tree.key.should.equal('');
+      _.isEqual(avlt.tree.data, ['some other data']).should.equal(true);
+    });
+
+    it('Auto-balancing insertions', function () {
+      var avlt = new AVLTree()
+        , avlt2 = new AVLTree()
+        , avlt3 = new AVLTree()
+        ;
+
+      // Balancing insertions on the left
+      avlt.tree.getNumberOfKeys().should.equal(0);
+      avlt.insert(18);
+      avlt.tree.getNumberOfKeys().should.equal(1);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(15);
+      avlt.tree.getNumberOfKeys().should.equal(2);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(13);
+      avlt.tree.getNumberOfKeys().should.equal(3);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(10);
+      avlt.tree.getNumberOfKeys().should.equal(4);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(8);
+      avlt.tree.getNumberOfKeys().should.equal(5);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(5);
+      avlt.tree.getNumberOfKeys().should.equal(6);
+      avlt.tree.checkIsAVLT();
+      avlt.insert(3);
+      avlt.tree.getNumberOfKeys().should.equal(7);
+      avlt.tree.checkIsAVLT();
+
+      // Balancing insertions on the right
+      avlt2.tree.getNumberOfKeys().should.equal(0);
+      avlt2.insert(3);
+      avlt2.tree.getNumberOfKeys().should.equal(1);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(5);
+      avlt2.tree.getNumberOfKeys().should.equal(2);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(8);
+      avlt2.tree.getNumberOfKeys().should.equal(3);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(10);
+      avlt2.tree.getNumberOfKeys().should.equal(4);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(13);
+      avlt2.tree.getNumberOfKeys().should.equal(5);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(15);
+      avlt2.tree.getNumberOfKeys().should.equal(6);
+      avlt2.tree.checkIsAVLT();
+      avlt2.insert(18);
+      avlt2.tree.getNumberOfKeys().should.equal(7);
+      avlt2.tree.checkIsAVLT();
+
+      // Balancing already-balanced insertions
+      avlt3.tree.getNumberOfKeys().should.equal(0);
+      avlt3.insert(10);
+      avlt3.tree.getNumberOfKeys().should.equal(1);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(5);
+      avlt3.tree.getNumberOfKeys().should.equal(2);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(15);
+      avlt3.tree.getNumberOfKeys().should.equal(3);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(3);
+      avlt3.tree.getNumberOfKeys().should.equal(4);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(8);
+      avlt3.tree.getNumberOfKeys().should.equal(5);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(13);
+      avlt3.tree.getNumberOfKeys().should.equal(6);
+      avlt3.tree.checkIsAVLT();
+      avlt3.insert(18);
+      avlt3.tree.getNumberOfKeys().should.equal(7);
+      avlt3.tree.checkIsAVLT();
+    });
+
+    it('Can insert a lot of keys and still get an AVLT (sanity check)', function () {
+      var avlt = new AVLTree({ unique: true });
+
+      customUtils.getRandomArray(1000).forEach(function (n) {
+        avlt.insert(n, 'some data');
+        avlt.checkIsAVLT();
+      });
+
+    });
+
+  });   // ==== End of 'Insertion' ==== //
+
+
+  describe('Search', function () {
+
+    it('Can find data in an AVLT', function () {
+      var avlt = new AVLTree()
+        , i;
+
+      customUtils.getRandomArray(100).forEach(function (n) {
+        avlt.insert(n, 'some data for ' + n);
+      });
+
+      avlt.checkIsAVLT();
+
+      for (i = 0; i < 100; i += 1) {
+        _.isEqual(avlt.search(i), ['some data for ' + i]).should.equal(true);
+      }
+    });
+
+    it('If no data can be found, return an empty array', function () {
+      var avlt = new AVLTree();
+
+      customUtils.getRandomArray(100).forEach(function (n) {
+        if (n !== 63) {
+          avlt.insert(n, 'some data for ' + n);
+        }
+      });
+
+      avlt.checkIsAVLT();
+
+      avlt.search(-2).length.should.equal(0);
+      avlt.search(100).length.should.equal(0);
+      avlt.search(101).length.should.equal(0);
+      avlt.search(63).length.should.equal(0);
+    });
+
+    it('Can search for data between two bounds', function () {
+      var avlt = new AVLTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        avlt.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+      assert.deepEqual(avlt.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13']);
+    });
+
+    it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
+      var avlt = new AVLTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        avlt.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(avlt.betweenBounds({ $gt:8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+      assert.deepEqual(avlt.betweenBounds({ $gt:5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+      assert.deepEqual(avlt.betweenBounds({ $gt:8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
+      assert.deepEqual(avlt.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+    });
+
+    it('Bounded search can work when one or both boundaries are missing', function () {
+      var avlt = new AVLTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        avlt.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(avlt.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18']);
+      assert.deepEqual(avlt.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8']);
+    });
+
+  });   /// ==== End of 'Search' ==== //
+
+
+  describe('Deletion', function () {
+
+    it('Deletion does nothing on an empty tree', function () {
+      var avlt = new AVLTree()
+        , avltu = new AVLTree({ unique: true });
+
+      avlt.getNumberOfKeys().should.equal(0);
+      avltu.getNumberOfKeys().should.equal(0);
+
+      avlt.delete(5);
+      avltu.delete(5);
+
+      avlt.tree.hasOwnProperty('key').should.equal(false);
+      avltu.tree.hasOwnProperty('key').should.equal(false);
+
+      avlt.tree.data.length.should.equal(0);
+      avltu.tree.data.length.should.equal(0);
+
+      avlt.getNumberOfKeys().should.equal(0);
+      avltu.getNumberOfKeys().should.equal(0);
+    });
+
+    it('Deleting a non-existent key doesnt have any effect', function () {
+      var avlt = new AVLTree();
+
+      [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+
+      function checkavlt () {
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+        });
+      }
+
+      checkavlt();
+      avlt.getNumberOfKeys().should.equal(7);
+
+      avlt.delete(2);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(4);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(9);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(6);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(11);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(14);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(20);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(200);
+      checkavlt(); avlt.checkIsAVLT(); avlt.getNumberOfKeys().should.equal(7);
+    });
+
+    it('Able to delete the root if it is also a leaf', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'hello');
+      avlt.tree.key.should.equal(10);
+      _.isEqual(avlt.tree.data, ['hello']).should.equal(true);
+      avlt.getNumberOfKeys().should.equal(1);
+
+      avlt.delete(10);
+      avlt.tree.hasOwnProperty('key').should.equal(false);
+      avlt.tree.data.length.should.equal(0);
+      avlt.getNumberOfKeys().should.equal(0);
+    });
+
+    it('Able to delete leaf nodes that are non-root', function () {
+      var avlt;
+
+      // This will create an AVL tree with leaves 3, 8, 12, 37
+      // (do a pretty print to see this)
+      function recreateavlt () {
+        avlt = new AVLTree();
+
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          avlt.insert(k, 'some ' + k);
+        });
+
+        avlt.getNumberOfKeys().should.equal(7);
+      }
+
+      // Check that only keys in array theRemoved were removed
+      function checkRemoved (theRemoved) {
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          if (theRemoved.indexOf(k) !== -1) {
+            avlt.search(k).length.should.equal(0);
+          } else {
+            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+          }
+        });
+
+        avlt.getNumberOfKeys().should.equal(7 - theRemoved.length);
+      }
+
+      recreateavlt();
+      avlt.delete(3);
+      avlt.checkIsAVLT();
+      checkRemoved([3]);
+
+      recreateavlt();
+      avlt.delete(8);
+      avlt.checkIsAVLT();
+      checkRemoved([8]);
+
+      recreateavlt();
+      avlt.delete(12);
+      avlt.checkIsAVLT();
+      checkRemoved([12]);
+
+      // Delete all leaves in a way that makes the tree unbalanced
+      recreateavlt();
+      avlt.delete(37);
+      avlt.checkIsAVLT();
+      checkRemoved([37]);
+
+      avlt.delete(12);
+      avlt.checkIsAVLT();
+      checkRemoved([12, 37]);
+
+      avlt.delete(15);
+      avlt.checkIsAVLT();
+      checkRemoved([12, 15, 37]);
+
+      avlt.delete(3);
+      avlt.checkIsAVLT();
+      checkRemoved([3, 12, 15, 37]);
+
+      avlt.delete(5);
+      avlt.checkIsAVLT();
+      checkRemoved([3, 5, 12, 15, 37]);
+
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      checkRemoved([3, 5, 10, 12, 15, 37]);
+
+      avlt.delete(8);
+      avlt.checkIsAVLT();
+      checkRemoved([3, 5, 8, 10, 12, 15, 37]);
+    });
+
+    it('Able to delete the root if it has only one child', function () {
+      var avlt;
+
+      // Root has only one child, on the left
+      avlt = new AVLTree();
+      [10, 5].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(2);
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(1);
+      _.isEqual(avlt.search(5), ['some 5']).should.equal(true);
+      avlt.search(10).length.should.equal(0);
+
+      // Root has only one child, on the right
+      avlt = new AVLTree();
+      [10, 15].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(2);
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(1);
+      _.isEqual(avlt.search(15), ['some 15']).should.equal(true);
+      avlt.search(10).length.should.equal(0);
+    });
+
+    it('Able to delete non root nodes that have only one child', function () {
+      var avlt = new AVLTree()
+        , firstSet = [10, 5, 15, 3, 1, 4, 20]
+        , secondSet = [10, 5, 15, 3, 1, 4, 20, 17, 25]
+        ;
+
+      // Check that only keys in array theRemoved were removed
+      function checkRemoved (set, theRemoved) {
+        set.forEach(function (k) {
+          if (theRemoved.indexOf(k) !== -1) {
+            avlt.search(k).length.should.equal(0);
+          } else {
+            _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+          }
+        });
+
+        avlt.getNumberOfKeys().should.equal(set.length - theRemoved.length);
+      }
+
+      // First set: no rebalancing necessary
+      firstSet.forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+
+      avlt.getNumberOfKeys().should.equal(7);
+      avlt.checkIsAVLT();
+
+      avlt.delete(4);   // Leaf
+      avlt.checkIsAVLT();
+      checkRemoved(firstSet, [4]);
+
+      avlt.delete(3);   // Node with only one child (on the left)
+      avlt.checkIsAVLT();
+      checkRemoved(firstSet, [3, 4]);
+
+      avlt.delete(10);   // Leaf
+      avlt.checkIsAVLT();
+      checkRemoved(firstSet, [3, 4, 10]);
+
+      avlt.delete(15);   // Node with only one child (on the right)
+      avlt.checkIsAVLT();
+      checkRemoved(firstSet, [3, 4, 10, 15]);
+
+      // Second set: some rebalancing necessary
+      avlt = new AVLTree();
+      secondSet.forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+
+      avlt.delete(4);   // Leaf
+      avlt.checkIsAVLT();
+      checkRemoved(secondSet, [4]);
+
+      avlt.delete(3);   // Node with only one child (on the left), causes rebalancing
+      avlt.checkIsAVLT();
+      checkRemoved(secondSet, [3, 4]);
+    });
+
+    it('Can delete the root if it has 2 children', function () {
+      var avlt = new AVLTree();
+
+      // No rebalancing needed
+      [10, 5, 15, 3, 8, 12, 37].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(6);
+      [5, 3, 8, 15, 12, 37].forEach(function (k) {
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+      });
+      avlt.search(10).length.should.equal(0);
+
+      // Rebalancing needed
+      avlt = new AVLTree();
+      [10, 5, 15, 8, 12, 37, 42].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(7);
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(6);
+      [5, 8, 15, 12, 37, 42].forEach(function (k) {
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+      });
+      avlt.search(10).length.should.equal(0);
+    });
+
+    it('Can delete a non-root node that has two children', function () {
+      var avlt;
+
+      // On the left
+      avlt = new AVLTree();
+      [10, 5, 15, 3, 8, 12, 20, 1, 4, 6, 9, 11, 13, 19, 42, 3.5].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(16);
+      avlt.delete(5);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(15);
+      [10, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42, 3.5].forEach(function (k) {
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+      });
+      avlt.search(5).length.should.equal(0);
+
+      // On the right
+      avlt = new AVLTree();
+      [10, 5, 15, 3, 8, 12, 20, 1, 4, 6, 9, 11, 13, 19, 42, 12.5].forEach(function (k) {
+        avlt.insert(k, 'some ' + k);
+      });
+      avlt.getNumberOfKeys().should.equal(16);
+      avlt.delete(15);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(15);
+      [10, 3, 1, 4, 8, 6, 9, 5, 12, 11, 13, 20, 19, 42, 12.5].forEach(function (k) {
+        _.isEqual(avlt.search(k), ['some ' + k]).should.equal(true);
+      });
+      avlt.search(15).length.should.equal(0);
+    });
+
+    it('If no value is provided, it will delete the entire node even if there are multiple pieces of data', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'yes');
+      avlt.insert(5, 'hello');
+      avlt.insert(3, 'yes');
+      avlt.insert(5, 'world');
+      avlt.insert(8, 'yes');
+
+      assert.deepEqual(avlt.search(5), ['hello', 'world']);
+      avlt.getNumberOfKeys().should.equal(4);
+
+      avlt.delete(5);
+      avlt.checkIsAVLT();
+      avlt.search(5).length.should.equal(0);
+      avlt.getNumberOfKeys().should.equal(3);
+    });
+
+    it('Can remove only one value from an array', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'yes');
+      avlt.insert(5, 'hello');
+      avlt.insert(3, 'yes');
+      avlt.insert(5, 'world');
+      avlt.insert(8, 'yes');
+
+      assert.deepEqual(avlt.search(5), ['hello', 'world']);
+      avlt.getNumberOfKeys().should.equal(4);
+
+      avlt.delete(5, 'hello');
+      avlt.checkIsAVLT();
+      assert.deepEqual(avlt.search(5), ['world']);
+      avlt.getNumberOfKeys().should.equal(4);
+    });
+
+    it('Removes nothing if value doesnt match', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'yes');
+      avlt.insert(5, 'hello');
+      avlt.insert(3, 'yes');
+      avlt.insert(5, 'world');
+      avlt.insert(8, 'yes');
+
+      assert.deepEqual(avlt.search(5), ['hello', 'world']);
+      avlt.getNumberOfKeys().should.equal(4);
+
+      avlt.delete(5, 'nope');
+      avlt.checkIsAVLT();
+      assert.deepEqual(avlt.search(5), ['hello', 'world']);
+      avlt.getNumberOfKeys().should.equal(4);
+    });
+
+    it('If value provided but node contains only one value, remove entire node', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'yes');
+      avlt.insert(5, 'hello');
+      avlt.insert(3, 'yes2');
+      avlt.insert(5, 'world');
+      avlt.insert(8, 'yes3');
+
+      assert.deepEqual(avlt.search(3), ['yes2']);
+      avlt.getNumberOfKeys().should.equal(4);
+
+      avlt.delete(3, 'yes2');
+      avlt.checkIsAVLT();
+      avlt.search(3).length.should.equal(0);
+      avlt.getNumberOfKeys().should.equal(3);
+    });
+
+    it('Can remove the root from a tree with height 2 when the root has two children (special case)', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'maybe');
+      avlt.insert(5, 'no');
+      avlt.insert(15, 'yes');
+      avlt.getNumberOfKeys().should.equal(3);
+
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(2);
+      assert.deepEqual(avlt.search(5), ['no']);
+      assert.deepEqual(avlt.search(15), ['yes']);
+    });
+
+    it('Can remove the root from a tree with height 3 when the root has two children (special case where the two children themselves have children)', function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 'maybe');
+      avlt.insert(5, 'no');
+      avlt.insert(15, 'yes');
+      avlt.insert(2, 'no');
+      avlt.insert(35, 'yes');
+      avlt.getNumberOfKeys().should.equal(5);
+
+      avlt.delete(10);
+      avlt.checkIsAVLT();
+      avlt.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(avlt.search(5), ['no']);
+      assert.deepEqual(avlt.search(15), ['yes']);
+    });
+
+    it("Removing falsy values does not delete the entire key", function () {
+      var avlt = new AVLTree();
+
+      avlt.insert(10, 2);
+      avlt.insert(10, 1);
+      assert.deepEqual(avlt.search(10), [2, 1]);
+
+      avlt.delete(10, 2);
+      assert.deepEqual(avlt.search(10), [1]);
+
+      avlt.insert(10, 0);
+      assert.deepEqual(avlt.search(10), [1, 0]);
+
+      avlt.delete(10, 0);
+      assert.deepEqual(avlt.search(10), [1]);
+    });
+
+  });   // ==== End of 'Deletion' ==== //
+
+
+  it('Can use undefined as key and value', function () {
+    function compareKeys (a, b) {
+      if (a === undefined && b === undefined) { return 0; }
+      if (a === undefined) { return -1; }
+      if (b === undefined) { return 1; }
+
+      if (a < b) { return -1; }
+      if (a > b) { return 1; }
+      if (a === b) { return 0; }
+    }
+
+    var avlt = new AVLTree({ compareKeys: compareKeys });
+
+    avlt.insert(2, undefined);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(undefined), []);
+
+    avlt.insert(undefined, 'hello');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(undefined), ['hello']);
+
+    avlt.insert(undefined, 'world');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(undefined), ['hello', 'world']);
+
+    avlt.insert(4, undefined);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(4), [undefined]);
+    assert.deepEqual(avlt.search(undefined), ['hello', 'world']);
+
+    avlt.delete(undefined, 'hello');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(4), [undefined]);
+    assert.deepEqual(avlt.search(undefined), ['world']);
+
+    avlt.delete(undefined);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [undefined]);
+    assert.deepEqual(avlt.search(4), [undefined]);
+    assert.deepEqual(avlt.search(undefined), []);
+
+    avlt.delete(2, undefined);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(avlt.search(2), []);
+    assert.deepEqual(avlt.search(4), [undefined]);
+    assert.deepEqual(avlt.search(undefined), []);
+
+    avlt.delete(4);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(0);
+    assert.deepEqual(avlt.search(2), []);
+    assert.deepEqual(avlt.search(4), []);
+    assert.deepEqual(avlt.search(undefined), []);
+  });
+
+
+  it('Can use null as key and value', function () {
+    function compareKeys (a, b) {
+      if (a === null && b === null) { return 0; }
+      if (a === null) { return -1; }
+      if (b === null) { return 1; }
+
+      if (a < b) { return -1; }
+      if (a > b) { return 1; }
+      if (a === b) { return 0; }
+    }
+
+    var avlt = new AVLTree({ compareKeys: compareKeys });
+
+    avlt.insert(2, null);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(null), []);
+
+    avlt.insert(null, 'hello');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(null), ['hello']);
+
+    avlt.insert(null, 'world');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(null), ['hello', 'world']);
+
+    avlt.insert(4, null);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(4), [null]);
+    assert.deepEqual(avlt.search(null), ['hello', 'world']);
+
+    avlt.delete(null, 'hello');
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(4), [null]);
+    assert.deepEqual(avlt.search(null), ['world']);
+
+    avlt.delete(null);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(avlt.search(2), [null]);
+    assert.deepEqual(avlt.search(4), [null]);
+    assert.deepEqual(avlt.search(null), []);
+
+    avlt.delete(2, null);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(avlt.search(2), []);
+    assert.deepEqual(avlt.search(4), [null]);
+    assert.deepEqual(avlt.search(null), []);
+
+    avlt.delete(4);
+    avlt.checkIsAVLT();
+    avlt.getNumberOfKeys().should.equal(0);
+    assert.deepEqual(avlt.search(2), []);
+    assert.deepEqual(avlt.search(4), []);
+    assert.deepEqual(avlt.search(null), []);
+  });
+
+
+  describe('Execute on every node (=tree traversal)', function () {
+
+    it('Can execute a function on every node', function () {
+      var avlt = new AVLTree()
+        , keys = []
+        , executed = 0
+        ;
+
+      avlt.insert(10, 'yes');
+      avlt.insert(5, 'hello');
+      avlt.insert(3, 'yes2');
+      avlt.insert(8, 'yes3');
+      avlt.insert(15, 'yes3');
+      avlt.insert(159, 'yes3');
+      avlt.insert(11, 'yes3');
+
+      avlt.executeOnEveryNode(function (node) {
+        keys.push(node.key);
+        executed += 1;
+      });
+
+      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159]);
+      executed.should.equal(7);
+    });
+
+  });   // ==== End of 'Execute on every node' ==== //
+
+
+  // This test performs several inserts and deletes at random, always checking the content
+  // of the tree are as expected and the binary search tree constraint is respected
+  // This test is important because it can catch bugs other tests can't
+  // By their nature, BSTs can be hard to test (many possible cases, bug at one operation whose
+  // effect begins to be felt only after several operations etc.)
+  describe('Randomized test (takes much longer than the rest of the test suite)', function () {
+    var avlt = new AVLTree()
+      , data = {};
+
+    // Check a avlt against a simple key => [data] object
+    function checkDataIsTheSame (avlt, data) {
+      var avltDataElems = [];
+
+      // avltDataElems is a simple array containing every piece of data in the tree
+      avlt.executeOnEveryNode(function (node) {
+        var i;
+        for (i = 0; i < node.data.length; i += 1) {
+          avltDataElems.push(node.data[i]);
+        }
+      });
+
+      // Number of key and number of pieces of data match
+      avlt.getNumberOfKeys().should.equal(Object.keys(data).length);
+      _.reduce(_.map(data, function (d) { return d.length; }), function (memo, n) { return memo + n; }, 0).should.equal(avltDataElems.length);
+
+      // Compare data
+      Object.keys(data).forEach(function (key) {
+        checkDataEquality(avlt.search(key), data[key]);
+      });
+    }
+
+    // Check two pieces of data coming from the avlt and data are the same
+    function checkDataEquality (fromavlt, fromData) {
+      if (fromavlt.length === 0) {
+        if (fromData) { fromData.length.should.equal(0); }
+      }
+
+      assert.deepEqual(fromavlt, fromData);
+    }
+
+    // Tests the tree structure (deletions concern the whole tree, deletion of some data in a node is well tested above)
+    it('Inserting and deleting entire nodes', function () {
+      // You can skew to be more insertive or deletive, to test all cases
+      function launchRandomTest (nTests, proba) {
+        var i, key, dataPiece, possibleKeys;
+
+        for (i = 0; i < nTests; i += 1) {
+          if (Math.random() > proba) {   // Deletion
+            possibleKeys = Object.keys(data);
+
+            if (possibleKeys.length > 0) {
+              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()];
+            } else {
+              key = Math.floor(70 * Math.random()).toString();
+            }
+
+            delete data[key];
+            avlt.delete(key);
+          } else {   // Insertion
+            key = Math.floor(70 * Math.random()).toString();
+            dataPiece = Math.random().toString().substring(0, 6);
+
+            avlt.insert(key, dataPiece);
+            if (data[key]) {
+              data[key].push(dataPiece);
+            } else {
+              data[key] = [dataPiece];
+            }
+          }
+
+          // Check the avlt constraint are still met and the data is correct
+          avlt.checkIsAVLT();
+          checkDataIsTheSame(avlt, data);
+        }
+      }
+
+      launchRandomTest(1000, 0.65);
+      launchRandomTest(2000, 0.35);
+    });
+
+  });   // ==== End of 'Randomized test' ==== //
+
+});
+
+
+
+
+
+
+
+
+

--- a/test/bst.test.js
+++ b/test/bst.test.js
@@ -418,7 +418,7 @@ describe('Binary search tree', function () {
     })
 
     it('Can search for data between two bounds', function () {
-      const bst = new BinarySearchTree()
+      const bst = new BinarySearchTree();
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         bst.insert(k, 'data ' + k)
@@ -429,7 +429,7 @@ describe('Binary search tree', function () {
     })
 
     it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
-      const bst = new BinarySearchTree()
+      const bst = new BinarySearchTree();
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         bst.insert(k, 'data ' + k)
@@ -445,7 +445,7 @@ describe('Binary search tree', function () {
     })
 
     it('Bounded search can work when one or both boundaries are missing', function () {
-      const bst = new BinarySearchTree()
+      const bst = new BinarySearchTree();
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
         bst.insert(k, 'data ' + k)
@@ -480,7 +480,7 @@ describe('Binary search tree', function () {
     })
 
     it('Deleting a non-existent key doesnt have any effect', function () {
-      const bst = new BinarySearchTree()
+      const bst = new BinarySearchTree();
 
       [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
         bst.insert(k, 'some ' + k)

--- a/test/bst.test.js
+++ b/test/bst.test.js
@@ -1,0 +1,1043 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , BinarySearchTree = require('../src/binarySearchTree/bst')
+  , _ = require('underscore')
+  , customUtils = require('../src/binarySearchTree/customUtils')
+  ;
+
+
+describe('Binary search tree', function () {
+
+  it('Upon creation, left, right are null, key and data can be set', function () {
+    var bst = new BinarySearchTree();
+    assert.isNull(bst.left);
+    assert.isNull(bst.right);
+    bst.hasOwnProperty('key').should.equal(false);
+    bst.data.length.should.equal(0);
+
+    bst = new BinarySearchTree({ key: 6, value: 'ggg' });
+    assert.isNull(bst.left);
+    assert.isNull(bst.right);
+    bst.key.should.equal(6);
+    bst.data.length.should.equal(1);
+    bst.data[0].should.equal('ggg');
+  });
+
+  describe('Sanity checks', function () {
+
+    it('Can get maxkey and minkey descendants', function () {
+      var t = new BinarySearchTree({ key: 10 })
+        , l = new BinarySearchTree({ key: 5 })
+        , r = new BinarySearchTree({ key: 15 })
+        , ll = new BinarySearchTree({ key: 3 })
+        , lr = new BinarySearchTree({ key: 8 })
+        , rl = new BinarySearchTree({ key: 11 })
+        , rr = new BinarySearchTree({ key: 42 })
+        ;
+
+      t.left = l; t.right = r;
+      l.left = ll; l.right = lr;
+      r.left = rl; r.right = rr;
+
+      // Getting min and max key descendants
+      t.getMinKeyDescendant().key.should.equal(3);
+      t.getMaxKeyDescendant().key.should.equal(42);
+
+      t.left.getMinKeyDescendant().key.should.equal(3);
+      t.left.getMaxKeyDescendant().key.should.equal(8);
+
+      t.right.getMinKeyDescendant().key.should.equal(11);
+      t.right.getMaxKeyDescendant().key.should.equal(42);
+
+      t.right.left.getMinKeyDescendant().key.should.equal(11);
+      t.right.left.getMaxKeyDescendant().key.should.equal(11);
+
+      // Getting min and max keys
+      t.getMinKey().should.equal(3);
+      t.getMaxKey().should.equal(42);
+
+      t.left.getMinKey().should.equal(3);
+      t.left.getMaxKey().should.equal(8);
+
+      t.right.getMinKey().should.equal(11);
+      t.right.getMaxKey().should.equal(42);
+
+      t.right.left.getMinKey().should.equal(11);
+      t.right.left.getMaxKey().should.equal(11);
+    });
+
+    it('Can check a condition against every node in a tree', function () {
+      var t = new BinarySearchTree({ key: 10 })
+        , l = new BinarySearchTree({ key: 6 })
+        , r = new BinarySearchTree({ key: 16 })
+        , ll = new BinarySearchTree({ key: 4 })
+        , lr = new BinarySearchTree({ key: 8 })
+        , rl = new BinarySearchTree({ key: 12 })
+        , rr = new BinarySearchTree({ key: 42 })
+        ;
+
+      t.left = l; t.right = r;
+      l.left = ll; l.right = lr;
+      r.left = rl; r.right = rr;
+
+      function test (k, v) { if (k % 2 !== 0) { throw 'Key is not even'; } }
+
+      t.checkAllNodesFullfillCondition(test);
+
+      [l, r, ll, lr, rl, rr].forEach(function (node) {
+        node.key += 1;
+        (function () { t.checkAllNodesFullfillCondition(test); }).should.throw();
+        node.key -= 1;
+      });
+
+      t.checkAllNodesFullfillCondition(test);
+    });
+
+    it('Can check that a tree verifies node ordering', function () {
+      var t = new BinarySearchTree({ key: 10 })
+        , l = new BinarySearchTree({ key: 5 })
+        , r = new BinarySearchTree({ key: 15 })
+        , ll = new BinarySearchTree({ key: 3 })
+        , lr = new BinarySearchTree({ key: 8 })
+        , rl = new BinarySearchTree({ key: 11 })
+        , rr = new BinarySearchTree({ key: 42 })
+        ;
+
+      t.left = l; t.right = r;
+      l.left = ll; l.right = lr;
+      r.left = rl; r.right = rr;
+
+      t.checkNodeOrdering();
+
+      // Let's be paranoid and check all cases...
+      l.key = 12;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      l.key = 5;
+
+      r.key = 9;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      r.key = 15;
+
+      ll.key = 6;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      ll.key = 11;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      ll.key = 3;
+
+      lr.key = 4;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      lr.key = 11;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      lr.key = 8;
+
+      rl.key = 16;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      rl.key = 9;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      rl.key = 11;
+
+      rr.key = 12;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      rr.key = 7;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      rr.key = 10.5;
+      (function () { t.checkNodeOrdering(); }).should.throw();
+      rr.key = 42;
+
+      t.checkNodeOrdering();
+    });
+
+    it('Checking if a tree\'s internal pointers (i.e. parents) are correct', function () {
+      var t = new BinarySearchTree({ key: 10 })
+        , l = new BinarySearchTree({ key: 5 })
+        , r = new BinarySearchTree({ key: 15 })
+        , ll = new BinarySearchTree({ key: 3 })
+        , lr = new BinarySearchTree({ key: 8 })
+        , rl = new BinarySearchTree({ key: 11 })
+        , rr = new BinarySearchTree({ key: 42 })
+        ;
+
+      t.left = l; t.right = r;
+      l.left = ll; l.right = lr;
+      r.left = rl; r.right = rr;
+
+      (function () { t.checkInternalPointers(); }).should.throw();
+      l.parent = t;
+      (function () { t.checkInternalPointers(); }).should.throw();
+      r.parent = t;
+      (function () { t.checkInternalPointers(); }).should.throw();
+      ll.parent = l;
+      (function () { t.checkInternalPointers(); }).should.throw();
+      lr.parent = l;
+      (function () { t.checkInternalPointers(); }).should.throw();
+      rl.parent = r;
+      (function () { t.checkInternalPointers(); }).should.throw();
+      rr.parent = r;
+
+      t.checkInternalPointers();
+    });
+
+    it('Can get the number of inserted keys', function () {
+      var bst = new BinarySearchTree();
+
+      bst.getNumberOfKeys().should.equal(0);
+      bst.insert(10);
+      bst.getNumberOfKeys().should.equal(1);
+      bst.insert(5);
+      bst.getNumberOfKeys().should.equal(2);
+      bst.insert(3);
+      bst.getNumberOfKeys().should.equal(3);
+      bst.insert(8);
+      bst.getNumberOfKeys().should.equal(4);
+      bst.insert(15);
+      bst.getNumberOfKeys().should.equal(5);
+      bst.insert(12);
+      bst.getNumberOfKeys().should.equal(6);
+      bst.insert(37);
+      bst.getNumberOfKeys().should.equal(7);
+    });
+
+  });
+
+  describe('Insertion', function () {
+
+    it('Insert at the root if its the first insertion', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+
+      bst.checkIsBST();
+      bst.key.should.equal(10);
+      _.isEqual(bst.data, ['some data']).should.equal(true);
+      assert.isNull(bst.left);
+      assert.isNull(bst.right);
+    });
+
+    it("Insert on the left if key is less than the root's", function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+      bst.insert(7, 'some other data');
+
+      bst.checkIsBST();
+      assert.isNull(bst.right);
+      bst.left.key.should.equal(7);
+      _.isEqual(bst.left.data, ['some other data']).should.equal(true);
+      assert.isNull(bst.left.left);
+      assert.isNull(bst.left.right);
+    });
+
+    it("Insert on the right if key is greater than the root's", function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+      bst.insert(14, 'some other data');
+
+      bst.checkIsBST();
+      assert.isNull(bst.left);
+      bst.right.key.should.equal(14);
+      _.isEqual(bst.right.data, ['some other data']).should.equal(true);
+      assert.isNull(bst.right.left);
+      assert.isNull(bst.right.right);
+    });
+
+    it("Recursive insertion on the left works", function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+      bst.insert(7, 'some other data');
+      bst.insert(1, 'hello');
+      bst.insert(9, 'world');
+
+      bst.checkIsBST();
+      assert.isNull(bst.right);
+      bst.left.key.should.equal(7);
+      _.isEqual(bst.left.data, ['some other data']).should.equal(true);
+
+      bst.left.left.key.should.equal(1);
+      _.isEqual(bst.left.left.data, ['hello']).should.equal(true);
+
+      bst.left.right.key.should.equal(9);
+      _.isEqual(bst.left.right.data, ['world']).should.equal(true);
+    });
+
+    it("Recursive insertion on the right works", function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+      bst.insert(17, 'some other data');
+      bst.insert(11, 'hello');
+      bst.insert(19, 'world');
+
+      bst.checkIsBST();
+      assert.isNull(bst.left);
+      bst.right.key.should.equal(17);
+      _.isEqual(bst.right.data, ['some other data']).should.equal(true);
+
+      bst.right.left.key.should.equal(11);
+      _.isEqual(bst.right.left.data, ['hello']).should.equal(true);
+
+      bst.right.right.key.should.equal(19);
+      _.isEqual(bst.right.right.data, ['world']).should.equal(true);
+    });
+
+    it('If uniqueness constraint not enforced, we can insert different data for same key', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'some data');
+      bst.insert(3, 'hello');
+      bst.insert(3, 'world');
+
+      bst.checkIsBST();
+      bst.left.key.should.equal(3);
+      _.isEqual(bst.left.data, ['hello', 'world']).should.equal(true);
+
+      bst.insert(12, 'a');
+      bst.insert(12, 'b');
+
+      bst.checkIsBST();
+      bst.right.key.should.equal(12);
+      _.isEqual(bst.right.data, ['a', 'b']).should.equal(true);
+    });
+
+    it('If uniqueness constraint is enforced, we cannot insert different data for same key', function () {
+      var bst = new BinarySearchTree({ unique: true });
+
+      bst.insert(10, 'some data');
+      bst.insert(3, 'hello');
+      try {
+        bst.insert(3, 'world');
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+        e.key.should.equal(3);
+      }
+
+      bst.checkIsBST();
+      bst.left.key.should.equal(3);
+      _.isEqual(bst.left.data, ['hello']).should.equal(true);
+
+      bst.insert(12, 'a');
+      try {
+        bst.insert(12, 'world');
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+        e.key.should.equal(12);
+      }
+
+      bst.checkIsBST();
+      bst.right.key.should.equal(12);
+      _.isEqual(bst.right.data, ['a']).should.equal(true);
+    });
+
+    it('Can insert 0 or the empty string', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(0, 'some data');
+
+      bst.checkIsBST();
+      bst.key.should.equal(0);
+      _.isEqual(bst.data, ['some data']).should.equal(true);
+      assert.isNull(bst.left);
+      assert.isNull(bst.right);
+
+      bst = new BinarySearchTree();
+
+      bst.insert('', 'some other data');
+
+      bst.checkIsBST();
+      bst.key.should.equal('');
+      _.isEqual(bst.data, ['some other data']).should.equal(true);
+      assert.isNull(bst.left);
+      assert.isNull(bst.right);
+    });
+
+    it('Can insert a lot of keys and still get a BST (sanity check)', function () {
+      var bst = new BinarySearchTree({ unique: true });
+
+      customUtils.getRandomArray(100).forEach(function (n) {
+        bst.insert(n, 'some data');
+      });
+
+      bst.checkIsBST();
+    });
+
+    it('All children get a pointer to their parent, the root doesnt', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'root');
+      bst.insert(5, 'yes');
+      bst.insert(15, 'no');
+
+      bst.checkIsBST();
+
+      assert.isNull(bst.parent);
+      bst.left.parent.should.equal(bst);
+      bst.right.parent.should.equal(bst);
+    });
+
+  });   // ==== End of 'Insertion' ==== //
+
+
+  describe('Search', function () {
+
+    it('Can find data in a BST', function () {
+      var bst = new BinarySearchTree()
+        , i;
+
+      customUtils.getRandomArray(100).forEach(function (n) {
+        bst.insert(n, 'some data for ' + n);
+      });
+
+      bst.checkIsBST();
+
+      for (i = 0; i < 100; i += 1) {
+        _.isEqual(bst.search(i), ['some data for ' + i]).should.equal(true);
+      }
+    });
+
+    it('If no data can be found, return an empty array', function () {
+      var bst = new BinarySearchTree();
+
+      customUtils.getRandomArray(100).forEach(function (n) {
+        if (n !== 63) {
+          bst.insert(n, 'some data for ' + n);
+        }
+      });
+
+      bst.checkIsBST();
+
+      bst.search(-2).length.should.equal(0);
+      bst.search(100).length.should.equal(0);
+      bst.search(101).length.should.equal(0);
+      bst.search(63).length.should.equal(0);
+    });
+
+    it('Can search for data between two bounds', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+      assert.deepEqual(bst.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13']);
+    });
+
+    it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.betweenBounds({ $gt:8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+      assert.deepEqual(bst.betweenBounds({ $gt:5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+      assert.deepEqual(bst.betweenBounds({ $gt:8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15']);
+    });
+
+    it('Bounded search can work when one or both boundaries are missing', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18']);
+      assert.deepEqual(bst.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8']);
+    });
+
+  });   /// ==== End of 'Search' ==== //
+
+
+  describe('Deletion', function () {
+
+    it('Deletion does nothing on an empty tree', function () {
+      var bst = new BinarySearchTree()
+        , bstu = new BinarySearchTree({ unique: true });
+
+      bst.getNumberOfKeys().should.equal(0);
+      bstu.getNumberOfKeys().should.equal(0);
+
+      bst.delete(5);
+      bstu.delete(5);
+
+      bst.hasOwnProperty('key').should.equal(false);
+      bstu.hasOwnProperty('key').should.equal(false);
+
+      bst.data.length.should.equal(0);
+      bstu.data.length.should.equal(0);
+
+      bst.getNumberOfKeys().should.equal(0);
+      bstu.getNumberOfKeys().should.equal(0);
+    });
+
+    it('Deleting a non-existent key doesnt have any effect', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+
+      function checkBst () {
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+        });
+      }
+
+      checkBst();
+      bst.getNumberOfKeys().should.equal(7);
+
+      bst.delete(2);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(4);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(9);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(6);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(11);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(14);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(20);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+      bst.delete(200);
+      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
+    });
+
+    it('Able to delete the root if it is also a leaf', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'hello');
+      bst.key.should.equal(10);
+      _.isEqual(bst.data, ['hello']).should.equal(true);
+      bst.getNumberOfKeys().should.equal(1);
+
+      bst.delete(10);
+      bst.hasOwnProperty('key').should.equal(false);
+      bst.data.length.should.equal(0);
+      bst.getNumberOfKeys().should.equal(0);
+    });
+
+    it('Able to delete leaf nodes that are non-root', function () {
+      var bst;
+
+      function recreateBst () {
+        bst = new BinarySearchTree();
+
+        // With this insertion order the tree is well balanced
+        // So we know the leaves are 3, 8, 12, 37
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          bst.insert(k, 'some ' + k);
+        });
+
+        bst.getNumberOfKeys().should.equal(7);
+      }
+
+      function checkOnlyOneWasRemoved (theRemoved) {
+        [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+          if (k === theRemoved) {
+            bst.search(k).length.should.equal(0);
+          } else {
+            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+          }
+        });
+
+        bst.getNumberOfKeys().should.equal(6);
+      }
+
+      recreateBst();
+      bst.delete(3);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(3);
+      assert.isNull(bst.left.left);
+
+      recreateBst();
+      bst.delete(8);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(8);
+      assert.isNull(bst.left.right);
+
+      recreateBst();
+      bst.delete(12);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(12);
+      assert.isNull(bst.right.left);
+
+      recreateBst();
+      bst.delete(37);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(37);
+      assert.isNull(bst.right.right);
+    });
+
+    it('Able to delete the root if it has only one child', function () {
+      var bst;
+
+      // Root has only one child, on the left
+      bst = new BinarySearchTree();
+      [10, 5, 3, 6].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+      bst.getNumberOfKeys().should.equal(4);
+      bst.delete(10);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(3);
+      [5, 3, 6].forEach(function (k) {
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+      });
+      bst.search(10).length.should.equal(0);
+
+      // Root has only one child, on the right
+      bst = new BinarySearchTree();
+      [10, 15, 13, 16].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+      bst.getNumberOfKeys().should.equal(4);
+      bst.delete(10);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(3);
+      [15, 13, 16].forEach(function (k) {
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+      });
+      bst.search(10).length.should.equal(0);
+    });
+
+    it('Able to delete non root nodes that have only one child', function () {
+      var bst;
+
+      function recreateBst () {
+        bst = new BinarySearchTree();
+
+        [10, 5, 15, 3, 1, 4, 20, 17, 25].forEach(function (k) {
+          bst.insert(k, 'some ' + k);
+        });
+
+        bst.getNumberOfKeys().should.equal(9);
+      }
+
+      function checkOnlyOneWasRemoved (theRemoved) {
+        [10, 5, 15, 3, 1, 4, 20, 17, 25].forEach(function (k) {
+          if (k === theRemoved) {
+            bst.search(k).length.should.equal(0);
+          } else {
+            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+          }
+        });
+
+        bst.getNumberOfKeys().should.equal(8);
+      }
+
+      recreateBst();
+      bst.delete(5);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(5);
+
+      recreateBst();
+      bst.delete(15);
+      bst.checkIsBST();
+      checkOnlyOneWasRemoved(15);
+    });
+
+    it('Can delete the root if it has 2 children', function () {
+      var bst;
+
+      bst = new BinarySearchTree();
+      [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+      bst.getNumberOfKeys().should.equal(7);
+      bst.delete(10);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(6);
+      [5, 3, 8, 15, 12, 37].forEach(function (k) {
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+      });
+      bst.search(10).length.should.equal(0);
+    });
+
+    it('Can delete a non-root node that has two children', function () {
+      var bst;
+
+      bst = new BinarySearchTree();
+      [10, 5, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+      bst.getNumberOfKeys().should.equal(15);
+      bst.delete(5);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(14);
+      [10, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+      });
+      bst.search(5).length.should.equal(0);
+
+      bst = new BinarySearchTree();
+      [10, 5, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
+        bst.insert(k, 'some ' + k);
+      });
+      bst.getNumberOfKeys().should.equal(15);
+      bst.delete(15);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(14);
+      [10, 5, 3, 1, 4, 8, 6, 9, 12, 11, 13, 20, 19, 42].forEach(function (k) {
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+      });
+      bst.search(15).length.should.equal(0);
+    });
+
+    it('If no value is provided, it will delete the entire node even if there are multiple pieces of data', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'yes');
+      bst.insert(5, 'hello');
+      bst.insert(3, 'yes');
+      bst.insert(5, 'world');
+      bst.insert(8, 'yes');
+
+      assert.deepEqual(bst.search(5), ['hello', 'world']);
+      bst.getNumberOfKeys().should.equal(4);
+
+      bst.delete(5);
+      bst.search(5).length.should.equal(0);
+      bst.getNumberOfKeys().should.equal(3);
+    });
+
+    it('Can remove only one value from an array', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'yes');
+      bst.insert(5, 'hello');
+      bst.insert(3, 'yes');
+      bst.insert(5, 'world');
+      bst.insert(8, 'yes');
+
+      assert.deepEqual(bst.search(5), ['hello', 'world']);
+      bst.getNumberOfKeys().should.equal(4);
+
+      bst.delete(5, 'hello');
+      assert.deepEqual(bst.search(5), ['world']);
+      bst.getNumberOfKeys().should.equal(4);
+    });
+
+    it('Removes nothing if value doesnt match', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'yes');
+      bst.insert(5, 'hello');
+      bst.insert(3, 'yes');
+      bst.insert(5, 'world');
+      bst.insert(8, 'yes');
+
+      assert.deepEqual(bst.search(5), ['hello', 'world']);
+      bst.getNumberOfKeys().should.equal(4);
+
+      bst.delete(5, 'nope');
+      assert.deepEqual(bst.search(5), ['hello', 'world']);
+      bst.getNumberOfKeys().should.equal(4);
+    });
+
+    it('If value provided but node contains only one value, remove entire node', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'yes');
+      bst.insert(5, 'hello');
+      bst.insert(3, 'yes2');
+      bst.insert(5, 'world');
+      bst.insert(8, 'yes3');
+
+      assert.deepEqual(bst.search(3), ['yes2']);
+      bst.getNumberOfKeys().should.equal(4);
+
+      bst.delete(3, 'yes2');
+      bst.search(3).length.should.equal(0);
+      bst.getNumberOfKeys().should.equal(3);
+    });
+
+    it('Can remove the root from a tree with height 2 when the root has two children (special case)', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'maybe');
+      bst.insert(5, 'no');
+      bst.insert(15, 'yes');
+      bst.getNumberOfKeys().should.equal(3);
+
+      bst.delete(10);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(2);
+      assert.deepEqual(bst.search(5), ['no']);
+      assert.deepEqual(bst.search(15), ['yes']);
+    });
+
+    it('Can remove the root from a tree with height 3 when the root has two children (special case where the two children themselves have children)', function () {
+      var bst = new BinarySearchTree();
+
+      bst.insert(10, 'maybe');
+      bst.insert(5, 'no');
+      bst.insert(15, 'yes');
+      bst.insert(2, 'no');
+      bst.insert(35, 'yes');
+      bst.getNumberOfKeys().should.equal(5);
+
+      bst.delete(10);
+      bst.checkIsBST();
+      bst.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(bst.search(5), ['no']);
+      assert.deepEqual(bst.search(15), ['yes']);
+    });
+
+  });   // ==== End of 'Deletion' ==== //
+
+
+  it('Can use undefined as key and value', function () {
+    function compareKeys (a, b) {
+      if (a === undefined && b === undefined) { return 0; }
+      if (a === undefined) { return -1; }
+      if (b === undefined) { return 1; }
+
+      if (a < b) { return -1; }
+      if (a > b) { return 1; }
+      if (a === b) { return 0; }
+    }
+
+    var bst = new BinarySearchTree({ compareKeys: compareKeys });
+
+    bst.insert(2, undefined);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(undefined), []);
+
+    bst.insert(undefined, 'hello');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(undefined), ['hello']);
+
+    bst.insert(undefined, 'world');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(undefined), ['hello', 'world']);
+
+    bst.insert(4, undefined);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(4), [undefined]);
+    assert.deepEqual(bst.search(undefined), ['hello', 'world']);
+
+    bst.delete(undefined, 'hello');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(4), [undefined]);
+    assert.deepEqual(bst.search(undefined), ['world']);
+
+    bst.delete(undefined);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [undefined]);
+    assert.deepEqual(bst.search(4), [undefined]);
+    assert.deepEqual(bst.search(undefined), []);
+
+    bst.delete(2, undefined);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(bst.search(2), []);
+    assert.deepEqual(bst.search(4), [undefined]);
+    assert.deepEqual(bst.search(undefined), []);
+
+    bst.delete(4);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(0);
+    assert.deepEqual(bst.search(2), []);
+    assert.deepEqual(bst.search(4), []);
+    assert.deepEqual(bst.search(undefined), []);
+  });
+
+
+  it('Can use null as key and value', function () {
+    function compareKeys (a, b) {
+      if (a === null && b === null) { return 0; }
+      if (a === null) { return -1; }
+      if (b === null) { return 1; }
+
+      if (a < b) { return -1; }
+      if (a > b) { return 1; }
+      if (a === b) { return 0; }
+    }
+
+    var bst = new BinarySearchTree({ compareKeys: compareKeys });
+
+    bst.insert(2, null);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(null), []);
+
+    bst.insert(null, 'hello');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(null), ['hello']);
+
+    bst.insert(null, 'world');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(null), ['hello', 'world']);
+
+    bst.insert(4, null);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(4), [null]);
+    assert.deepEqual(bst.search(null), ['hello', 'world']);
+
+    bst.delete(null, 'hello');
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(3);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(4), [null]);
+    assert.deepEqual(bst.search(null), ['world']);
+
+    bst.delete(null);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(2);
+    assert.deepEqual(bst.search(2), [null]);
+    assert.deepEqual(bst.search(4), [null]);
+    assert.deepEqual(bst.search(null), []);
+
+    bst.delete(2, null);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(1);
+    assert.deepEqual(bst.search(2), []);
+    assert.deepEqual(bst.search(4), [null]);
+    assert.deepEqual(bst.search(null), []);
+
+    bst.delete(4);
+    bst.checkIsBST();
+    bst.getNumberOfKeys().should.equal(0);
+    assert.deepEqual(bst.search(2), []);
+    assert.deepEqual(bst.search(4), []);
+    assert.deepEqual(bst.search(null), []);
+  });
+
+
+  describe('Execute on every node (=tree traversal)', function () {
+
+    it('Can execute a function on every node', function () {
+      var bst = new BinarySearchTree()
+        , keys = []
+        , executed = 0
+        ;
+
+      bst.insert(10, 'yes');
+      bst.insert(5, 'hello');
+      bst.insert(3, 'yes2');
+      bst.insert(8, 'yes3');
+      bst.insert(15, 'yes3');
+      bst.insert(159, 'yes3');
+      bst.insert(11, 'yes3');
+
+      bst.executeOnEveryNode(function (node) {
+        keys.push(node.key);
+        executed += 1;
+      });
+
+      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159]);
+      executed.should.equal(7);
+    });
+
+  });   // ==== End of 'Execute on every node' ==== //
+
+
+  // This test performs several inserts and deletes at random, always checking the content
+  // of the tree are as expected and the binary search tree constraint is respected
+  // This test is important because it can catch bugs other tests can't
+  // By their nature, BSTs can be hard to test (many possible cases, bug at one operation whose
+  // effect begins to be felt only after several operations etc.)
+  describe('Randomized test (takes much longer than the rest of the test suite)', function () {
+    var bst = new BinarySearchTree()
+      , data = {};
+
+    // Check a bst against a simple key => [data] object
+    function checkDataIsTheSame (bst, data) {
+      var bstDataElems = [];
+
+      // bstDataElems is a simple array containing every piece of data in the tree
+      bst.executeOnEveryNode(function (node) {
+        var i;
+        for (i = 0; i < node.data.length; i += 1) {
+          bstDataElems.push(node.data[i]);
+        }
+      });
+
+      // Number of key and number of pieces of data match
+      bst.getNumberOfKeys().should.equal(Object.keys(data).length);
+      _.reduce(_.map(data, function (d) { return d.length; }), function (memo, n) { return memo + n; }, 0).should.equal(bstDataElems.length);
+
+      // Compare data
+      Object.keys(data).forEach(function (key) {
+        checkDataEquality(bst.search(key), data[key]);
+      });
+    }
+
+    // Check two pieces of data coming from the bst and data are the same
+    function checkDataEquality (fromBst, fromData) {
+      if (fromBst.length === 0) {
+        if (fromData) { fromData.length.should.equal(0); }
+      }
+
+      assert.deepEqual(fromBst, fromData);
+    }
+
+    // Tests the tree structure (deletions concern the whole tree, deletion of some data in a node is well tested above)
+    it('Inserting and deleting entire nodes', function () {
+      // You can skew to be more insertive or deletive, to test all cases
+      function launchRandomTest (nTests, proba) {
+        var i, key, dataPiece, possibleKeys;
+
+        for (i = 0; i < nTests; i += 1) {
+          if (Math.random() > proba) {   // Deletion
+            possibleKeys = Object.keys(data);
+
+            if (possibleKeys.length > 0) {
+              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()];
+            } else {
+              key = Math.floor(70 * Math.random()).toString();
+            }
+
+            delete data[key];
+            bst.delete(key);
+          } else {   // Insertion
+            key = Math.floor(70 * Math.random()).toString();
+            dataPiece = Math.random().toString().substring(0, 6);
+            bst.insert(key, dataPiece);
+            if (data[key]) {
+              data[key].push(dataPiece);
+            } else {
+              data[key] = [dataPiece];
+            }
+          }
+
+          // Check the bst constraint are still met and the data is correct
+          bst.checkIsBST();
+          checkDataIsTheSame(bst, data);
+        }
+      }
+
+      launchRandomTest(1000, 0.65);
+      launchRandomTest(2000, 0.35);
+    });
+
+  });   // ==== End of 'Randomized test' ==== //
+
+
+
+});

--- a/test/bst.test.js
+++ b/test/bst.test.js
@@ -1,530 +1,550 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , BinarySearchTree = require('../src/binarySearchTree/bst')
-  , _ = require('underscore')
-  , customUtils = require('../src/binarySearchTree/customUtils')
-  ;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const BinarySearchTree = require('../src/binarySearchTree/bst')
+const _ = require('underscore')
+const customUtils = require('../src/binarySearchTree/customUtils')
 
 describe('Binary search tree', function () {
 
   it('Upon creation, left, right are null, key and data can be set', function () {
-    var bst = new BinarySearchTree();
-    assert.isNull(bst.left);
-    assert.isNull(bst.right);
-    bst.hasOwnProperty('key').should.equal(false);
-    bst.data.length.should.equal(0);
+    var bst = new BinarySearchTree()
+    assert.isNull(bst.left)
+    assert.isNull(bst.right)
+    bst.hasOwnProperty('key').should.equal(false)
+    bst.data.length.should.equal(0)
 
-    bst = new BinarySearchTree({ key: 6, value: 'ggg' });
-    assert.isNull(bst.left);
-    assert.isNull(bst.right);
-    bst.key.should.equal(6);
-    bst.data.length.should.equal(1);
-    bst.data[0].should.equal('ggg');
-  });
+    bst = new BinarySearchTree({ key: 6, value: 'ggg' })
+    assert.isNull(bst.left)
+    assert.isNull(bst.right)
+    bst.key.should.equal(6)
+    bst.data.length.should.equal(1)
+    bst.data[0].should.equal('ggg')
+  })
 
   describe('Sanity checks', function () {
 
     it('Can get maxkey and minkey descendants', function () {
-      var t = new BinarySearchTree({ key: 10 })
-        , l = new BinarySearchTree({ key: 5 })
-        , r = new BinarySearchTree({ key: 15 })
-        , ll = new BinarySearchTree({ key: 3 })
-        , lr = new BinarySearchTree({ key: 8 })
-        , rl = new BinarySearchTree({ key: 11 })
-        , rr = new BinarySearchTree({ key: 42 })
-        ;
+      const t = new BinarySearchTree({ key: 10 })
+      const l = new BinarySearchTree({ key: 5 })
+      const r = new BinarySearchTree({ key: 15 })
+      const ll = new BinarySearchTree({ key: 3 })
+      const lr = new BinarySearchTree({ key: 8 })
+      const rl = new BinarySearchTree({ key: 11 })
+      const rr = new BinarySearchTree({ key: 42 })
 
-      t.left = l; t.right = r;
-      l.left = ll; l.right = lr;
-      r.left = rl; r.right = rr;
+      t.left = l
+      t.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr
 
       // Getting min and max key descendants
-      t.getMinKeyDescendant().key.should.equal(3);
-      t.getMaxKeyDescendant().key.should.equal(42);
+      t.getMinKeyDescendant().key.should.equal(3)
+      t.getMaxKeyDescendant().key.should.equal(42)
 
-      t.left.getMinKeyDescendant().key.should.equal(3);
-      t.left.getMaxKeyDescendant().key.should.equal(8);
+      t.left.getMinKeyDescendant().key.should.equal(3)
+      t.left.getMaxKeyDescendant().key.should.equal(8)
 
-      t.right.getMinKeyDescendant().key.should.equal(11);
-      t.right.getMaxKeyDescendant().key.should.equal(42);
+      t.right.getMinKeyDescendant().key.should.equal(11)
+      t.right.getMaxKeyDescendant().key.should.equal(42)
 
-      t.right.left.getMinKeyDescendant().key.should.equal(11);
-      t.right.left.getMaxKeyDescendant().key.should.equal(11);
+      t.right.left.getMinKeyDescendant().key.should.equal(11)
+      t.right.left.getMaxKeyDescendant().key.should.equal(11)
 
       // Getting min and max keys
-      t.getMinKey().should.equal(3);
-      t.getMaxKey().should.equal(42);
+      t.getMinKey().should.equal(3)
+      t.getMaxKey().should.equal(42)
 
-      t.left.getMinKey().should.equal(3);
-      t.left.getMaxKey().should.equal(8);
+      t.left.getMinKey().should.equal(3)
+      t.left.getMaxKey().should.equal(8)
 
-      t.right.getMinKey().should.equal(11);
-      t.right.getMaxKey().should.equal(42);
+      t.right.getMinKey().should.equal(11)
+      t.right.getMaxKey().should.equal(42)
 
-      t.right.left.getMinKey().should.equal(11);
-      t.right.left.getMaxKey().should.equal(11);
-    });
+      t.right.left.getMinKey().should.equal(11)
+      t.right.left.getMaxKey().should.equal(11)
+    })
 
     it('Can check a condition against every node in a tree', function () {
-      var t = new BinarySearchTree({ key: 10 })
-        , l = new BinarySearchTree({ key: 6 })
-        , r = new BinarySearchTree({ key: 16 })
-        , ll = new BinarySearchTree({ key: 4 })
-        , lr = new BinarySearchTree({ key: 8 })
-        , rl = new BinarySearchTree({ key: 12 })
-        , rr = new BinarySearchTree({ key: 42 })
-        ;
+      const t = new BinarySearchTree({ key: 10 })
+      const l = new BinarySearchTree({ key: 6 })
+      const r = new BinarySearchTree({ key: 16 })
+      const ll = new BinarySearchTree({ key: 4 })
+      const lr = new BinarySearchTree({ key: 8 })
+      const rl = new BinarySearchTree({ key: 12 })
+      const rr = new BinarySearchTree({ key: 42 })
 
-      t.left = l; t.right = r;
-      l.left = ll; l.right = lr;
-      r.left = rl; r.right = rr;
+      t.left = l
+      t.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr
 
-      function test (k, v) { if (k % 2 !== 0) { throw 'Key is not even'; } }
+      function test (k, v) { if (k % 2 !== 0) { throw 'Key is not even' } }
 
       t.checkAllNodesFullfillCondition(test);
 
       [l, r, ll, lr, rl, rr].forEach(function (node) {
         node.key += 1;
-        (function () { t.checkAllNodesFullfillCondition(test); }).should.throw();
-        node.key -= 1;
-      });
+        (function () { t.checkAllNodesFullfillCondition(test) }).should.throw()
+        node.key -= 1
+      })
 
-      t.checkAllNodesFullfillCondition(test);
-    });
+      t.checkAllNodesFullfillCondition(test)
+    })
 
     it('Can check that a tree verifies node ordering', function () {
-      var t = new BinarySearchTree({ key: 10 })
-        , l = new BinarySearchTree({ key: 5 })
-        , r = new BinarySearchTree({ key: 15 })
-        , ll = new BinarySearchTree({ key: 3 })
-        , lr = new BinarySearchTree({ key: 8 })
-        , rl = new BinarySearchTree({ key: 11 })
-        , rr = new BinarySearchTree({ key: 42 })
-        ;
+      const t = new BinarySearchTree({ key: 10 })
+      const l = new BinarySearchTree({ key: 5 })
+      const r = new BinarySearchTree({ key: 15 })
+      const ll = new BinarySearchTree({ key: 3 })
+      const lr = new BinarySearchTree({ key: 8 })
+      const rl = new BinarySearchTree({ key: 11 })
+      const rr = new BinarySearchTree({ key: 42 })
 
-      t.left = l; t.right = r;
-      l.left = ll; l.right = lr;
-      r.left = rl; r.right = rr;
+      t.left = l
+      t.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr
 
-      t.checkNodeOrdering();
+      t.checkNodeOrdering()
 
       // Let's be paranoid and check all cases...
       l.key = 12;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      l.key = 5;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      l.key = 5
 
       r.key = 9;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      r.key = 15;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      r.key = 15
 
       ll.key = 6;
-      (function () { t.checkNodeOrdering(); }).should.throw();
+      (function () { t.checkNodeOrdering() }).should.throw()
       ll.key = 11;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      ll.key = 3;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      ll.key = 3
 
       lr.key = 4;
-      (function () { t.checkNodeOrdering(); }).should.throw();
+      (function () { t.checkNodeOrdering() }).should.throw()
       lr.key = 11;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      lr.key = 8;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      lr.key = 8
 
       rl.key = 16;
-      (function () { t.checkNodeOrdering(); }).should.throw();
+      (function () { t.checkNodeOrdering() }).should.throw()
       rl.key = 9;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      rl.key = 11;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      rl.key = 11
 
       rr.key = 12;
-      (function () { t.checkNodeOrdering(); }).should.throw();
+      (function () { t.checkNodeOrdering() }).should.throw()
       rr.key = 7;
-      (function () { t.checkNodeOrdering(); }).should.throw();
+      (function () { t.checkNodeOrdering() }).should.throw()
       rr.key = 10.5;
-      (function () { t.checkNodeOrdering(); }).should.throw();
-      rr.key = 42;
+      (function () { t.checkNodeOrdering() }).should.throw()
+      rr.key = 42
 
-      t.checkNodeOrdering();
-    });
+      t.checkNodeOrdering()
+    })
 
     it('Checking if a tree\'s internal pointers (i.e. parents) are correct', function () {
-      var t = new BinarySearchTree({ key: 10 })
-        , l = new BinarySearchTree({ key: 5 })
-        , r = new BinarySearchTree({ key: 15 })
-        , ll = new BinarySearchTree({ key: 3 })
-        , lr = new BinarySearchTree({ key: 8 })
-        , rl = new BinarySearchTree({ key: 11 })
-        , rr = new BinarySearchTree({ key: 42 })
-        ;
+      const t = new BinarySearchTree({ key: 10 })
+      const l = new BinarySearchTree({ key: 5 })
+      const r = new BinarySearchTree({ key: 15 })
+      const ll = new BinarySearchTree({ key: 3 })
+      const lr = new BinarySearchTree({ key: 8 })
+      const rl = new BinarySearchTree({ key: 11 })
+      const rr = new BinarySearchTree({ key: 42 })
 
-      t.left = l; t.right = r;
-      l.left = ll; l.right = lr;
-      r.left = rl; r.right = rr;
+      t.left = l
+      t.right = r
+      l.left = ll
+      l.right = lr
+      r.left = rl
+      r.right = rr;
 
-      (function () { t.checkInternalPointers(); }).should.throw();
+      (function () { t.checkInternalPointers() }).should.throw()
       l.parent = t;
-      (function () { t.checkInternalPointers(); }).should.throw();
+      (function () { t.checkInternalPointers() }).should.throw()
       r.parent = t;
-      (function () { t.checkInternalPointers(); }).should.throw();
+      (function () { t.checkInternalPointers() }).should.throw()
       ll.parent = l;
-      (function () { t.checkInternalPointers(); }).should.throw();
+      (function () { t.checkInternalPointers() }).should.throw()
       lr.parent = l;
-      (function () { t.checkInternalPointers(); }).should.throw();
+      (function () { t.checkInternalPointers() }).should.throw()
       rl.parent = r;
-      (function () { t.checkInternalPointers(); }).should.throw();
-      rr.parent = r;
+      (function () { t.checkInternalPointers() }).should.throw()
+      rr.parent = r
 
-      t.checkInternalPointers();
-    });
+      t.checkInternalPointers()
+    })
 
     it('Can get the number of inserted keys', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.getNumberOfKeys().should.equal(0);
-      bst.insert(10);
-      bst.getNumberOfKeys().should.equal(1);
-      bst.insert(5);
-      bst.getNumberOfKeys().should.equal(2);
-      bst.insert(3);
-      bst.getNumberOfKeys().should.equal(3);
-      bst.insert(8);
-      bst.getNumberOfKeys().should.equal(4);
-      bst.insert(15);
-      bst.getNumberOfKeys().should.equal(5);
-      bst.insert(12);
-      bst.getNumberOfKeys().should.equal(6);
-      bst.insert(37);
-      bst.getNumberOfKeys().should.equal(7);
-    });
+      bst.getNumberOfKeys().should.equal(0)
+      bst.insert(10)
+      bst.getNumberOfKeys().should.equal(1)
+      bst.insert(5)
+      bst.getNumberOfKeys().should.equal(2)
+      bst.insert(3)
+      bst.getNumberOfKeys().should.equal(3)
+      bst.insert(8)
+      bst.getNumberOfKeys().should.equal(4)
+      bst.insert(15)
+      bst.getNumberOfKeys().should.equal(5)
+      bst.insert(12)
+      bst.getNumberOfKeys().should.equal(6)
+      bst.insert(37)
+      bst.getNumberOfKeys().should.equal(7)
+    })
 
-  });
+  })
 
   describe('Insertion', function () {
 
     it('Insert at the root if its the first insertion', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
+      bst.insert(10, 'some data')
 
-      bst.checkIsBST();
-      bst.key.should.equal(10);
-      _.isEqual(bst.data, ['some data']).should.equal(true);
-      assert.isNull(bst.left);
-      assert.isNull(bst.right);
-    });
+      bst.checkIsBST()
+      bst.key.should.equal(10)
+      _.isEqual(bst.data, ['some data']).should.equal(true)
+      assert.isNull(bst.left)
+      assert.isNull(bst.right)
+    })
 
-    it("Insert on the left if key is less than the root's", function () {
-      var bst = new BinarySearchTree();
+    it('Insert on the left if key is less than the root\'s', function () {
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
-      bst.insert(7, 'some other data');
+      bst.insert(10, 'some data')
+      bst.insert(7, 'some other data')
 
-      bst.checkIsBST();
-      assert.isNull(bst.right);
-      bst.left.key.should.equal(7);
-      _.isEqual(bst.left.data, ['some other data']).should.equal(true);
-      assert.isNull(bst.left.left);
-      assert.isNull(bst.left.right);
-    });
+      bst.checkIsBST()
+      assert.isNull(bst.right)
+      bst.left.key.should.equal(7)
+      _.isEqual(bst.left.data, ['some other data']).should.equal(true)
+      assert.isNull(bst.left.left)
+      assert.isNull(bst.left.right)
+    })
 
-    it("Insert on the right if key is greater than the root's", function () {
-      var bst = new BinarySearchTree();
+    it('Insert on the right if key is greater than the root\'s', function () {
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
-      bst.insert(14, 'some other data');
+      bst.insert(10, 'some data')
+      bst.insert(14, 'some other data')
 
-      bst.checkIsBST();
-      assert.isNull(bst.left);
-      bst.right.key.should.equal(14);
-      _.isEqual(bst.right.data, ['some other data']).should.equal(true);
-      assert.isNull(bst.right.left);
-      assert.isNull(bst.right.right);
-    });
+      bst.checkIsBST()
+      assert.isNull(bst.left)
+      bst.right.key.should.equal(14)
+      _.isEqual(bst.right.data, ['some other data']).should.equal(true)
+      assert.isNull(bst.right.left)
+      assert.isNull(bst.right.right)
+    })
 
-    it("Recursive insertion on the left works", function () {
-      var bst = new BinarySearchTree();
+    it('Recursive insertion on the left works', function () {
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
-      bst.insert(7, 'some other data');
-      bst.insert(1, 'hello');
-      bst.insert(9, 'world');
+      bst.insert(10, 'some data')
+      bst.insert(7, 'some other data')
+      bst.insert(1, 'hello')
+      bst.insert(9, 'world')
 
-      bst.checkIsBST();
-      assert.isNull(bst.right);
-      bst.left.key.should.equal(7);
-      _.isEqual(bst.left.data, ['some other data']).should.equal(true);
+      bst.checkIsBST()
+      assert.isNull(bst.right)
+      bst.left.key.should.equal(7)
+      _.isEqual(bst.left.data, ['some other data']).should.equal(true)
 
-      bst.left.left.key.should.equal(1);
-      _.isEqual(bst.left.left.data, ['hello']).should.equal(true);
+      bst.left.left.key.should.equal(1)
+      _.isEqual(bst.left.left.data, ['hello']).should.equal(true)
 
-      bst.left.right.key.should.equal(9);
-      _.isEqual(bst.left.right.data, ['world']).should.equal(true);
-    });
+      bst.left.right.key.should.equal(9)
+      _.isEqual(bst.left.right.data, ['world']).should.equal(true)
+    })
 
-    it("Recursive insertion on the right works", function () {
-      var bst = new BinarySearchTree();
+    it('Recursive insertion on the right works', function () {
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
-      bst.insert(17, 'some other data');
-      bst.insert(11, 'hello');
-      bst.insert(19, 'world');
+      bst.insert(10, 'some data')
+      bst.insert(17, 'some other data')
+      bst.insert(11, 'hello')
+      bst.insert(19, 'world')
 
-      bst.checkIsBST();
-      assert.isNull(bst.left);
-      bst.right.key.should.equal(17);
-      _.isEqual(bst.right.data, ['some other data']).should.equal(true);
+      bst.checkIsBST()
+      assert.isNull(bst.left)
+      bst.right.key.should.equal(17)
+      _.isEqual(bst.right.data, ['some other data']).should.equal(true)
 
-      bst.right.left.key.should.equal(11);
-      _.isEqual(bst.right.left.data, ['hello']).should.equal(true);
+      bst.right.left.key.should.equal(11)
+      _.isEqual(bst.right.left.data, ['hello']).should.equal(true)
 
-      bst.right.right.key.should.equal(19);
-      _.isEqual(bst.right.right.data, ['world']).should.equal(true);
-    });
+      bst.right.right.key.should.equal(19)
+      _.isEqual(bst.right.right.data, ['world']).should.equal(true)
+    })
 
     it('If uniqueness constraint not enforced, we can insert different data for same key', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'some data');
-      bst.insert(3, 'hello');
-      bst.insert(3, 'world');
+      bst.insert(10, 'some data')
+      bst.insert(3, 'hello')
+      bst.insert(3, 'world')
 
-      bst.checkIsBST();
-      bst.left.key.should.equal(3);
-      _.isEqual(bst.left.data, ['hello', 'world']).should.equal(true);
+      bst.checkIsBST()
+      bst.left.key.should.equal(3)
+      _.isEqual(bst.left.data, ['hello', 'world']).should.equal(true)
 
-      bst.insert(12, 'a');
-      bst.insert(12, 'b');
+      bst.insert(12, 'a')
+      bst.insert(12, 'b')
 
-      bst.checkIsBST();
-      bst.right.key.should.equal(12);
-      _.isEqual(bst.right.data, ['a', 'b']).should.equal(true);
-    });
+      bst.checkIsBST()
+      bst.right.key.should.equal(12)
+      _.isEqual(bst.right.data, ['a', 'b']).should.equal(true)
+    })
 
     it('If uniqueness constraint is enforced, we cannot insert different data for same key', function () {
-      var bst = new BinarySearchTree({ unique: true });
+      const bst = new BinarySearchTree({ unique: true })
 
-      bst.insert(10, 'some data');
-      bst.insert(3, 'hello');
+      bst.insert(10, 'some data')
+      bst.insert(3, 'hello')
       try {
-        bst.insert(3, 'world');
+        bst.insert(3, 'world')
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
-        e.key.should.equal(3);
+        e.errorType.should.equal('uniqueViolated')
+        e.key.should.equal(3)
       }
 
-      bst.checkIsBST();
-      bst.left.key.should.equal(3);
-      _.isEqual(bst.left.data, ['hello']).should.equal(true);
+      bst.checkIsBST()
+      bst.left.key.should.equal(3)
+      _.isEqual(bst.left.data, ['hello']).should.equal(true)
 
-      bst.insert(12, 'a');
+      bst.insert(12, 'a')
       try {
-        bst.insert(12, 'world');
+        bst.insert(12, 'world')
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
-        e.key.should.equal(12);
+        e.errorType.should.equal('uniqueViolated')
+        e.key.should.equal(12)
       }
 
-      bst.checkIsBST();
-      bst.right.key.should.equal(12);
-      _.isEqual(bst.right.data, ['a']).should.equal(true);
-    });
+      bst.checkIsBST()
+      bst.right.key.should.equal(12)
+      _.isEqual(bst.right.data, ['a']).should.equal(true)
+    })
 
     it('Can insert 0 or the empty string', function () {
-      var bst = new BinarySearchTree();
+      let bst = new BinarySearchTree()
 
-      bst.insert(0, 'some data');
+      bst.insert(0, 'some data')
 
-      bst.checkIsBST();
-      bst.key.should.equal(0);
-      _.isEqual(bst.data, ['some data']).should.equal(true);
-      assert.isNull(bst.left);
-      assert.isNull(bst.right);
+      bst.checkIsBST()
+      bst.key.should.equal(0)
+      _.isEqual(bst.data, ['some data']).should.equal(true)
+      assert.isNull(bst.left)
+      assert.isNull(bst.right)
 
-      bst = new BinarySearchTree();
+      bst = new BinarySearchTree()
 
-      bst.insert('', 'some other data');
+      bst.insert('', 'some other data')
 
-      bst.checkIsBST();
-      bst.key.should.equal('');
-      _.isEqual(bst.data, ['some other data']).should.equal(true);
-      assert.isNull(bst.left);
-      assert.isNull(bst.right);
-    });
+      bst.checkIsBST()
+      bst.key.should.equal('')
+      _.isEqual(bst.data, ['some other data']).should.equal(true)
+      assert.isNull(bst.left)
+      assert.isNull(bst.right)
+    })
 
     it('Can insert a lot of keys and still get a BST (sanity check)', function () {
-      var bst = new BinarySearchTree({ unique: true });
+      const bst = new BinarySearchTree({ unique: true })
 
       customUtils.getRandomArray(100).forEach(function (n) {
-        bst.insert(n, 'some data');
-      });
+        bst.insert(n, 'some data')
+      })
 
-      bst.checkIsBST();
-    });
+      bst.checkIsBST()
+    })
 
     it('All children get a pointer to their parent, the root doesnt', function () {
-      var bst = new BinarySearchTree();
+      var bst = new BinarySearchTree()
 
-      bst.insert(10, 'root');
-      bst.insert(5, 'yes');
-      bst.insert(15, 'no');
+      bst.insert(10, 'root')
+      bst.insert(5, 'yes')
+      bst.insert(15, 'no')
 
-      bst.checkIsBST();
+      bst.checkIsBST()
 
-      assert.isNull(bst.parent);
-      bst.left.parent.should.equal(bst);
-      bst.right.parent.should.equal(bst);
-    });
+      assert.isNull(bst.parent)
+      bst.left.parent.should.equal(bst)
+      bst.right.parent.should.equal(bst)
+    })
 
-  });   // ==== End of 'Insertion' ==== //
-
+  })   // ==== End of 'Insertion' ==== //
 
   describe('Search', function () {
 
     it('Can find data in a BST', function () {
-      var bst = new BinarySearchTree()
-        , i;
+      const bst = new BinarySearchTree()
+      let i
 
       customUtils.getRandomArray(100).forEach(function (n) {
-        bst.insert(n, 'some data for ' + n);
-      });
+        bst.insert(n, 'some data for ' + n)
+      })
 
-      bst.checkIsBST();
+      bst.checkIsBST()
 
       for (i = 0; i < 100; i += 1) {
-        _.isEqual(bst.search(i), ['some data for ' + i]).should.equal(true);
+        _.isEqual(bst.search(i), ['some data for ' + i]).should.equal(true)
       }
-    });
+    })
 
     it('If no data can be found, return an empty array', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
       customUtils.getRandomArray(100).forEach(function (n) {
         if (n !== 63) {
-          bst.insert(n, 'some data for ' + n);
+          bst.insert(n, 'some data for ' + n)
         }
-      });
+      })
 
-      bst.checkIsBST();
+      bst.checkIsBST()
 
-      bst.search(-2).length.should.equal(0);
-      bst.search(100).length.should.equal(0);
-      bst.search(101).length.should.equal(0);
-      bst.search(63).length.should.equal(0);
-    });
+      bst.search(-2).length.should.equal(0)
+      bst.search(100).length.should.equal(0)
+      bst.search(101).length.should.equal(0)
+      bst.search(63).length.should.equal(0)
+    })
 
     it('Can search for data between two bounds', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        bst.insert(k, 'data ' + k);
-      });
+        bst.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-      assert.deepEqual(bst.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13']);
-    });
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+      assert.deepEqual(bst.betweenBounds({ $gt: 8, $lt: 15 }), ['data 10', 'data 13'])
+    })
 
     it('Bounded search can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        bst.insert(k, 'data ' + k);
-      });
+        bst.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(bst.betweenBounds({ $gt:8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
-      assert.deepEqual(bst.betweenBounds({ $gt:5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-      assert.deepEqual(bst.betweenBounds({ $gt:8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15']);
+      assert.deepEqual(bst.betweenBounds({ $gt: 8, $gte: 8, $lte: 15 }), ['data 10', 'data 13', 'data 15'])
+      assert.deepEqual(bst.betweenBounds({ $gt: 5, $gte: 8, $lte: 15 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+      assert.deepEqual(bst.betweenBounds({ $gt: 8, $gte: 5, $lte: 15 }), ['data 10', 'data 13', 'data 15'])
 
-      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
-      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13']);
-      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15']);
-    });
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), ['data 8', 'data 10', 'data 13'])
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), ['data 8', 'data 10', 'data 13'])
+      assert.deepEqual(bst.betweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), ['data 8', 'data 10', 'data 13', 'data 15'])
+    })
 
     it('Bounded search can work when one or both boundaries are missing', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
       [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
-        bst.insert(k, 'data ' + k);
-      });
+        bst.insert(k, 'data ' + k)
+      })
 
-      assert.deepEqual(bst.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18']);
-      assert.deepEqual(bst.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8']);
-    });
+      assert.deepEqual(bst.betweenBounds({ $gte: 11 }), ['data 13', 'data 15', 'data 18'])
+      assert.deepEqual(bst.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8'])
+    })
 
-  });   /// ==== End of 'Search' ==== //
-
+  })   /// ==== End of 'Search' ==== //
 
   describe('Deletion', function () {
 
     it('Deletion does nothing on an empty tree', function () {
-      var bst = new BinarySearchTree()
-        , bstu = new BinarySearchTree({ unique: true });
+      const bst = new BinarySearchTree()
+      const bstu = new BinarySearchTree({ unique: true })
 
-      bst.getNumberOfKeys().should.equal(0);
-      bstu.getNumberOfKeys().should.equal(0);
+      bst.getNumberOfKeys().should.equal(0)
+      bstu.getNumberOfKeys().should.equal(0)
 
-      bst.delete(5);
-      bstu.delete(5);
+      bst.delete(5)
+      bstu.delete(5)
 
-      bst.hasOwnProperty('key').should.equal(false);
-      bstu.hasOwnProperty('key').should.equal(false);
+      bst.hasOwnProperty('key').should.equal(false)
+      bstu.hasOwnProperty('key').should.equal(false)
 
-      bst.data.length.should.equal(0);
-      bstu.data.length.should.equal(0);
+      bst.data.length.should.equal(0)
+      bstu.data.length.should.equal(0)
 
-      bst.getNumberOfKeys().should.equal(0);
-      bstu.getNumberOfKeys().should.equal(0);
-    });
+      bst.getNumberOfKeys().should.equal(0)
+      bstu.getNumberOfKeys().should.equal(0)
+    })
 
     it('Deleting a non-existent key doesnt have any effect', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
       [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
+        bst.insert(k, 'some ' + k)
+      })
 
       function checkBst () {
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-          _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-        });
+          _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+        })
       }
 
-      checkBst();
-      bst.getNumberOfKeys().should.equal(7);
+      checkBst()
+      bst.getNumberOfKeys().should.equal(7)
 
-      bst.delete(2);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(4);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(9);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(6);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(11);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(14);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(20);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-      bst.delete(200);
-      checkBst(); bst.checkIsBST(); bst.getNumberOfKeys().should.equal(7);
-    });
+      bst.delete(2)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(4)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(9)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(6)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(11)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(14)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(20)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(200)
+      checkBst()
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(7)
+    })
 
     it('Able to delete the root if it is also a leaf', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'hello');
-      bst.key.should.equal(10);
-      _.isEqual(bst.data, ['hello']).should.equal(true);
-      bst.getNumberOfKeys().should.equal(1);
+      bst.insert(10, 'hello')
+      bst.key.should.equal(10)
+      _.isEqual(bst.data, ['hello']).should.equal(true)
+      bst.getNumberOfKeys().should.equal(1)
 
-      bst.delete(10);
-      bst.hasOwnProperty('key').should.equal(false);
-      bst.data.length.should.equal(0);
-      bst.getNumberOfKeys().should.equal(0);
-    });
+      bst.delete(10)
+      bst.hasOwnProperty('key').should.equal(false)
+      bst.data.length.should.equal(0)
+      bst.getNumberOfKeys().should.equal(0)
+    })
 
     it('Able to delete leaf nodes that are non-root', function () {
-      var bst;
+      let bst
 
       function recreateBst () {
         bst = new BinarySearchTree();
@@ -532,430 +552,425 @@ describe('Binary search tree', function () {
         // With this insertion order the tree is well balanced
         // So we know the leaves are 3, 8, 12, 37
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-          bst.insert(k, 'some ' + k);
-        });
+          bst.insert(k, 'some ' + k)
+        })
 
-        bst.getNumberOfKeys().should.equal(7);
+        bst.getNumberOfKeys().should.equal(7)
       }
 
       function checkOnlyOneWasRemoved (theRemoved) {
         [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
           if (k === theRemoved) {
-            bst.search(k).length.should.equal(0);
+            bst.search(k).length.should.equal(0)
           } else {
-            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
           }
-        });
+        })
 
-        bst.getNumberOfKeys().should.equal(6);
+        bst.getNumberOfKeys().should.equal(6)
       }
 
-      recreateBst();
-      bst.delete(3);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(3);
-      assert.isNull(bst.left.left);
+      recreateBst()
+      bst.delete(3)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(3)
+      assert.isNull(bst.left.left)
 
-      recreateBst();
-      bst.delete(8);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(8);
-      assert.isNull(bst.left.right);
+      recreateBst()
+      bst.delete(8)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(8)
+      assert.isNull(bst.left.right)
 
-      recreateBst();
-      bst.delete(12);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(12);
-      assert.isNull(bst.right.left);
+      recreateBst()
+      bst.delete(12)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(12)
+      assert.isNull(bst.right.left)
 
-      recreateBst();
-      bst.delete(37);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(37);
-      assert.isNull(bst.right.right);
-    });
+      recreateBst()
+      bst.delete(37)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(37)
+      assert.isNull(bst.right.right)
+    })
 
     it('Able to delete the root if it has only one child', function () {
-      var bst;
+      let bst
 
       // Root has only one child, on the left
       bst = new BinarySearchTree();
       [10, 5, 3, 6].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
-      bst.getNumberOfKeys().should.equal(4);
-      bst.delete(10);
-      bst.checkIsBST();
+        bst.insert(k, 'some ' + k)
+      })
+      bst.getNumberOfKeys().should.equal(4)
+      bst.delete(10)
+      bst.checkIsBST()
       bst.getNumberOfKeys().should.equal(3);
       [5, 3, 6].forEach(function (k) {
-        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-      });
-      bst.search(10).length.should.equal(0);
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+      })
+      bst.search(10).length.should.equal(0)
 
       // Root has only one child, on the right
       bst = new BinarySearchTree();
       [10, 15, 13, 16].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
-      bst.getNumberOfKeys().should.equal(4);
-      bst.delete(10);
-      bst.checkIsBST();
+        bst.insert(k, 'some ' + k)
+      })
+      bst.getNumberOfKeys().should.equal(4)
+      bst.delete(10)
+      bst.checkIsBST()
       bst.getNumberOfKeys().should.equal(3);
       [15, 13, 16].forEach(function (k) {
-        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-      });
-      bst.search(10).length.should.equal(0);
-    });
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+      })
+      bst.search(10).length.should.equal(0)
+    })
 
     it('Able to delete non root nodes that have only one child', function () {
-      var bst;
+      let bst
 
       function recreateBst () {
         bst = new BinarySearchTree();
 
         [10, 5, 15, 3, 1, 4, 20, 17, 25].forEach(function (k) {
-          bst.insert(k, 'some ' + k);
-        });
+          bst.insert(k, 'some ' + k)
+        })
 
-        bst.getNumberOfKeys().should.equal(9);
+        bst.getNumberOfKeys().should.equal(9)
       }
 
       function checkOnlyOneWasRemoved (theRemoved) {
         [10, 5, 15, 3, 1, 4, 20, 17, 25].forEach(function (k) {
           if (k === theRemoved) {
-            bst.search(k).length.should.equal(0);
+            bst.search(k).length.should.equal(0)
           } else {
-            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
+            _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
           }
-        });
+        })
 
-        bst.getNumberOfKeys().should.equal(8);
+        bst.getNumberOfKeys().should.equal(8)
       }
 
-      recreateBst();
-      bst.delete(5);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(5);
+      recreateBst()
+      bst.delete(5)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(5)
 
-      recreateBst();
-      bst.delete(15);
-      bst.checkIsBST();
-      checkOnlyOneWasRemoved(15);
-    });
+      recreateBst()
+      bst.delete(15)
+      bst.checkIsBST()
+      checkOnlyOneWasRemoved(15)
+    })
 
     it('Can delete the root if it has 2 children', function () {
-      var bst;
+      let bst
 
       bst = new BinarySearchTree();
       [10, 5, 3, 8, 15, 12, 37].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
-      bst.getNumberOfKeys().should.equal(7);
-      bst.delete(10);
-      bst.checkIsBST();
+        bst.insert(k, 'some ' + k)
+      })
+      bst.getNumberOfKeys().should.equal(7)
+      bst.delete(10)
+      bst.checkIsBST()
       bst.getNumberOfKeys().should.equal(6);
       [5, 3, 8, 15, 12, 37].forEach(function (k) {
-        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-      });
-      bst.search(10).length.should.equal(0);
-    });
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+      })
+      bst.search(10).length.should.equal(0)
+    })
 
     it('Can delete a non-root node that has two children', function () {
-      var bst;
+      let bst
 
       bst = new BinarySearchTree();
       [10, 5, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
-      bst.getNumberOfKeys().should.equal(15);
-      bst.delete(5);
-      bst.checkIsBST();
+        bst.insert(k, 'some ' + k)
+      })
+      bst.getNumberOfKeys().should.equal(15)
+      bst.delete(5)
+      bst.checkIsBST()
       bst.getNumberOfKeys().should.equal(14);
       [10, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
-        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-      });
-      bst.search(5).length.should.equal(0);
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+      })
+      bst.search(5).length.should.equal(0)
 
       bst = new BinarySearchTree();
       [10, 5, 3, 1, 4, 8, 6, 9, 15, 12, 11, 13, 20, 19, 42].forEach(function (k) {
-        bst.insert(k, 'some ' + k);
-      });
-      bst.getNumberOfKeys().should.equal(15);
-      bst.delete(15);
-      bst.checkIsBST();
+        bst.insert(k, 'some ' + k)
+      })
+      bst.getNumberOfKeys().should.equal(15)
+      bst.delete(15)
+      bst.checkIsBST()
       bst.getNumberOfKeys().should.equal(14);
       [10, 5, 3, 1, 4, 8, 6, 9, 12, 11, 13, 20, 19, 42].forEach(function (k) {
-        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true);
-      });
-      bst.search(15).length.should.equal(0);
-    });
+        _.isEqual(bst.search(k), ['some ' + k]).should.equal(true)
+      })
+      bst.search(15).length.should.equal(0)
+    })
 
     it('If no value is provided, it will delete the entire node even if there are multiple pieces of data', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'yes');
-      bst.insert(5, 'hello');
-      bst.insert(3, 'yes');
-      bst.insert(5, 'world');
-      bst.insert(8, 'yes');
+      bst.insert(10, 'yes')
+      bst.insert(5, 'hello')
+      bst.insert(3, 'yes')
+      bst.insert(5, 'world')
+      bst.insert(8, 'yes')
 
-      assert.deepEqual(bst.search(5), ['hello', 'world']);
-      bst.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(bst.search(5), ['hello', 'world'])
+      bst.getNumberOfKeys().should.equal(4)
 
-      bst.delete(5);
-      bst.search(5).length.should.equal(0);
-      bst.getNumberOfKeys().should.equal(3);
-    });
+      bst.delete(5)
+      bst.search(5).length.should.equal(0)
+      bst.getNumberOfKeys().should.equal(3)
+    })
 
     it('Can remove only one value from an array', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'yes');
-      bst.insert(5, 'hello');
-      bst.insert(3, 'yes');
-      bst.insert(5, 'world');
-      bst.insert(8, 'yes');
+      bst.insert(10, 'yes')
+      bst.insert(5, 'hello')
+      bst.insert(3, 'yes')
+      bst.insert(5, 'world')
+      bst.insert(8, 'yes')
 
-      assert.deepEqual(bst.search(5), ['hello', 'world']);
-      bst.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(bst.search(5), ['hello', 'world'])
+      bst.getNumberOfKeys().should.equal(4)
 
-      bst.delete(5, 'hello');
-      assert.deepEqual(bst.search(5), ['world']);
-      bst.getNumberOfKeys().should.equal(4);
-    });
+      bst.delete(5, 'hello')
+      assert.deepEqual(bst.search(5), ['world'])
+      bst.getNumberOfKeys().should.equal(4)
+    })
 
     it('Removes nothing if value doesnt match', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'yes');
-      bst.insert(5, 'hello');
-      bst.insert(3, 'yes');
-      bst.insert(5, 'world');
-      bst.insert(8, 'yes');
+      bst.insert(10, 'yes')
+      bst.insert(5, 'hello')
+      bst.insert(3, 'yes')
+      bst.insert(5, 'world')
+      bst.insert(8, 'yes')
 
-      assert.deepEqual(bst.search(5), ['hello', 'world']);
-      bst.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(bst.search(5), ['hello', 'world'])
+      bst.getNumberOfKeys().should.equal(4)
 
-      bst.delete(5, 'nope');
-      assert.deepEqual(bst.search(5), ['hello', 'world']);
-      bst.getNumberOfKeys().should.equal(4);
-    });
+      bst.delete(5, 'nope')
+      assert.deepEqual(bst.search(5), ['hello', 'world'])
+      bst.getNumberOfKeys().should.equal(4)
+    })
 
     it('If value provided but node contains only one value, remove entire node', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'yes');
-      bst.insert(5, 'hello');
-      bst.insert(3, 'yes2');
-      bst.insert(5, 'world');
-      bst.insert(8, 'yes3');
+      bst.insert(10, 'yes')
+      bst.insert(5, 'hello')
+      bst.insert(3, 'yes2')
+      bst.insert(5, 'world')
+      bst.insert(8, 'yes3')
 
-      assert.deepEqual(bst.search(3), ['yes2']);
-      bst.getNumberOfKeys().should.equal(4);
+      assert.deepEqual(bst.search(3), ['yes2'])
+      bst.getNumberOfKeys().should.equal(4)
 
-      bst.delete(3, 'yes2');
-      bst.search(3).length.should.equal(0);
-      bst.getNumberOfKeys().should.equal(3);
-    });
+      bst.delete(3, 'yes2')
+      bst.search(3).length.should.equal(0)
+      bst.getNumberOfKeys().should.equal(3)
+    })
 
     it('Can remove the root from a tree with height 2 when the root has two children (special case)', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'maybe');
-      bst.insert(5, 'no');
-      bst.insert(15, 'yes');
-      bst.getNumberOfKeys().should.equal(3);
+      bst.insert(10, 'maybe')
+      bst.insert(5, 'no')
+      bst.insert(15, 'yes')
+      bst.getNumberOfKeys().should.equal(3)
 
-      bst.delete(10);
-      bst.checkIsBST();
-      bst.getNumberOfKeys().should.equal(2);
-      assert.deepEqual(bst.search(5), ['no']);
-      assert.deepEqual(bst.search(15), ['yes']);
-    });
+      bst.delete(10)
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(2)
+      assert.deepEqual(bst.search(5), ['no'])
+      assert.deepEqual(bst.search(15), ['yes'])
+    })
 
     it('Can remove the root from a tree with height 3 when the root has two children (special case where the two children themselves have children)', function () {
-      var bst = new BinarySearchTree();
+      const bst = new BinarySearchTree()
 
-      bst.insert(10, 'maybe');
-      bst.insert(5, 'no');
-      bst.insert(15, 'yes');
-      bst.insert(2, 'no');
-      bst.insert(35, 'yes');
-      bst.getNumberOfKeys().should.equal(5);
+      bst.insert(10, 'maybe')
+      bst.insert(5, 'no')
+      bst.insert(15, 'yes')
+      bst.insert(2, 'no')
+      bst.insert(35, 'yes')
+      bst.getNumberOfKeys().should.equal(5)
 
-      bst.delete(10);
-      bst.checkIsBST();
-      bst.getNumberOfKeys().should.equal(4);
-      assert.deepEqual(bst.search(5), ['no']);
-      assert.deepEqual(bst.search(15), ['yes']);
-    });
+      bst.delete(10)
+      bst.checkIsBST()
+      bst.getNumberOfKeys().should.equal(4)
+      assert.deepEqual(bst.search(5), ['no'])
+      assert.deepEqual(bst.search(15), ['yes'])
+    })
 
-  });   // ==== End of 'Deletion' ==== //
-
+  })   // ==== End of 'Deletion' ==== //
 
   it('Can use undefined as key and value', function () {
     function compareKeys (a, b) {
-      if (a === undefined && b === undefined) { return 0; }
-      if (a === undefined) { return -1; }
-      if (b === undefined) { return 1; }
+      if (a === undefined && b === undefined) { return 0 }
+      if (a === undefined) { return -1 }
+      if (b === undefined) { return 1 }
 
-      if (a < b) { return -1; }
-      if (a > b) { return 1; }
-      if (a === b) { return 0; }
+      if (a < b) { return -1 }
+      if (a > b) { return 1 }
+      if (a === b) { return 0 }
     }
 
-    var bst = new BinarySearchTree({ compareKeys: compareKeys });
+    const bst = new BinarySearchTree({ compareKeys: compareKeys })
 
-    bst.insert(2, undefined);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(undefined), []);
+    bst.insert(2, undefined)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(undefined), [])
 
-    bst.insert(undefined, 'hello');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(undefined), ['hello']);
+    bst.insert(undefined, 'hello')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(undefined), ['hello'])
 
-    bst.insert(undefined, 'world');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(undefined), ['hello', 'world']);
+    bst.insert(undefined, 'world')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(undefined), ['hello', 'world'])
 
-    bst.insert(4, undefined);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(4), [undefined]);
-    assert.deepEqual(bst.search(undefined), ['hello', 'world']);
+    bst.insert(4, undefined)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(4), [undefined])
+    assert.deepEqual(bst.search(undefined), ['hello', 'world'])
 
-    bst.delete(undefined, 'hello');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(4), [undefined]);
-    assert.deepEqual(bst.search(undefined), ['world']);
+    bst.delete(undefined, 'hello')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(4), [undefined])
+    assert.deepEqual(bst.search(undefined), ['world'])
 
-    bst.delete(undefined);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [undefined]);
-    assert.deepEqual(bst.search(4), [undefined]);
-    assert.deepEqual(bst.search(undefined), []);
+    bst.delete(undefined)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [undefined])
+    assert.deepEqual(bst.search(4), [undefined])
+    assert.deepEqual(bst.search(undefined), [])
 
-    bst.delete(2, undefined);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(bst.search(2), []);
-    assert.deepEqual(bst.search(4), [undefined]);
-    assert.deepEqual(bst.search(undefined), []);
+    bst.delete(2, undefined)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(bst.search(2), [])
+    assert.deepEqual(bst.search(4), [undefined])
+    assert.deepEqual(bst.search(undefined), [])
 
-    bst.delete(4);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(0);
-    assert.deepEqual(bst.search(2), []);
-    assert.deepEqual(bst.search(4), []);
-    assert.deepEqual(bst.search(undefined), []);
-  });
-
+    bst.delete(4)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(0)
+    assert.deepEqual(bst.search(2), [])
+    assert.deepEqual(bst.search(4), [])
+    assert.deepEqual(bst.search(undefined), [])
+  })
 
   it('Can use null as key and value', function () {
     function compareKeys (a, b) {
-      if (a === null && b === null) { return 0; }
-      if (a === null) { return -1; }
-      if (b === null) { return 1; }
+      if (a === null && b === null) { return 0 }
+      if (a === null) { return -1 }
+      if (b === null) { return 1 }
 
-      if (a < b) { return -1; }
-      if (a > b) { return 1; }
-      if (a === b) { return 0; }
+      if (a < b) { return -1 }
+      if (a > b) { return 1 }
+      if (a === b) { return 0 }
     }
 
-    var bst = new BinarySearchTree({ compareKeys: compareKeys });
+    const bst = new BinarySearchTree({ compareKeys: compareKeys })
 
-    bst.insert(2, null);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(null), []);
+    bst.insert(2, null)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(null), [])
 
-    bst.insert(null, 'hello');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(null), ['hello']);
+    bst.insert(null, 'hello')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(null), ['hello'])
 
-    bst.insert(null, 'world');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(null), ['hello', 'world']);
+    bst.insert(null, 'world')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(null), ['hello', 'world'])
 
-    bst.insert(4, null);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(4), [null]);
-    assert.deepEqual(bst.search(null), ['hello', 'world']);
+    bst.insert(4, null)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(4), [null])
+    assert.deepEqual(bst.search(null), ['hello', 'world'])
 
-    bst.delete(null, 'hello');
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(3);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(4), [null]);
-    assert.deepEqual(bst.search(null), ['world']);
+    bst.delete(null, 'hello')
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(3)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(4), [null])
+    assert.deepEqual(bst.search(null), ['world'])
 
-    bst.delete(null);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(2);
-    assert.deepEqual(bst.search(2), [null]);
-    assert.deepEqual(bst.search(4), [null]);
-    assert.deepEqual(bst.search(null), []);
+    bst.delete(null)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(2)
+    assert.deepEqual(bst.search(2), [null])
+    assert.deepEqual(bst.search(4), [null])
+    assert.deepEqual(bst.search(null), [])
 
-    bst.delete(2, null);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(1);
-    assert.deepEqual(bst.search(2), []);
-    assert.deepEqual(bst.search(4), [null]);
-    assert.deepEqual(bst.search(null), []);
+    bst.delete(2, null)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(1)
+    assert.deepEqual(bst.search(2), [])
+    assert.deepEqual(bst.search(4), [null])
+    assert.deepEqual(bst.search(null), [])
 
-    bst.delete(4);
-    bst.checkIsBST();
-    bst.getNumberOfKeys().should.equal(0);
-    assert.deepEqual(bst.search(2), []);
-    assert.deepEqual(bst.search(4), []);
-    assert.deepEqual(bst.search(null), []);
-  });
-
+    bst.delete(4)
+    bst.checkIsBST()
+    bst.getNumberOfKeys().should.equal(0)
+    assert.deepEqual(bst.search(2), [])
+    assert.deepEqual(bst.search(4), [])
+    assert.deepEqual(bst.search(null), [])
+  })
 
   describe('Execute on every node (=tree traversal)', function () {
 
     it('Can execute a function on every node', function () {
-      var bst = new BinarySearchTree()
-        , keys = []
-        , executed = 0
-        ;
+      const bst = new BinarySearchTree()
+      const keys = []
+      let executed = 0
 
-      bst.insert(10, 'yes');
-      bst.insert(5, 'hello');
-      bst.insert(3, 'yes2');
-      bst.insert(8, 'yes3');
-      bst.insert(15, 'yes3');
-      bst.insert(159, 'yes3');
-      bst.insert(11, 'yes3');
+      bst.insert(10, 'yes')
+      bst.insert(5, 'hello')
+      bst.insert(3, 'yes2')
+      bst.insert(8, 'yes3')
+      bst.insert(15, 'yes3')
+      bst.insert(159, 'yes3')
+      bst.insert(11, 'yes3')
 
       bst.executeOnEveryNode(function (node) {
-        keys.push(node.key);
-        executed += 1;
-      });
+        keys.push(node.key)
+        executed += 1
+      })
 
-      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159]);
-      executed.should.equal(7);
-    });
+      assert.deepEqual(keys, [3, 5, 8, 10, 11, 15, 159])
+      executed.should.equal(7)
+    })
 
-  });   // ==== End of 'Execute on every node' ==== //
-
+  })   // ==== End of 'Execute on every node' ==== //
 
   // This test performs several inserts and deletes at random, always checking the content
   // of the tree are as expected and the binary search tree constraint is respected
@@ -963,81 +978,82 @@ describe('Binary search tree', function () {
   // By their nature, BSTs can be hard to test (many possible cases, bug at one operation whose
   // effect begins to be felt only after several operations etc.)
   describe('Randomized test (takes much longer than the rest of the test suite)', function () {
-    var bst = new BinarySearchTree()
-      , data = {};
+    const bst = new BinarySearchTree()
+    const data = {}
 
     // Check a bst against a simple key => [data] object
     function checkDataIsTheSame (bst, data) {
-      var bstDataElems = [];
+      const bstDataElems = []
 
       // bstDataElems is a simple array containing every piece of data in the tree
       bst.executeOnEveryNode(function (node) {
-        var i;
+        let i
         for (i = 0; i < node.data.length; i += 1) {
-          bstDataElems.push(node.data[i]);
+          bstDataElems.push(node.data[i])
         }
-      });
+      })
 
       // Number of key and number of pieces of data match
-      bst.getNumberOfKeys().should.equal(Object.keys(data).length);
-      _.reduce(_.map(data, function (d) { return d.length; }), function (memo, n) { return memo + n; }, 0).should.equal(bstDataElems.length);
+      bst.getNumberOfKeys().should.equal(Object.keys(data).length)
+      _.reduce(_.map(data, function (d) { return d.length }), function (memo, n) { return memo + n }, 0).should.equal(bstDataElems.length)
 
       // Compare data
       Object.keys(data).forEach(function (key) {
-        checkDataEquality(bst.search(key), data[key]);
-      });
+        checkDataEquality(bst.search(key), data[key])
+      })
     }
 
     // Check two pieces of data coming from the bst and data are the same
     function checkDataEquality (fromBst, fromData) {
       if (fromBst.length === 0) {
-        if (fromData) { fromData.length.should.equal(0); }
+        if (fromData) { fromData.length.should.equal(0) }
       }
 
-      assert.deepEqual(fromBst, fromData);
+      assert.deepEqual(fromBst, fromData)
     }
 
     // Tests the tree structure (deletions concern the whole tree, deletion of some data in a node is well tested above)
     it('Inserting and deleting entire nodes', function () {
       // You can skew to be more insertive or deletive, to test all cases
       function launchRandomTest (nTests, proba) {
-        var i, key, dataPiece, possibleKeys;
+        let i
+        let key
+        let dataPiece
+        let possibleKeys
 
         for (i = 0; i < nTests; i += 1) {
           if (Math.random() > proba) {   // Deletion
-            possibleKeys = Object.keys(data);
+            possibleKeys = Object.keys(data)
 
             if (possibleKeys.length > 0) {
-              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()];
+              key = possibleKeys[Math.floor(possibleKeys.length * Math.random()).toString()]
             } else {
-              key = Math.floor(70 * Math.random()).toString();
+              key = Math.floor(70 * Math.random()).toString()
             }
 
-            delete data[key];
-            bst.delete(key);
+            delete data[key]
+            bst.delete(key)
           } else {   // Insertion
-            key = Math.floor(70 * Math.random()).toString();
-            dataPiece = Math.random().toString().substring(0, 6);
-            bst.insert(key, dataPiece);
+            key = Math.floor(70 * Math.random()).toString()
+            dataPiece = Math.random().toString().substring(0, 6)
+            bst.insert(key, dataPiece)
             if (data[key]) {
-              data[key].push(dataPiece);
+              data[key].push(dataPiece)
             } else {
-              data[key] = [dataPiece];
+              data[key] = [dataPiece]
             }
           }
 
           // Check the bst constraint are still met and the data is correct
-          bst.checkIsBST();
-          checkDataIsTheSame(bst, data);
+          bst.checkIsBST()
+          checkDataIsTheSame(bst, data)
         }
       }
 
-      launchRandomTest(1000, 0.65);
-      launchRandomTest(2000, 0.35);
-    });
+      launchRandomTest(1000, 0.65)
+      launchRandomTest(2000, 0.35)
+    })
 
-  });   // ==== End of 'Randomized test' ==== //
+  })   // ==== End of 'Randomized test' ==== //
 
-
-
-});
+})

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -1,44 +1,42 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , testDb = 'workspace/test.db'
-  , fs = require('fs')
-  , path = require('path')
-  , _ = require('underscore')
-  , async = require('async')
-  , model = require('../src/nedb/model')
-  , Datastore = require('../src/nedb/datastore')
-  , Persistence = require('../src/nedb/persistence')
-  , Cursor = require('../src/nedb/cursor')
-  ;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const testDb = 'workspace/test.db'
+const fs = require('fs')
+const path = require('path')
+const _ = require('underscore')
+const async = require('async')
+const model = require('../src/nedb/model')
+const Datastore = require('../src/nedb/datastore')
+const Persistence = require('../src/nedb/persistence')
+const Cursor = require('../src/nedb/cursor')
 
 describe('Cursor', function () {
-  var d;
+  let d
 
   beforeEach(function (done) {
-    d = new Datastore({ filename: testDb });
-    d.filename.should.equal(testDb);
-    d.inMemoryOnly.should.equal(false);
+    d = new Datastore({ filename: testDb })
+    d.filename.should.equal(testDb)
+    d.inMemoryOnly.should.equal(false)
 
     async.waterfall([
       function (cb) {
         Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
           fs.exists(testDb, function (exists) {
             if (exists) {
-              fs.unlink(testDb, cb);
-            } else { return cb(); }
-          });
-        });
+              fs.unlink(testDb, cb)
+            } else { return cb() }
+          })
+        })
       }
-    , function (cb) {
+      , function (cb) {
         d.loadDatabase(function (err) {
-          assert.isNull(err);
-          d.getAllData().length.should.equal(0);
-          return cb();
-        });
+          assert.isNull(err)
+          d.getAllData().length.should.equal(0)
+          return cb()
+        })
       }
-    ], done);
-  });
+    ], done)
+  })
 
   describe('Without sorting', function () {
 
@@ -48,106 +46,105 @@ describe('Cursor', function () {
           d.insert({ age: 52 }, function (err) {
             d.insert({ age: 23 }, function (err) {
               d.insert({ age: 89 }, function (err) {
-                return done();
-              });
-            });
-          });
-        });
-      });
-    });
+                return done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Without query, an empty query or a simple query and no skip or limit', function (done) {
       async.waterfall([
         function (cb) {
-        var cursor = new Cursor(d);
-        cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(5);
-          _.filter(docs, function(doc) { return doc.age === 5; })[0].age.should.equal(5);
-          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
-          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
-          _.filter(docs, function(doc) { return doc.age === 23; })[0].age.should.equal(23);
-          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
-          cb();
-        });
-      }
-      , function (cb) {
-        var cursor = new Cursor(d, {});
-        cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(5);
-          _.filter(docs, function(doc) { return doc.age === 5; })[0].age.should.equal(5);
-          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
-          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
-          _.filter(docs, function(doc) { return doc.age === 23; })[0].age.should.equal(23);
-          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
-          cb();
-        });
-      }
-      , function (cb) {
-        var cursor = new Cursor(d, { age: { $gt: 23 } });
-        cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(3);
-          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
-          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
-          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
-          cb();
-        });
-      }
-      ], done);
-    });
+          const cursor = new Cursor(d)
+          cursor.exec(function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(5)
+            _.filter(docs, function (doc) { return doc.age === 5 })[0].age.should.equal(5)
+            _.filter(docs, function (doc) { return doc.age === 57 })[0].age.should.equal(57)
+            _.filter(docs, function (doc) { return doc.age === 52 })[0].age.should.equal(52)
+            _.filter(docs, function (doc) { return doc.age === 23 })[0].age.should.equal(23)
+            _.filter(docs, function (doc) { return doc.age === 89 })[0].age.should.equal(89)
+            cb()
+          })
+        }
+        , function (cb) {
+          const cursor = new Cursor(d, {})
+          cursor.exec(function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(5)
+            _.filter(docs, function (doc) { return doc.age === 5 })[0].age.should.equal(5)
+            _.filter(docs, function (doc) { return doc.age === 57 })[0].age.should.equal(57)
+            _.filter(docs, function (doc) { return doc.age === 52 })[0].age.should.equal(52)
+            _.filter(docs, function (doc) { return doc.age === 23 })[0].age.should.equal(23)
+            _.filter(docs, function (doc) { return doc.age === 89 })[0].age.should.equal(89)
+            cb()
+          })
+        }
+        , function (cb) {
+          const cursor = new Cursor(d, { age: { $gt: 23 } })
+          cursor.exec(function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(3)
+            _.filter(docs, function (doc) { return doc.age === 57 })[0].age.should.equal(57)
+            _.filter(docs, function (doc) { return doc.age === 52 })[0].age.should.equal(52)
+            _.filter(docs, function (doc) { return doc.age === 89 })[0].age.should.equal(89)
+            cb()
+          })
+        }
+      ], done)
+    })
 
     it('With an empty collection', function (done) {
       async.waterfall([
         function (cb) {
-          d.remove({}, { multi: true }, function(err) { return cb(err); })
+          d.remove({}, { multi: true }, function (err) { return cb(err) })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('With a limit', function (done) {
-      var cursor = new Cursor(d);
-      cursor.limit(3);
+      const cursor = new Cursor(d)
+      cursor.limit(3)
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(3);
+        assert.isNull(err)
+        docs.length.should.equal(3)
         // No way to predict which results are returned of course ...
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it('With a skip', function (done) {
-      var cursor = new Cursor(d);
+      const cursor = new Cursor(d)
       cursor.skip(2).exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(3);
+        assert.isNull(err)
+        docs.length.should.equal(3)
         // No way to predict which results are returned of course ...
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it('With a limit and a skip and method chaining', function (done) {
-      var cursor = new Cursor(d);
-      cursor.limit(4).skip(3);   // Only way to know that the right number of results was skipped is if limit + skip > number of results
+      const cursor = new Cursor(d)
+      cursor.limit(4).skip(3)   // Only way to know that the right number of results was skipped is if limit + skip > number of results
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(2);
+        assert.isNull(err)
+        docs.length.should.equal(2)
         // No way to predict which results are returned of course ...
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-  });   // ===== End of 'Without sorting' =====
-
+  })   // ===== End of 'Without sorting' =====
 
   describe('Sorting of the results', function () {
 
@@ -158,700 +155,710 @@ describe('Cursor', function () {
           d.insert({ age: 52 }, function (err) {
             d.insert({ age: 23 }, function (err) {
               d.insert({ age: 89 }, function (err) {
-                return done();
-              });
-            });
-          });
-        });
-      });
-    });
+                return done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Using one sort', function (done) {
-      var cursor, i;
+      let cursor
+      let i
 
-      cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });
+      cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
+        assert.isNull(err)
         // Results are in ascending order
         for (i = 0; i < docs.length - 1; i += 1) {
           assert(docs[i].age < docs[i + 1].age)
         }
 
-        cursor.sort({ age: -1 });
+        cursor.sort({ age: -1 })
         cursor.exec(function (err, docs) {
-          assert.isNull(err);
+          assert.isNull(err)
           // Results are in descending order
           for (i = 0; i < docs.length - 1; i += 1) {
             assert(docs[i].age > docs[i + 1].age)
           }
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
-    it("Sorting strings with custom string comparison function", function (done) {
-      var db = new Datastore({ inMemoryOnly: true, autoload: true
-                             , compareStrings: function (a, b) { return a.length - b.length; }
-                             });
+    it('Sorting strings with custom string comparison function', function (done) {
+      const db = new Datastore({
+        inMemoryOnly: true, autoload: true
+        , compareStrings: function (a, b) { return a.length - b.length }
+      })
 
-      db.insert({ name: 'alpha' });
-      db.insert({ name: 'charlie' });
-      db.insert({ name: 'zulu' });
+      db.insert({ name: 'alpha' })
+      db.insert({ name: 'charlie' })
+      db.insert({ name: 'zulu' })
 
       db.find({}).sort({ name: 1 }).exec(function (err, docs) {
-        _.pluck(docs, 'name')[0].should.equal('zulu');
-        _.pluck(docs, 'name')[1].should.equal('alpha');
-        _.pluck(docs, 'name')[2].should.equal('charlie');
+        _.pluck(docs, 'name')[0].should.equal('zulu')
+        _.pluck(docs, 'name')[1].should.equal('alpha')
+        _.pluck(docs, 'name')[2].should.equal('charlie')
 
-        delete db.compareStrings;
+        delete db.compareStrings
         db.find({}).sort({ name: 1 }).exec(function (err, docs) {
-          _.pluck(docs, 'name')[0].should.equal('alpha');
-          _.pluck(docs, 'name')[1].should.equal('charlie');
-          _.pluck(docs, 'name')[2].should.equal('zulu');
+          _.pluck(docs, 'name')[0].should.equal('alpha')
+          _.pluck(docs, 'name')[1].should.equal('charlie')
+          _.pluck(docs, 'name')[2].should.equal('zulu')
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('With an empty collection', function (done) {
       async.waterfall([
         function (cb) {
-          d.remove({}, { multi: true }, function(err) { return cb(err); })
+          d.remove({}, { multi: true }, function (err) { return cb(err) })
         }
-      , function (cb) {
-    var cursor = new Cursor(d);
-    cursor.sort({ age: 1 });
-    cursor.exec(function (err, docs) {
-      assert.isNull(err);
-      docs.length.should.equal(0);
-      cb();
-    });
-      }
-      ], done);
-    });
+        , function (cb) {
+          const cursor = new Cursor(d)
+          cursor.sort({ age: 1 })
+          cursor.exec(function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
+        }
+      ], done)
+    })
 
     it('Ability to chain sorting and exec', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).exec(function (err, docs) {
-            assert.isNull(err);
+            assert.isNull(err)
             // Results are in ascending order
             for (i = 0; i < docs.length - 1; i += 1) {
               assert(docs[i].age < docs[i + 1].age)
             }
-            cb();
-          });
+            cb()
+          })
         }
-      , function (cb) {
-    var cursor = new Cursor(d);
-    cursor.sort({ age: -1 }).exec(function (err, docs) {
-      assert.isNull(err);
-      // Results are in descending order
-      for (i = 0; i < docs.length - 1; i += 1) {
-        assert(docs[i].age > docs[i + 1].age)
-      }
-      cb();
-    });
-      }
-      ], done);
-    });
+        , function (cb) {
+          const cursor = new Cursor(d)
+          cursor.sort({ age: -1 }).exec(function (err, docs) {
+            assert.isNull(err)
+            // Results are in descending order
+            for (i = 0; i < docs.length - 1; i += 1) {
+              assert(docs[i].age > docs[i + 1].age)
+            }
+            cb()
+          })
+        }
+      ], done)
+    })
 
     it('Using limit and sort', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(3).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(3);
-            docs[0].age.should.equal(5);
-            docs[1].age.should.equal(23);
-            docs[2].age.should.equal(52);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(3)
+            docs[0].age.should.equal(5)
+            docs[1].age.should.equal(23)
+            docs[2].age.should.equal(52)
+            cb()
+          })
         }
-      , function (cb) {
-    var cursor = new Cursor(d);
-    cursor.sort({ age: -1 }).limit(2).exec(function (err, docs) {
-      assert.isNull(err);
-      docs.length.should.equal(2);
-      docs[0].age.should.equal(89);
-      docs[1].age.should.equal(57);
-      cb();
-    });
-      }
-      ], done);
-    });
+        , function (cb) {
+          const cursor = new Cursor(d)
+          cursor.sort({ age: -1 }).limit(2).exec(function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            docs[0].age.should.equal(89)
+            docs[1].age.should.equal(57)
+            cb()
+          })
+        }
+      ], done)
+    })
 
     it('Using a limit higher than total number of docs shouldnt cause an error', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(7).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(5);
-            docs[0].age.should.equal(5);
-            docs[1].age.should.equal(23);
-            docs[2].age.should.equal(52);
-            docs[3].age.should.equal(57);
-            docs[4].age.should.equal(89);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(5)
+            docs[0].age.should.equal(5)
+            docs[1].age.should.equal(23)
+            docs[2].age.should.equal(52)
+            docs[3].age.should.equal(57)
+            docs[4].age.should.equal(89)
+            cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Using limit and skip with sort', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(1).skip(2).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            docs[0].age.should.equal(52);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            docs[0].age.should.equal(52)
+            cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(3).skip(1).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(3);
-            docs[0].age.should.equal(23);
-            docs[1].age.should.equal(52);
-            docs[2].age.should.equal(57);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(3)
+            docs[0].age.should.equal(23)
+            docs[1].age.should.equal(52)
+            docs[2].age.should.equal(57)
+            cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.sort({ age: -1 }).limit(2).skip(2).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(2);
-            docs[0].age.should.equal(52);
-            docs[1].age.should.equal(23);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            docs[0].age.should.equal(52)
+            docs[1].age.should.equal(23)
+            cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Using too big a limit and a skip with sort', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(8).skip(2).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(3);
-            docs[0].age.should.equal(52);
-            docs[1].age.should.equal(57);
-            docs[2].age.should.equal(89);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(3)
+            docs[0].age.should.equal(52)
+            docs[1].age.should.equal(57)
+            docs[2].age.should.equal(89)
+            cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Using too big a skip with sort should return no result', function (done) {
-      var i;
+      let i
       async.waterfall([
         function (cb) {
-          var cursor = new Cursor(d);
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).skip(5).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).skip(7).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(3).skip(7).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d);
+        , function (cb) {
+          const cursor = new Cursor(d)
           cursor.sort({ age: 1 }).limit(6).skip(7).exec(function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Sorting strings', function (done) {
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
-            d.insert({ name: 'jako'}, function () {
+            d.insert({ name: 'jako' }, function () {
               d.insert({ name: 'jakeb' }, function () {
                 d.insert({ name: 'sue' }, function () {
-                  return cb();
-                });
-              });
-            });
-          });
+                  return cb()
+                })
+              })
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ name: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(3);
-            docs[0].name.should.equal('jakeb');
-            docs[1].name.should.equal('jako');
-            docs[2].name.should.equal('sue');
-            return cb();
-          });
+            docs.length.should.equal(3)
+            docs[0].name.should.equal('jakeb')
+            docs[1].name.should.equal('jako')
+            docs[2].name.should.equal('sue')
+            return cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ name: -1 }).exec(function (err, docs) {
-            docs.length.should.equal(3);
-            docs[0].name.should.equal('sue');
-            docs[1].name.should.equal('jako');
-            docs[2].name.should.equal('jakeb');
-            return cb();
-          });
+            docs.length.should.equal(3)
+            docs[0].name.should.equal('sue')
+            docs[1].name.should.equal('jako')
+            docs[2].name.should.equal('jakeb')
+            return cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Sorting nested fields with dates', function (done) {
-      var doc1, doc2, doc3;
+      let doc1
+      let doc2
+      let doc3
 
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
             d.insert({ event: { recorded: new Date(400) } }, function (err, _doc1) {
-              doc1 = _doc1;
+              doc1 = _doc1
               d.insert({ event: { recorded: new Date(60000) } }, function (err, _doc2) {
-                doc2 = _doc2;
+                doc2 = _doc2
                 d.insert({ event: { recorded: new Date(32) } }, function (err, _doc3) {
-                  doc3 = _doc3;
-                  return cb();
-                });
-              });
-            });
-          });
+                  doc3 = _doc3
+                  return cb()
+                })
+              })
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
-          cursor.sort({ "event.recorded": 1 }).exec(function (err, docs) {
-            docs.length.should.equal(3);
-            docs[0]._id.should.equal(doc3._id);
-            docs[1]._id.should.equal(doc1._id);
-            docs[2]._id.should.equal(doc2._id);
-            return cb();
-          });
+        , function (cb) {
+          const cursor = new Cursor(d, {})
+          cursor.sort({ 'event.recorded': 1 }).exec(function (err, docs) {
+            docs.length.should.equal(3)
+            docs[0]._id.should.equal(doc3._id)
+            docs[1]._id.should.equal(doc1._id)
+            docs[2]._id.should.equal(doc2._id)
+            return cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
-          cursor.sort({ "event.recorded": -1 }).exec(function (err, docs) {
-            docs.length.should.equal(3);
-            docs[0]._id.should.equal(doc2._id);
-            docs[1]._id.should.equal(doc1._id);
-            docs[2]._id.should.equal(doc3._id);
-            return cb();
-          });
+        , function (cb) {
+          const cursor = new Cursor(d, {})
+          cursor.sort({ 'event.recorded': -1 }).exec(function (err, docs) {
+            docs.length.should.equal(3)
+            docs[0]._id.should.equal(doc2._id)
+            docs[1]._id.should.equal(doc1._id)
+            docs[2]._id.should.equal(doc3._id)
+            return cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Sorting when some fields are undefined', function (done) {
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
             d.insert({ name: 'jako', other: 2 }, function () {
               d.insert({ name: 'jakeb', other: 3 }, function () {
                 d.insert({ name: 'sue' }, function () {
                   d.insert({ name: 'henry', other: 4 }, function () {
-                    return cb();
-                  });
-                });
-              });
-            });
-          });
+                    return cb()
+                  })
+                })
+              })
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ other: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(4);
-            docs[0].name.should.equal('sue');
-            assert.isUndefined(docs[0].other);
-            docs[1].name.should.equal('jako');
-            docs[1].other.should.equal(2);
-            docs[2].name.should.equal('jakeb');
-            docs[2].other.should.equal(3);
-            docs[3].name.should.equal('henry');
-            docs[3].other.should.equal(4);
-            return cb();
-          });
+            docs.length.should.equal(4)
+            docs[0].name.should.equal('sue')
+            assert.isUndefined(docs[0].other)
+            docs[1].name.should.equal('jako')
+            docs[1].other.should.equal(2)
+            docs[2].name.should.equal('jakeb')
+            docs[2].other.should.equal(3)
+            docs[3].name.should.equal('henry')
+            docs[3].other.should.equal(4)
+            return cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, { name: { $in: [ 'suzy', 'jakeb', 'jako' ] } });
+        , function (cb) {
+          const cursor = new Cursor(d, { name: { $in: ['suzy', 'jakeb', 'jako'] } })
           cursor.sort({ other: -1 }).exec(function (err, docs) {
-            docs.length.should.equal(2);
-            docs[0].name.should.equal('jakeb');
-            docs[0].other.should.equal(3);
-            docs[1].name.should.equal('jako');
-            docs[1].other.should.equal(2);
-            return cb();
-          });
+            docs.length.should.equal(2)
+            docs[0].name.should.equal('jakeb')
+            docs[0].other.should.equal(3)
+            docs[1].name.should.equal('jako')
+            docs[1].other.should.equal(2)
+            return cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
     it('Sorting when all fields are undefined', function (done) {
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
-            d.insert({ name: 'jako'}, function () {
+            d.insert({ name: 'jako' }, function () {
               d.insert({ name: 'jakeb' }, function () {
                 d.insert({ name: 'sue' }, function () {
-                  return cb();
-                });
-              });
-            });
-          });
+                  return cb()
+                })
+              })
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ other: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(3);
-            return cb();
-          });
+            docs.length.should.equal(3)
+            return cb()
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, { name: { $in: [ 'sue', 'jakeb', 'jakob' ] } });
+        , function (cb) {
+          const cursor = new Cursor(d, { name: { $in: ['sue', 'jakeb', 'jakob'] } })
           cursor.sort({ other: -1 }).exec(function (err, docs) {
-            docs.length.should.equal(2);
-            return cb();
-          });
+            docs.length.should.equal(2)
+            return cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
-    it('Multiple consecutive sorts', function(done) {
+    it('Multiple consecutive sorts', function (done) {
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
             d.insert({ name: 'jako', age: 43, nid: 1 }, function () {
               d.insert({ name: 'jakeb', age: 43, nid: 2 }, function () {
                 d.insert({ name: 'sue', age: 12, nid: 3 }, function () {
                   d.insert({ name: 'zoe', age: 23, nid: 4 }, function () {
                     d.insert({ name: 'jako', age: 35, nid: 5 }, function () {
-                      return cb();
-                    });
-                  });
-                });
-              });
-            });
-          });
+                      return cb()
+                    })
+                  })
+                })
+              })
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ name: 1, age: -1 }).exec(function (err, docs) {
-            docs.length.should.equal(5);
+            docs.length.should.equal(5)
 
-            docs[0].nid.should.equal(2);
-            docs[1].nid.should.equal(1);
-            docs[2].nid.should.equal(5);
-            docs[3].nid.should.equal(3);
-            docs[4].nid.should.equal(4);
-            return cb();
-          });
+            docs[0].nid.should.equal(2)
+            docs[1].nid.should.equal(1)
+            docs[2].nid.should.equal(5)
+            docs[3].nid.should.equal(3)
+            docs[4].nid.should.equal(4)
+            return cb()
+          })
         }
         , function (cb) {
-          var cursor = new Cursor(d, {});
+          const cursor = new Cursor(d, {})
           cursor.sort({ name: 1, age: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(5);
+            docs.length.should.equal(5)
 
-            docs[0].nid.should.equal(2);
-            docs[1].nid.should.equal(5);
-            docs[2].nid.should.equal(1);
-            docs[3].nid.should.equal(3);
-            docs[4].nid.should.equal(4);
-            return cb();
-          });
+            docs[0].nid.should.equal(2)
+            docs[1].nid.should.equal(5)
+            docs[2].nid.should.equal(1)
+            docs[3].nid.should.equal(3)
+            docs[4].nid.should.equal(4)
+            return cb()
+          })
         }
         , function (cb) {
-          var cursor = new Cursor(d, {});
+          const cursor = new Cursor(d, {})
           cursor.sort({ age: 1, name: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(5);
+            docs.length.should.equal(5)
 
-            docs[0].nid.should.equal(3);
-            docs[1].nid.should.equal(4);
-            docs[2].nid.should.equal(5);
-            docs[3].nid.should.equal(2);
-            docs[4].nid.should.equal(1);
-            return cb();
-          });
+            docs[0].nid.should.equal(3)
+            docs[1].nid.should.equal(4)
+            docs[2].nid.should.equal(5)
+            docs[3].nid.should.equal(2)
+            docs[4].nid.should.equal(1)
+            return cb()
+          })
         }
         , function (cb) {
-          var cursor = new Cursor(d, {});
+          const cursor = new Cursor(d, {})
           cursor.sort({ age: 1, name: -1 }).exec(function (err, docs) {
-            docs.length.should.equal(5);
+            docs.length.should.equal(5)
 
-            docs[0].nid.should.equal(3);
-            docs[1].nid.should.equal(4);
-            docs[2].nid.should.equal(5);
-            docs[3].nid.should.equal(1);
-            docs[4].nid.should.equal(2);
-            return cb();
-          });
+            docs[0].nid.should.equal(3)
+            docs[1].nid.should.equal(4)
+            docs[2].nid.should.equal(5)
+            docs[3].nid.should.equal(1)
+            docs[4].nid.should.equal(2)
+            return cb()
+          })
         }
-      ], done);    });
+      ], done)
+    })
 
-    it('Similar data, multiple consecutive sorts', function(done) {
-      var i, j, id
-        , companies = [ 'acme', 'milkman', 'zoinks' ]
-        , entities = []
-        ;
+    it('Similar data, multiple consecutive sorts', function (done) {
+      let i
+      let j
+      let id
+      const companies = ['acme', 'milkman', 'zoinks']
+      const entities = []
 
       async.waterfall([
         function (cb) {
           d.remove({}, { multi: true }, function (err) {
-            if (err) { return cb(err); }
+            if (err) { return cb(err) }
 
-            id = 1;
+            id = 1
             for (i = 0; i < companies.length; i++) {
               for (j = 5; j <= 100; j += 5) {
                 entities.push({
                   company: companies[i],
                   cost: j,
                   nid: id
-                });
-                id++;
+                })
+                id++
               }
             }
 
-            async.each(entities, function(entity, callback) {
-              d.insert(entity, function() {
-                callback();
-              });
-            }, function(err) {
-              return cb();
-            });
-          });
+            async.each(entities, function (entity, callback) {
+              d.insert(entity, function () {
+                callback()
+              })
+            }, function (err) {
+              return cb()
+            })
+          })
         }
-      , function (cb) {
-          var cursor = new Cursor(d, {});
+        , function (cb) {
+          const cursor = new Cursor(d, {})
           cursor.sort({ company: 1, cost: 1 }).exec(function (err, docs) {
-            docs.length.should.equal(60);
+            docs.length.should.equal(60)
 
-            for (var i = 0; i < docs.length; i++) {
-              docs[i].nid.should.equal(i+1);
-            };
-            return cb();
-          });
+            for (let i = 0; i < docs.length; i++) {
+              docs[i].nid.should.equal(i + 1)
+            }
+
+            return cb()
+          })
         }
-      ], done);    });
+      ], done)
+    })
 
-  });   // ===== End of 'Sorting' =====
-
+  })   // ===== End of 'Sorting' =====
 
   describe('Projections', function () {
-    var doc1, doc2, doc3, doc4, doc0;
-
+    let doc1
+    let doc2
+    let doc3
+    let doc4
+    let doc0
 
     beforeEach(function (done) {
       // We don't know the order in which docs wil be inserted but we ensure correctness by testing both sort orders
       d.insert({ age: 5, name: 'Jo', planet: 'B', toys: { bebe: true, ballon: 'much' } }, function (err, _doc0) {
-        doc0 = _doc0;
+        doc0 = _doc0
         d.insert({ age: 57, name: 'Louis', planet: 'R', toys: { ballon: 'yeah', bebe: false } }, function (err, _doc1) {
-          doc1 = _doc1;
+          doc1 = _doc1
           d.insert({ age: 52, name: 'Grafitti', planet: 'C', toys: { bebe: 'kind of' } }, function (err, _doc2) {
-            doc2 = _doc2;
+            doc2 = _doc2
             d.insert({ age: 23, name: 'LM', planet: 'S' }, function (err, _doc3) {
-              doc3 = _doc3;
+              doc3 = _doc3
               d.insert({ age: 89, planet: 'Earth' }, function (err, _doc4) {
-                doc4 = _doc4;
-                return done();
-              });
-            });
-          });
-        });
-      });
-    });
+                doc4 = _doc4
+                return done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Takes all results if no projection or empty object given', function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(5);
-        assert.deepEqual(docs[0], doc0);
-        assert.deepEqual(docs[1], doc3);
-        assert.deepEqual(docs[2], doc2);
-        assert.deepEqual(docs[3], doc1);
-        assert.deepEqual(docs[4], doc4);
+        assert.isNull(err)
+        docs.length.should.equal(5)
+        assert.deepEqual(docs[0], doc0)
+        assert.deepEqual(docs[1], doc3)
+        assert.deepEqual(docs[2], doc2)
+        assert.deepEqual(docs[3], doc1)
+        assert.deepEqual(docs[4], doc4)
 
-        cursor.projection({});
+        cursor.projection({})
         cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(5);
-          assert.deepEqual(docs[0], doc0);
-          assert.deepEqual(docs[1], doc3);
-          assert.deepEqual(docs[2], doc2);
-          assert.deepEqual(docs[3], doc1);
-          assert.deepEqual(docs[4], doc4);
+          assert.isNull(err)
+          docs.length.should.equal(5)
+          assert.deepEqual(docs[0], doc0)
+          assert.deepEqual(docs[1], doc3)
+          assert.deepEqual(docs[2], doc2)
+          assert.deepEqual(docs[3], doc1)
+          assert.deepEqual(docs[4], doc4)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('Can take only the expected fields', function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
-      cursor.projection({ age: 1, name: 1 });
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
+      cursor.projection({ age: 1, name: 1 })
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(5);
+        assert.isNull(err)
+        docs.length.should.equal(5)
         // Takes the _id by default
-        assert.deepEqual(docs[0], { age: 5, name: 'Jo', _id: doc0._id });
-        assert.deepEqual(docs[1], { age: 23, name: 'LM', _id: doc3._id });
-        assert.deepEqual(docs[2], { age: 52, name: 'Grafitti', _id: doc2._id });
-        assert.deepEqual(docs[3], { age: 57, name: 'Louis', _id: doc1._id });
-        assert.deepEqual(docs[4], { age: 89, _id: doc4._id });   // No problems if one field to take doesn't exist
+        assert.deepEqual(docs[0], { age: 5, name: 'Jo', _id: doc0._id })
+        assert.deepEqual(docs[1], { age: 23, name: 'LM', _id: doc3._id })
+        assert.deepEqual(docs[2], { age: 52, name: 'Grafitti', _id: doc2._id })
+        assert.deepEqual(docs[3], { age: 57, name: 'Louis', _id: doc1._id })
+        assert.deepEqual(docs[4], { age: 89, _id: doc4._id })   // No problems if one field to take doesn't exist
 
-        cursor.projection({ age: 1, name: 1, _id: 0 });
+        cursor.projection({ age: 1, name: 1, _id: 0 })
         cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(5);
-          assert.deepEqual(docs[0], { age: 5, name: 'Jo' });
-          assert.deepEqual(docs[1], { age: 23, name: 'LM' });
-          assert.deepEqual(docs[2], { age: 52, name: 'Grafitti' });
-          assert.deepEqual(docs[3], { age: 57, name: 'Louis' });
-          assert.deepEqual(docs[4], { age: 89 });   // No problems if one field to take doesn't exist
+          assert.isNull(err)
+          docs.length.should.equal(5)
+          assert.deepEqual(docs[0], { age: 5, name: 'Jo' })
+          assert.deepEqual(docs[1], { age: 23, name: 'LM' })
+          assert.deepEqual(docs[2], { age: 52, name: 'Grafitti' })
+          assert.deepEqual(docs[3], { age: 57, name: 'Louis' })
+          assert.deepEqual(docs[4], { age: 89 })   // No problems if one field to take doesn't exist
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('Can omit only the expected fields', function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
-      cursor.projection({ age: 0, name: 0 });
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
+      cursor.projection({ age: 0, name: 0 })
       cursor.exec(function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(5);
+        assert.isNull(err)
+        docs.length.should.equal(5)
         // Takes the _id by default
-        assert.deepEqual(docs[0], { planet: 'B', _id: doc0._id, toys: { bebe: true, ballon: 'much' } });
-        assert.deepEqual(docs[1], { planet: 'S', _id: doc3._id });
-        assert.deepEqual(docs[2], { planet: 'C', _id: doc2._id, toys: { bebe: 'kind of' } });
-        assert.deepEqual(docs[3], { planet: 'R', _id: doc1._id, toys: { bebe: false, ballon: 'yeah' } });
-        assert.deepEqual(docs[4], { planet: 'Earth', _id: doc4._id });
+        assert.deepEqual(docs[0], { planet: 'B', _id: doc0._id, toys: { bebe: true, ballon: 'much' } })
+        assert.deepEqual(docs[1], { planet: 'S', _id: doc3._id })
+        assert.deepEqual(docs[2], { planet: 'C', _id: doc2._id, toys: { bebe: 'kind of' } })
+        assert.deepEqual(docs[3], { planet: 'R', _id: doc1._id, toys: { bebe: false, ballon: 'yeah' } })
+        assert.deepEqual(docs[4], { planet: 'Earth', _id: doc4._id })
 
-        cursor.projection({ age: 0, name: 0, _id: 0 });
+        cursor.projection({ age: 0, name: 0, _id: 0 })
         cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(5);
-          assert.deepEqual(docs[0], { planet: 'B', toys: { bebe: true, ballon: 'much' } });
-          assert.deepEqual(docs[1], { planet: 'S' });
-          assert.deepEqual(docs[2], { planet: 'C', toys: { bebe: 'kind of' } });
-          assert.deepEqual(docs[3], { planet: 'R', toys: { bebe: false, ballon: 'yeah' } });
-          assert.deepEqual(docs[4], { planet: 'Earth' });
+          assert.isNull(err)
+          docs.length.should.equal(5)
+          assert.deepEqual(docs[0], { planet: 'B', toys: { bebe: true, ballon: 'much' } })
+          assert.deepEqual(docs[1], { planet: 'S' })
+          assert.deepEqual(docs[2], { planet: 'C', toys: { bebe: 'kind of' } })
+          assert.deepEqual(docs[3], { planet: 'R', toys: { bebe: false, ballon: 'yeah' } })
+          assert.deepEqual(docs[4], { planet: 'Earth' })
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('Cannot use both modes except for _id', function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
-      cursor.projection({ age: 1, name: 0 });
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
+      cursor.projection({ age: 1, name: 0 })
       cursor.exec(function (err, docs) {
-        assert.isNotNull(err);
-        assert.isUndefined(docs);
+        assert.isNotNull(err)
+        assert.isUndefined(docs)
 
-        cursor.projection({ age: 1, _id: 0 });
+        cursor.projection({ age: 1, _id: 0 })
         cursor.exec(function (err, docs) {
-          assert.isNull(err);
-          assert.deepEqual(docs[0], { age: 5 });
-          assert.deepEqual(docs[1], { age: 23 });
-          assert.deepEqual(docs[2], { age: 52 });
-          assert.deepEqual(docs[3], { age: 57 });
-          assert.deepEqual(docs[4], { age: 89 });
+          assert.isNull(err)
+          assert.deepEqual(docs[0], { age: 5 })
+          assert.deepEqual(docs[1], { age: 23 })
+          assert.deepEqual(docs[2], { age: 52 })
+          assert.deepEqual(docs[3], { age: 57 })
+          assert.deepEqual(docs[4], { age: 89 })
 
-          cursor.projection({ age: 0, toys: 0, planet: 0, _id: 1 });
+          cursor.projection({ age: 0, toys: 0, planet: 0, _id: 1 })
           cursor.exec(function (err, docs) {
-            assert.isNull(err);
-            assert.deepEqual(docs[0], { name: 'Jo', _id: doc0._id });
-            assert.deepEqual(docs[1], { name: 'LM', _id: doc3._id });
-            assert.deepEqual(docs[2], { name: 'Grafitti', _id: doc2._id });
-            assert.deepEqual(docs[3], { name: 'Louis', _id: doc1._id });
-            assert.deepEqual(docs[4], { _id: doc4._id });
+            assert.isNull(err)
+            assert.deepEqual(docs[0], { name: 'Jo', _id: doc0._id })
+            assert.deepEqual(docs[1], { name: 'LM', _id: doc3._id })
+            assert.deepEqual(docs[2], { name: 'Grafitti', _id: doc2._id })
+            assert.deepEqual(docs[3], { name: 'Louis', _id: doc1._id })
+            assert.deepEqual(docs[4], { _id: doc4._id })
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
-    it("Projections on embedded documents - omit type", function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
-      cursor.projection({ name: 0, planet: 0, 'toys.bebe': 0, _id: 0 });
+    it('Projections on embedded documents - omit type', function (done) {
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
+      cursor.projection({ name: 0, planet: 0, 'toys.bebe': 0, _id: 0 })
       cursor.exec(function (err, docs) {
-        assert.deepEqual(docs[0], { age: 5, toys: { ballon: 'much' } });
-        assert.deepEqual(docs[1], { age: 23 });
-        assert.deepEqual(docs[2], { age: 52, toys: {} });
-        assert.deepEqual(docs[3], { age: 57, toys: { ballon: 'yeah' } });
-        assert.deepEqual(docs[4], { age: 89 });
+        assert.deepEqual(docs[0], { age: 5, toys: { ballon: 'much' } })
+        assert.deepEqual(docs[1], { age: 23 })
+        assert.deepEqual(docs[2], { age: 52, toys: {} })
+        assert.deepEqual(docs[3], { age: 57, toys: { ballon: 'yeah' } })
+        assert.deepEqual(docs[4], { age: 89 })
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-    it("Projections on embedded documents - pick type", function (done) {
-      var cursor = new Cursor(d, {});
-      cursor.sort({ age: 1 });   // For easier finding
-      cursor.projection({ name: 1, 'toys.ballon': 1, _id: 0 });
+    it('Projections on embedded documents - pick type', function (done) {
+      const cursor = new Cursor(d, {})
+      cursor.sort({ age: 1 })   // For easier finding
+      cursor.projection({ name: 1, 'toys.ballon': 1, _id: 0 })
       cursor.exec(function (err, docs) {
-        assert.deepEqual(docs[0], { name: 'Jo', toys: { ballon: 'much' } });
-        assert.deepEqual(docs[1], { name: 'LM' });
-        assert.deepEqual(docs[2], { name: 'Grafitti' });
-        assert.deepEqual(docs[3], { name: 'Louis', toys: { ballon: 'yeah' } });
-        assert.deepEqual(docs[4], {});
+        assert.deepEqual(docs[0], { name: 'Jo', toys: { ballon: 'much' } })
+        assert.deepEqual(docs[1], { name: 'LM' })
+        assert.deepEqual(docs[2], { name: 'Grafitti' })
+        assert.deepEqual(docs[3], { name: 'Louis', toys: { ballon: 'yeah' } })
+        assert.deepEqual(docs[4], {})
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-  });   // ==== End of 'Projections' ====
+  })   // ==== End of 'Projections' ====
 
-});
+})
 
 
 

--- a/test/cursor.test.js
+++ b/test/cursor.test.js
@@ -1,0 +1,862 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , testDb = 'workspace/test.db'
+  , fs = require('fs')
+  , path = require('path')
+  , _ = require('underscore')
+  , async = require('async')
+  , model = require('../src/nedb/model')
+  , Datastore = require('../src/nedb/datastore')
+  , Persistence = require('../src/nedb/persistence')
+  , Cursor = require('../src/nedb/cursor')
+  ;
+
+
+describe('Cursor', function () {
+  var d;
+
+  beforeEach(function (done) {
+    d = new Datastore({ filename: testDb });
+    d.filename.should.equal(testDb);
+    d.inMemoryOnly.should.equal(false);
+
+    async.waterfall([
+      function (cb) {
+        Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
+          fs.exists(testDb, function (exists) {
+            if (exists) {
+              fs.unlink(testDb, cb);
+            } else { return cb(); }
+          });
+        });
+      }
+    , function (cb) {
+        d.loadDatabase(function (err) {
+          assert.isNull(err);
+          d.getAllData().length.should.equal(0);
+          return cb();
+        });
+      }
+    ], done);
+  });
+
+  describe('Without sorting', function () {
+
+    beforeEach(function (done) {
+      d.insert({ age: 5 }, function (err) {
+        d.insert({ age: 57 }, function (err) {
+          d.insert({ age: 52 }, function (err) {
+            d.insert({ age: 23 }, function (err) {
+              d.insert({ age: 89 }, function (err) {
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Without query, an empty query or a simple query and no skip or limit', function (done) {
+      async.waterfall([
+        function (cb) {
+        var cursor = new Cursor(d);
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(5);
+          _.filter(docs, function(doc) { return doc.age === 5; })[0].age.should.equal(5);
+          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
+          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
+          _.filter(docs, function(doc) { return doc.age === 23; })[0].age.should.equal(23);
+          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
+          cb();
+        });
+      }
+      , function (cb) {
+        var cursor = new Cursor(d, {});
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(5);
+          _.filter(docs, function(doc) { return doc.age === 5; })[0].age.should.equal(5);
+          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
+          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
+          _.filter(docs, function(doc) { return doc.age === 23; })[0].age.should.equal(23);
+          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
+          cb();
+        });
+      }
+      , function (cb) {
+        var cursor = new Cursor(d, { age: { $gt: 23 } });
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(3);
+          _.filter(docs, function(doc) { return doc.age === 57; })[0].age.should.equal(57);
+          _.filter(docs, function(doc) { return doc.age === 52; })[0].age.should.equal(52);
+          _.filter(docs, function(doc) { return doc.age === 89; })[0].age.should.equal(89);
+          cb();
+        });
+      }
+      ], done);
+    });
+
+    it('With an empty collection', function (done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function(err) { return cb(err); })
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('With a limit', function (done) {
+      var cursor = new Cursor(d);
+      cursor.limit(3);
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(3);
+        // No way to predict which results are returned of course ...
+        done();
+      });
+    });
+
+    it('With a skip', function (done) {
+      var cursor = new Cursor(d);
+      cursor.skip(2).exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(3);
+        // No way to predict which results are returned of course ...
+        done();
+      });
+    });
+
+    it('With a limit and a skip and method chaining', function (done) {
+      var cursor = new Cursor(d);
+      cursor.limit(4).skip(3);   // Only way to know that the right number of results was skipped is if limit + skip > number of results
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(2);
+        // No way to predict which results are returned of course ...
+        done();
+      });
+    });
+
+  });   // ===== End of 'Without sorting' =====
+
+
+  describe('Sorting of the results', function () {
+
+    beforeEach(function (done) {
+      // We don't know the order in which docs wil be inserted but we ensure correctness by testing both sort orders
+      d.insert({ age: 5 }, function (err) {
+        d.insert({ age: 57 }, function (err) {
+          d.insert({ age: 52 }, function (err) {
+            d.insert({ age: 23 }, function (err) {
+              d.insert({ age: 89 }, function (err) {
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Using one sort', function (done) {
+      var cursor, i;
+
+      cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        // Results are in ascending order
+        for (i = 0; i < docs.length - 1; i += 1) {
+          assert(docs[i].age < docs[i + 1].age)
+        }
+
+        cursor.sort({ age: -1 });
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          // Results are in descending order
+          for (i = 0; i < docs.length - 1; i += 1) {
+            assert(docs[i].age > docs[i + 1].age)
+          }
+
+          done();
+        });
+      });
+    });
+
+    it("Sorting strings with custom string comparison function", function (done) {
+      var db = new Datastore({ inMemoryOnly: true, autoload: true
+                             , compareStrings: function (a, b) { return a.length - b.length; }
+                             });
+
+      db.insert({ name: 'alpha' });
+      db.insert({ name: 'charlie' });
+      db.insert({ name: 'zulu' });
+
+      db.find({}).sort({ name: 1 }).exec(function (err, docs) {
+        _.pluck(docs, 'name')[0].should.equal('zulu');
+        _.pluck(docs, 'name')[1].should.equal('alpha');
+        _.pluck(docs, 'name')[2].should.equal('charlie');
+
+        delete db.compareStrings;
+        db.find({}).sort({ name: 1 }).exec(function (err, docs) {
+          _.pluck(docs, 'name')[0].should.equal('alpha');
+          _.pluck(docs, 'name')[1].should.equal('charlie');
+          _.pluck(docs, 'name')[2].should.equal('zulu');
+
+          done();
+        });
+      });
+    });
+
+    it('With an empty collection', function (done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function(err) { return cb(err); })
+        }
+      , function (cb) {
+    var cursor = new Cursor(d);
+    cursor.sort({ age: 1 });
+    cursor.exec(function (err, docs) {
+      assert.isNull(err);
+      docs.length.should.equal(0);
+      cb();
+    });
+      }
+      ], done);
+    });
+
+    it('Ability to chain sorting and exec', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).exec(function (err, docs) {
+            assert.isNull(err);
+            // Results are in ascending order
+            for (i = 0; i < docs.length - 1; i += 1) {
+              assert(docs[i].age < docs[i + 1].age)
+            }
+            cb();
+          });
+        }
+      , function (cb) {
+    var cursor = new Cursor(d);
+    cursor.sort({ age: -1 }).exec(function (err, docs) {
+      assert.isNull(err);
+      // Results are in descending order
+      for (i = 0; i < docs.length - 1; i += 1) {
+        assert(docs[i].age > docs[i + 1].age)
+      }
+      cb();
+    });
+      }
+      ], done);
+    });
+
+    it('Using limit and sort', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(3).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(3);
+            docs[0].age.should.equal(5);
+            docs[1].age.should.equal(23);
+            docs[2].age.should.equal(52);
+            cb();
+          });
+        }
+      , function (cb) {
+    var cursor = new Cursor(d);
+    cursor.sort({ age: -1 }).limit(2).exec(function (err, docs) {
+      assert.isNull(err);
+      docs.length.should.equal(2);
+      docs[0].age.should.equal(89);
+      docs[1].age.should.equal(57);
+      cb();
+    });
+      }
+      ], done);
+    });
+
+    it('Using a limit higher than total number of docs shouldnt cause an error', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(7).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(5);
+            docs[0].age.should.equal(5);
+            docs[1].age.should.equal(23);
+            docs[2].age.should.equal(52);
+            docs[3].age.should.equal(57);
+            docs[4].age.should.equal(89);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Using limit and skip with sort', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(1).skip(2).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            docs[0].age.should.equal(52);
+            cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(3).skip(1).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(3);
+            docs[0].age.should.equal(23);
+            docs[1].age.should.equal(52);
+            docs[2].age.should.equal(57);
+            cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: -1 }).limit(2).skip(2).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(2);
+            docs[0].age.should.equal(52);
+            docs[1].age.should.equal(23);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Using too big a limit and a skip with sort', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(8).skip(2).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(3);
+            docs[0].age.should.equal(52);
+            docs[1].age.should.equal(57);
+            docs[2].age.should.equal(89);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Using too big a skip with sort should return no result', function (done) {
+      var i;
+      async.waterfall([
+        function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).skip(5).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).skip(7).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(3).skip(7).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d);
+          cursor.sort({ age: 1 }).limit(6).skip(7).exec(function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Sorting strings', function (done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            d.insert({ name: 'jako'}, function () {
+              d.insert({ name: 'jakeb' }, function () {
+                d.insert({ name: 'sue' }, function () {
+                  return cb();
+                });
+              });
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ name: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(3);
+            docs[0].name.should.equal('jakeb');
+            docs[1].name.should.equal('jako');
+            docs[2].name.should.equal('sue');
+            return cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ name: -1 }).exec(function (err, docs) {
+            docs.length.should.equal(3);
+            docs[0].name.should.equal('sue');
+            docs[1].name.should.equal('jako');
+            docs[2].name.should.equal('jakeb');
+            return cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Sorting nested fields with dates', function (done) {
+      var doc1, doc2, doc3;
+
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            d.insert({ event: { recorded: new Date(400) } }, function (err, _doc1) {
+              doc1 = _doc1;
+              d.insert({ event: { recorded: new Date(60000) } }, function (err, _doc2) {
+                doc2 = _doc2;
+                d.insert({ event: { recorded: new Date(32) } }, function (err, _doc3) {
+                  doc3 = _doc3;
+                  return cb();
+                });
+              });
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ "event.recorded": 1 }).exec(function (err, docs) {
+            docs.length.should.equal(3);
+            docs[0]._id.should.equal(doc3._id);
+            docs[1]._id.should.equal(doc1._id);
+            docs[2]._id.should.equal(doc2._id);
+            return cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ "event.recorded": -1 }).exec(function (err, docs) {
+            docs.length.should.equal(3);
+            docs[0]._id.should.equal(doc2._id);
+            docs[1]._id.should.equal(doc1._id);
+            docs[2]._id.should.equal(doc3._id);
+            return cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Sorting when some fields are undefined', function (done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            d.insert({ name: 'jako', other: 2 }, function () {
+              d.insert({ name: 'jakeb', other: 3 }, function () {
+                d.insert({ name: 'sue' }, function () {
+                  d.insert({ name: 'henry', other: 4 }, function () {
+                    return cb();
+                  });
+                });
+              });
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ other: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(4);
+            docs[0].name.should.equal('sue');
+            assert.isUndefined(docs[0].other);
+            docs[1].name.should.equal('jako');
+            docs[1].other.should.equal(2);
+            docs[2].name.should.equal('jakeb');
+            docs[2].other.should.equal(3);
+            docs[3].name.should.equal('henry');
+            docs[3].other.should.equal(4);
+            return cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, { name: { $in: [ 'suzy', 'jakeb', 'jako' ] } });
+          cursor.sort({ other: -1 }).exec(function (err, docs) {
+            docs.length.should.equal(2);
+            docs[0].name.should.equal('jakeb');
+            docs[0].other.should.equal(3);
+            docs[1].name.should.equal('jako');
+            docs[1].other.should.equal(2);
+            return cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Sorting when all fields are undefined', function (done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            d.insert({ name: 'jako'}, function () {
+              d.insert({ name: 'jakeb' }, function () {
+                d.insert({ name: 'sue' }, function () {
+                  return cb();
+                });
+              });
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ other: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(3);
+            return cb();
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, { name: { $in: [ 'sue', 'jakeb', 'jakob' ] } });
+          cursor.sort({ other: -1 }).exec(function (err, docs) {
+            docs.length.should.equal(2);
+            return cb();
+          });
+        }
+      ], done);
+    });
+
+    it('Multiple consecutive sorts', function(done) {
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            d.insert({ name: 'jako', age: 43, nid: 1 }, function () {
+              d.insert({ name: 'jakeb', age: 43, nid: 2 }, function () {
+                d.insert({ name: 'sue', age: 12, nid: 3 }, function () {
+                  d.insert({ name: 'zoe', age: 23, nid: 4 }, function () {
+                    d.insert({ name: 'jako', age: 35, nid: 5 }, function () {
+                      return cb();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ name: 1, age: -1 }).exec(function (err, docs) {
+            docs.length.should.equal(5);
+
+            docs[0].nid.should.equal(2);
+            docs[1].nid.should.equal(1);
+            docs[2].nid.should.equal(5);
+            docs[3].nid.should.equal(3);
+            docs[4].nid.should.equal(4);
+            return cb();
+          });
+        }
+        , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ name: 1, age: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(5);
+
+            docs[0].nid.should.equal(2);
+            docs[1].nid.should.equal(5);
+            docs[2].nid.should.equal(1);
+            docs[3].nid.should.equal(3);
+            docs[4].nid.should.equal(4);
+            return cb();
+          });
+        }
+        , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ age: 1, name: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(5);
+
+            docs[0].nid.should.equal(3);
+            docs[1].nid.should.equal(4);
+            docs[2].nid.should.equal(5);
+            docs[3].nid.should.equal(2);
+            docs[4].nid.should.equal(1);
+            return cb();
+          });
+        }
+        , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ age: 1, name: -1 }).exec(function (err, docs) {
+            docs.length.should.equal(5);
+
+            docs[0].nid.should.equal(3);
+            docs[1].nid.should.equal(4);
+            docs[2].nid.should.equal(5);
+            docs[3].nid.should.equal(1);
+            docs[4].nid.should.equal(2);
+            return cb();
+          });
+        }
+      ], done);    });
+
+    it('Similar data, multiple consecutive sorts', function(done) {
+      var i, j, id
+        , companies = [ 'acme', 'milkman', 'zoinks' ]
+        , entities = []
+        ;
+
+      async.waterfall([
+        function (cb) {
+          d.remove({}, { multi: true }, function (err) {
+            if (err) { return cb(err); }
+
+            id = 1;
+            for (i = 0; i < companies.length; i++) {
+              for (j = 5; j <= 100; j += 5) {
+                entities.push({
+                  company: companies[i],
+                  cost: j,
+                  nid: id
+                });
+                id++;
+              }
+            }
+
+            async.each(entities, function(entity, callback) {
+              d.insert(entity, function() {
+                callback();
+              });
+            }, function(err) {
+              return cb();
+            });
+          });
+        }
+      , function (cb) {
+          var cursor = new Cursor(d, {});
+          cursor.sort({ company: 1, cost: 1 }).exec(function (err, docs) {
+            docs.length.should.equal(60);
+
+            for (var i = 0; i < docs.length; i++) {
+              docs[i].nid.should.equal(i+1);
+            };
+            return cb();
+          });
+        }
+      ], done);    });
+
+  });   // ===== End of 'Sorting' =====
+
+
+  describe('Projections', function () {
+    var doc1, doc2, doc3, doc4, doc0;
+
+
+    beforeEach(function (done) {
+      // We don't know the order in which docs wil be inserted but we ensure correctness by testing both sort orders
+      d.insert({ age: 5, name: 'Jo', planet: 'B', toys: { bebe: true, ballon: 'much' } }, function (err, _doc0) {
+        doc0 = _doc0;
+        d.insert({ age: 57, name: 'Louis', planet: 'R', toys: { ballon: 'yeah', bebe: false } }, function (err, _doc1) {
+          doc1 = _doc1;
+          d.insert({ age: 52, name: 'Grafitti', planet: 'C', toys: { bebe: 'kind of' } }, function (err, _doc2) {
+            doc2 = _doc2;
+            d.insert({ age: 23, name: 'LM', planet: 'S' }, function (err, _doc3) {
+              doc3 = _doc3;
+              d.insert({ age: 89, planet: 'Earth' }, function (err, _doc4) {
+                doc4 = _doc4;
+                return done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Takes all results if no projection or empty object given', function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(5);
+        assert.deepEqual(docs[0], doc0);
+        assert.deepEqual(docs[1], doc3);
+        assert.deepEqual(docs[2], doc2);
+        assert.deepEqual(docs[3], doc1);
+        assert.deepEqual(docs[4], doc4);
+
+        cursor.projection({});
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(5);
+          assert.deepEqual(docs[0], doc0);
+          assert.deepEqual(docs[1], doc3);
+          assert.deepEqual(docs[2], doc2);
+          assert.deepEqual(docs[3], doc1);
+          assert.deepEqual(docs[4], doc4);
+
+          done();
+        });
+      });
+    });
+
+    it('Can take only the expected fields', function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.projection({ age: 1, name: 1 });
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(5);
+        // Takes the _id by default
+        assert.deepEqual(docs[0], { age: 5, name: 'Jo', _id: doc0._id });
+        assert.deepEqual(docs[1], { age: 23, name: 'LM', _id: doc3._id });
+        assert.deepEqual(docs[2], { age: 52, name: 'Grafitti', _id: doc2._id });
+        assert.deepEqual(docs[3], { age: 57, name: 'Louis', _id: doc1._id });
+        assert.deepEqual(docs[4], { age: 89, _id: doc4._id });   // No problems if one field to take doesn't exist
+
+        cursor.projection({ age: 1, name: 1, _id: 0 });
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(5);
+          assert.deepEqual(docs[0], { age: 5, name: 'Jo' });
+          assert.deepEqual(docs[1], { age: 23, name: 'LM' });
+          assert.deepEqual(docs[2], { age: 52, name: 'Grafitti' });
+          assert.deepEqual(docs[3], { age: 57, name: 'Louis' });
+          assert.deepEqual(docs[4], { age: 89 });   // No problems if one field to take doesn't exist
+
+          done();
+        });
+      });
+    });
+
+    it('Can omit only the expected fields', function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.projection({ age: 0, name: 0 });
+      cursor.exec(function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(5);
+        // Takes the _id by default
+        assert.deepEqual(docs[0], { planet: 'B', _id: doc0._id, toys: { bebe: true, ballon: 'much' } });
+        assert.deepEqual(docs[1], { planet: 'S', _id: doc3._id });
+        assert.deepEqual(docs[2], { planet: 'C', _id: doc2._id, toys: { bebe: 'kind of' } });
+        assert.deepEqual(docs[3], { planet: 'R', _id: doc1._id, toys: { bebe: false, ballon: 'yeah' } });
+        assert.deepEqual(docs[4], { planet: 'Earth', _id: doc4._id });
+
+        cursor.projection({ age: 0, name: 0, _id: 0 });
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(5);
+          assert.deepEqual(docs[0], { planet: 'B', toys: { bebe: true, ballon: 'much' } });
+          assert.deepEqual(docs[1], { planet: 'S' });
+          assert.deepEqual(docs[2], { planet: 'C', toys: { bebe: 'kind of' } });
+          assert.deepEqual(docs[3], { planet: 'R', toys: { bebe: false, ballon: 'yeah' } });
+          assert.deepEqual(docs[4], { planet: 'Earth' });
+
+          done();
+        });
+      });
+    });
+
+    it('Cannot use both modes except for _id', function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.projection({ age: 1, name: 0 });
+      cursor.exec(function (err, docs) {
+        assert.isNotNull(err);
+        assert.isUndefined(docs);
+
+        cursor.projection({ age: 1, _id: 0 });
+        cursor.exec(function (err, docs) {
+          assert.isNull(err);
+          assert.deepEqual(docs[0], { age: 5 });
+          assert.deepEqual(docs[1], { age: 23 });
+          assert.deepEqual(docs[2], { age: 52 });
+          assert.deepEqual(docs[3], { age: 57 });
+          assert.deepEqual(docs[4], { age: 89 });
+
+          cursor.projection({ age: 0, toys: 0, planet: 0, _id: 1 });
+          cursor.exec(function (err, docs) {
+            assert.isNull(err);
+            assert.deepEqual(docs[0], { name: 'Jo', _id: doc0._id });
+            assert.deepEqual(docs[1], { name: 'LM', _id: doc3._id });
+            assert.deepEqual(docs[2], { name: 'Grafitti', _id: doc2._id });
+            assert.deepEqual(docs[3], { name: 'Louis', _id: doc1._id });
+            assert.deepEqual(docs[4], { _id: doc4._id });
+
+            done();
+          });
+        });
+      });
+    });
+
+    it("Projections on embedded documents - omit type", function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.projection({ name: 0, planet: 0, 'toys.bebe': 0, _id: 0 });
+      cursor.exec(function (err, docs) {
+        assert.deepEqual(docs[0], { age: 5, toys: { ballon: 'much' } });
+        assert.deepEqual(docs[1], { age: 23 });
+        assert.deepEqual(docs[2], { age: 52, toys: {} });
+        assert.deepEqual(docs[3], { age: 57, toys: { ballon: 'yeah' } });
+        assert.deepEqual(docs[4], { age: 89 });
+
+        done();
+      });
+    });
+
+    it("Projections on embedded documents - pick type", function (done) {
+      var cursor = new Cursor(d, {});
+      cursor.sort({ age: 1 });   // For easier finding
+      cursor.projection({ name: 1, 'toys.ballon': 1, _id: 0 });
+      cursor.exec(function (err, docs) {
+        assert.deepEqual(docs[0], { name: 'Jo', toys: { ballon: 'much' } });
+        assert.deepEqual(docs[1], { name: 'LM' });
+        assert.deepEqual(docs[2], { name: 'Grafitti' });
+        assert.deepEqual(docs[3], { name: 'Louis', toys: { ballon: 'yeah' } });
+        assert.deepEqual(docs[4], {});
+
+        done();
+      });
+    });
+
+  });   // ==== End of 'Projections' ====
+
+});
+
+
+
+
+
+
+
+

--- a/test/customUtil.test.js
+++ b/test/customUtil.test.js
@@ -1,0 +1,26 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , customUtils = require('../src/nedb/customUtils')
+  , fs = require('fs')
+  ;
+
+
+describe('customUtils', function () {
+
+  describe('uid', function () {
+
+    it('Generates a string of the expected length', function () {
+      customUtils.uid(3).length.should.equal(3);
+      customUtils.uid(16).length.should.equal(16);
+      customUtils.uid(42).length.should.equal(42);
+      customUtils.uid(1000).length.should.equal(1000);
+    });
+
+    // Very small probability of conflict
+    it('Generated uids should not be the same', function () {
+      customUtils.uid(56).should.not.equal(customUtils.uid(56));
+    });
+
+  });
+
+});

--- a/test/customUtil.test.js
+++ b/test/customUtil.test.js
@@ -1,26 +1,24 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , customUtils = require('../src/nedb/customUtils')
-  , fs = require('fs')
-  ;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const customUtils = require('../src/nedb/customUtils')
+const fs = require('fs')
 
 describe('customUtils', function () {
 
   describe('uid', function () {
 
     it('Generates a string of the expected length', function () {
-      customUtils.uid(3).length.should.equal(3);
-      customUtils.uid(16).length.should.equal(16);
-      customUtils.uid(42).length.should.equal(42);
-      customUtils.uid(1000).length.should.equal(1000);
-    });
+      customUtils.uid(3).length.should.equal(3)
+      customUtils.uid(16).length.should.equal(16)
+      customUtils.uid(42).length.should.equal(42)
+      customUtils.uid(1000).length.should.equal(1000)
+    })
 
     // Very small probability of conflict
     it('Generated uids should not be the same', function () {
-      customUtils.uid(56).should.not.equal(customUtils.uid(56));
-    });
+      customUtils.uid(56).should.not.equal(customUtils.uid(56))
+    })
 
-  });
+  })
 
-});
+})

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,0 +1,2876 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , testDb = 'workspace/test.db'
+  , fs = require('fs')
+  , path = require('path')
+  , _ = require('underscore')
+  , async = require('async')
+  , model = require('../src/nedb/model')
+  , Datastore = require('../src/nedb/datastore')
+  , Persistence = require('../src/nedb/persistence')
+  , reloadTimeUpperBound = 60;   // In ms, an upper bound for the reload time used to check createdAt and updatedAt
+  ;
+
+
+describe('Database', function () {
+  var d;
+
+  beforeEach(function (done) {
+    d = new Datastore({ filename: testDb });
+    d.filename.should.equal(testDb);
+    d.inMemoryOnly.should.equal(false);
+
+    async.waterfall([
+      function (cb) {
+        Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
+          fs.exists(testDb, function (exists) {
+            if (exists) {
+              fs.unlink(testDb, cb);
+            } else { return cb(); }
+          });
+        });
+      }
+    , function (cb) {
+        d.loadDatabase(function (err) {
+          assert.isNull(err);
+          d.getAllData().length.should.equal(0);
+          return cb();
+        });
+      }
+    ], done);
+  });
+
+  it('Constructor compatibility with v0.6-', function () {
+    var dbef = new Datastore('somefile');
+    dbef.filename.should.equal('somefile');
+    dbef.inMemoryOnly.should.equal(false);
+
+    var dbef = new Datastore('');
+    assert.isNull(dbef.filename);
+    dbef.inMemoryOnly.should.equal(true);
+
+    var dbef = new Datastore();
+    assert.isNull(dbef.filename);
+    dbef.inMemoryOnly.should.equal(true);
+  });
+
+  describe('Autoloading', function () {
+
+    it('Can autoload a database and query it right away', function (done) {
+      var fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({ _id: '2', a: 5, planet: 'Mars' }) + '\n'
+        , autoDb = 'workspace/auto.db'
+        , db
+        ;
+
+      fs.writeFileSync(autoDb, fileStr, 'utf8');
+      db = new Datastore({ filename: autoDb, autoload: true })
+
+      db.find({}, function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(2);
+        done();
+      });
+    });
+
+    it('Throws if autoload fails', function (done) {
+      var fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({ _id: '2', a: 5, planet: 'Mars' }) + '\n' + '{"$$indexCreated":{"fieldName":"a","unique":true}}'
+        , autoDb = 'workspace/auto.db'
+        , db
+        ;
+
+      fs.writeFileSync(autoDb, fileStr, 'utf8');
+
+      // Check the loadDatabase generated an error
+      function onload (err) {
+        err.errorType.should.equal('uniqueViolated');
+        done();
+      }
+
+      db = new Datastore({ filename: autoDb, autoload: true, onload: onload })
+
+      db.find({}, function (err, docs) {
+        done(new Error("Find should not be executed since autoload failed"));
+      });
+    });
+
+  });
+
+  describe('Insert', function () {
+
+    it('Able to insert a document in the database, setting an _id if none provided, and retrieve it even after a reload', function (done) {
+      d.find({}, function (err, docs) {
+        docs.length.should.equal(0);
+
+        d.insert({ somedata: 'ok' }, function (err) {
+          // The data was correctly updated
+          d.find({}, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            Object.keys(docs[0]).length.should.equal(2);
+            docs[0].somedata.should.equal('ok');
+            assert.isDefined(docs[0]._id);
+
+            // After a reload the data has been correctly persisted
+            d.loadDatabase(function (err) {
+              d.find({}, function (err, docs) {
+                assert.isNull(err);
+                docs.length.should.equal(1);
+                Object.keys(docs[0]).length.should.equal(2);
+                docs[0].somedata.should.equal('ok');
+                assert.isDefined(docs[0]._id);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can insert multiple documents in the database', function (done) {
+      d.find({}, function (err, docs) {
+        docs.length.should.equal(0);
+
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'another' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) {
+              d.find({}, function (err, docs) {
+                docs.length.should.equal(3);
+                _.pluck(docs, 'somedata').should.contain('ok');
+                _.pluck(docs, 'somedata').should.contain('another');
+                _.pluck(docs, 'somedata').should.contain('again');
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can insert and get back from DB complex objects with all primitive and secondary types', function (done) {
+      var da = new Date()
+        , obj = { a: ['ee', 'ff', 42], date: da, subobj: { a: 'b', b: 'c' } }
+        ;
+
+      d.insert(obj, function (err) {
+        d.findOne({}, function (err, res) {
+          assert.isNull(err);
+          res.a.length.should.equal(3);
+          res.a[0].should.equal('ee');
+          res.a[1].should.equal('ff');
+          res.a[2].should.equal(42);
+          res.date.getTime().should.equal(da.getTime());
+          res.subobj.a.should.equal('b');
+          res.subobj.b.should.equal('c');
+
+          done();
+        });
+      });
+    });
+
+    it('If an object returned from the DB is modified and refetched, the original value should be found', function (done) {
+      d.insert({ a: 'something' }, function () {
+        d.findOne({}, function (err, doc) {
+          doc.a.should.equal('something');
+          doc.a = 'another thing';
+          doc.a.should.equal('another thing');
+
+          // Re-fetching with findOne should yield the persisted value
+          d.findOne({}, function (err, doc) {
+            doc.a.should.equal('something');
+            doc.a = 'another thing';
+            doc.a.should.equal('another thing');
+
+            // Re-fetching with find should yield the persisted value
+            d.find({}, function (err, docs) {
+              docs[0].a.should.equal('something');
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('Cannot insert a doc that has a field beginning with a $ sign', function (done) {
+      d.insert({ $something: 'atest' }, function (err) {
+        assert.isDefined(err);
+        done();
+      });
+    });
+
+    it('If an _id is already given when we insert a document, use that instead of generating a random one', function (done) {
+      d.insert({ _id: 'test', stuff: true }, function (err, newDoc) {
+        if (err) { return done(err); }
+
+        newDoc.stuff.should.equal(true);
+        newDoc._id.should.equal('test');
+
+        d.insert({ _id: 'test', otherstuff: 42 }, function (err) {
+          err.errorType.should.equal('uniqueViolated');
+
+          done();
+        });
+      });
+    });
+
+    it('Modifying the insertedDoc after an insert doesnt change the copy saved in the database', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function (err, newDoc) {
+        newDoc.hello = 'changed';
+
+        d.findOne({ a: 2 }, function (err, doc) {
+          doc.hello.should.equal('world');
+          done();
+        });
+      });
+    });
+
+    it('Can insert an array of documents at once', function (done) {
+      var docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }];
+
+      d.insert(docs, function (err) {
+        d.find({}, function (err, docs) {
+          var data;
+
+          docs.length.should.equal(2);
+          _.find(docs, function (doc) { return doc.a === 5; }).b.should.equal('hello');
+          _.find(docs, function (doc) { return doc.a === 42; }).b.should.equal('world');
+
+          // The data has been persisted correctly
+          data = _.filter(fs.readFileSync(testDb, 'utf8').split('\n'), function (line) { return line.length > 0; });
+          data.length.should.equal(2);
+          model.deserialize(data[0]).a.should.equal(5);
+          model.deserialize(data[0]).b.should.equal('hello');
+          model.deserialize(data[1]).a.should.equal(42);
+          model.deserialize(data[1]).b.should.equal('world');
+
+          done();
+        });
+      });
+    });
+
+    it('If a bulk insert violates a constraint, all changes are rolled back', function (done) {
+      var docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }, { a: 5, b: 'bloup' }, { a: 7 }];
+
+      d.ensureIndex({ fieldName: 'a', unique: true }, function () {   // Important to specify callback here to make sure filesystem synced
+        d.insert(docs, function (err) {
+          err.errorType.should.equal('uniqueViolated');
+
+          d.find({}, function (err, docs) {
+            // Datafile only contains index definition
+            var datafileContents = model.deserialize(fs.readFileSync(testDb, 'utf8'));
+            assert.deepEqual(datafileContents, { $$indexCreated: { fieldName: 'a', unique: true } });
+
+            docs.length.should.equal(0);
+
+            done();
+          });
+        });
+      });
+    });
+
+    it("If timestampData option is set, a createdAt field is added and persisted", function (done) {
+      var newDoc = { hello: 'world' }, beginning = Date.now();
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+      d.find({}, function (err, docs) {
+        assert.isNull(err);
+        docs.length.should.equal(0);
+
+        d.insert(newDoc, function (err, insertedDoc) {
+          // No side effect on given input
+          assert.deepEqual(newDoc, { hello: 'world' });
+          // Insert doc has two new fields, _id and createdAt
+          insertedDoc.hello.should.equal('world');
+          assert.isDefined(insertedDoc.createdAt);
+          assert.isDefined(insertedDoc.updatedAt);
+          insertedDoc.createdAt.should.equal(insertedDoc.updatedAt);
+          assert.isDefined(insertedDoc._id);
+          Object.keys(insertedDoc).length.should.equal(4);
+          assert.isBelow(Math.abs(insertedDoc.createdAt.getTime() - beginning), reloadTimeUpperBound);   // No more than 30ms should have elapsed (worst case, if there is a flush)
+
+          // Modifying results of insert doesn't change the cache
+          insertedDoc.bloup = "another";
+          Object.keys(insertedDoc).length.should.equal(5);
+
+          d.find({}, function (err, docs) {
+            docs.length.should.equal(1);
+            assert.deepEqual(newDoc, { hello: 'world' });
+            assert.deepEqual({ hello: 'world', _id: insertedDoc._id, createdAt: insertedDoc.createdAt, updatedAt: insertedDoc.updatedAt }, docs[0]);
+
+            // All data correctly persisted on disk
+            d.loadDatabase(function () {
+              d.find({}, function (err, docs) {
+                docs.length.should.equal(1);
+                assert.deepEqual(newDoc, { hello: 'world' });
+                assert.deepEqual({ hello: 'world', _id: insertedDoc._id, createdAt: insertedDoc.createdAt, updatedAt: insertedDoc.updatedAt }, docs[0]);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it("If timestampData option not set, don't create a createdAt and a updatedAt field", function (done) {
+      d.insert({ hello: 'world' }, function (err, insertedDoc) {
+        Object.keys(insertedDoc).length.should.equal(2);
+        assert.isUndefined(insertedDoc.createdAt);
+        assert.isUndefined(insertedDoc.updatedAt);
+
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+          assert.deepEqual(docs[0], insertedDoc);
+
+          done();
+        });
+      });
+    });
+
+    it("If timestampData is set but createdAt is specified by user, don't change it", function (done) {
+      var newDoc = { hello: 'world', createdAt: new Date(234) }, beginning = Date.now();
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+      d.insert(newDoc, function (err, insertedDoc) {
+        Object.keys(insertedDoc).length.should.equal(4);
+        insertedDoc.createdAt.getTime().should.equal(234);   // Not modified
+        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound);   // Created
+
+        d.find({}, function (err, docs) {
+          assert.deepEqual(insertedDoc, docs[0]);
+
+          d.loadDatabase(function () {
+            d.find({}, function (err, docs) {
+              assert.deepEqual(insertedDoc, docs[0]);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it("If timestampData is set but updatedAt is specified by user, don't change it", function (done) {
+      var newDoc = { hello: 'world', updatedAt: new Date(234) }, beginning = Date.now();
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+      d.insert(newDoc, function (err, insertedDoc) {
+        Object.keys(insertedDoc).length.should.equal(4);
+        insertedDoc.updatedAt.getTime().should.equal(234);   // Not modified
+        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound);   // Created
+
+        d.find({}, function (err, docs) {
+          assert.deepEqual(insertedDoc, docs[0]);
+
+          d.loadDatabase(function () {
+            d.find({}, function (err, docs) {
+              assert.deepEqual(insertedDoc, docs[0]);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('Can insert a doc with id 0', function (done) {
+      d.insert({ _id: 0, hello: 'world' }, function (err, doc) {
+        doc._id.should.equal(0);
+        doc.hello.should.equal('world');
+        done();
+      });
+    });
+
+    /**
+     * Complicated behavior here. Basically we need to test that when a user function throws an exception, it is not caught
+     * in NeDB and the callback called again, transforming a user error into a NeDB error.
+     *
+     * So we need a way to check that the callback is called only once and the exception thrown is indeed the client exception
+     * Mocha's exception handling mechanism interferes with this since it already registers a listener on uncaughtException
+     * which we need to use since findOne is not called in the same turn of the event loop (so no try/catch)
+     * So we remove all current listeners, put our own which when called will register the former listeners (incl. Mocha's) again.
+     *
+     * Note: maybe using an in-memory only NeDB would give us an easier solution
+     */
+    it('If the callback throws an uncaught exception, do not catch it inside findOne, this is userspace concern', function (done) {
+      var tryCount = 0
+        , currentUncaughtExceptionHandlers = process.listeners('uncaughtException')
+        , i
+        ;
+
+      process.removeAllListeners('uncaughtException');
+
+      process.on('uncaughtException', function MINE (ex) {
+        process.removeAllListeners('uncaughtException');
+
+        for (i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
+          process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+        }
+
+        ex.message.should.equal('SOME EXCEPTION');
+        done();
+      });
+
+      d.insert({ a: 5 }, function () {
+        d.findOne({ a : 5}, function (err, doc) {
+          if (tryCount === 0) {
+            tryCount += 1;
+            throw new Error('SOME EXCEPTION');
+          } else {
+            done(new Error('Callback was called twice'));
+          }
+        });
+      });
+    });
+
+  });   // ==== End of 'Insert' ==== //
+
+
+  describe('#getCandidates', function () {
+
+    it('Can use an index to get docs with a basic match', function (done) {
+      d.ensureIndex({ fieldName: 'tf' }, function (err) {
+        d.insert({ tf: 4 }, function (err, _doc1) {
+          d.insert({ tf: 6 }, function () {
+            d.insert({ tf: 4, an: 'other' }, function (err, _doc2) {
+              d.insert({ tf: 9 }, function () {
+                d.getCandidates({ r: 6, tf: 4 }, function (err, data) {
+                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
+                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
+                    ;
+
+                  data.length.should.equal(2);
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 });
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 4, an: 'other' });
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use an index to get docs with a $in match', function (done) {
+      d.ensureIndex({ fieldName: 'tf' }, function (err) {
+        d.insert({ tf: 4 }, function (err) {
+          d.insert({ tf: 6 }, function (err, _doc1) {
+            d.insert({ tf: 4, an: 'other' }, function (err) {
+              d.insert({ tf: 9 }, function (err, _doc2) {
+                d.getCandidates({ r: 6, tf: { $in: [6, 9, 5] } }, function (err, data) {
+                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
+                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
+                    ;
+
+                  data.length.should.equal(2);
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 6 });
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 9 });
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('If no index can be used, return the whole database', function (done) {
+      d.ensureIndex({ fieldName: 'tf' }, function (err) {
+        d.insert({ tf: 4 }, function (err, _doc1) {
+          d.insert({ tf: 6 }, function (err, _doc2) {
+            d.insert({ tf: 4, an: 'other' }, function (err, _doc3) {
+              d.insert({ tf: 9 }, function (err, _doc4) {
+                d.getCandidates({ r: 6, notf: { $in: [6, 9, 5] } }, function (err, data) {
+                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
+                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
+                    , doc3 = _.find(data, function (d) { return d._id === _doc3._id; })
+                    , doc4 = _.find(data, function (d) { return d._id === _doc4._id; })
+                    ;
+
+                  data.length.should.equal(4);
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 });
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 });
+                  assert.deepEqual(doc3, { _id: doc3._id, tf: 4, an: 'other' });
+                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 });
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use indexes for comparison matches', function (done) {
+      d.ensureIndex({ fieldName: 'tf' }, function (err) {
+        d.insert({ tf: 4 }, function (err, _doc1) {
+          d.insert({ tf: 6 }, function (err, _doc2) {
+            d.insert({ tf: 4, an: 'other' }, function (err, _doc3) {
+              d.insert({ tf: 9 }, function (err, _doc4) {
+                d.getCandidates({ r: 6, tf: { $lte: 9, $gte: 6 } }, function (err, data) {
+                  var doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
+                    , doc4 = _.find(data, function (d) { return d._id === _doc4._id; })
+                    ;
+
+                  data.length.should.equal(2);
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 });
+                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 });
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it("Can set a TTL index that expires documents", function (done) {
+      d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
+        d.insert({ hello: 'world', exp: new Date() }, function () {
+          setTimeout(function () {
+            d.findOne({}, function (err, doc) {
+              assert.isNull(err);
+              doc.hello.should.equal('world');
+
+              setTimeout(function () {
+                d.findOne({}, function (err, doc) {
+                  assert.isNull(err);
+                  assert.isNull(doc);
+
+                  d.on('compaction.done', function () {
+                    // After compaction, no more mention of the document, correctly removed
+                    var datafileContents = fs.readFileSync(testDb, 'utf8');
+                    datafileContents.split('\n').length.should.equal(2);
+                    assert.isNull(datafileContents.match(/world/));
+
+                    // New datastore on same datafile is empty
+                    var d2 = new Datastore({ filename: testDb, autoload: true });
+                    d2.findOne({}, function (err, doc) {
+                      assert.isNull(err);
+                      assert.isNull(doc);
+
+                      done();
+                    });
+                  });
+
+                  d.persistence.compactDatafile();
+                });
+              }, 101);
+            });
+          }, 100);
+        });
+      });
+    });
+
+    it("TTL indexes can expire multiple documents and only what needs to be expired", function (done) {
+      d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
+        d.insert({ hello: 'world1', exp: new Date() }, function () {
+          d.insert({ hello: 'world2', exp: new Date() }, function () {
+            d.insert({ hello: 'world3', exp: new Date((new Date()).getTime() + 100) }, function () {
+              setTimeout(function () {
+                d.find({}, function (err, docs) {
+                  assert.isNull(err);
+                  docs.length.should.equal(3);
+
+                  setTimeout(function () {
+                    d.find({}, function (err, docs) {
+                      assert.isNull(err);
+                      docs.length.should.equal(1);
+                      docs[0].hello.should.equal('world3');
+
+                      setTimeout(function () {
+                        d.find({}, function (err, docs) {
+                          assert.isNull(err);
+                          docs.length.should.equal(0);
+
+                          done();
+                        });
+                      }, 101);
+                    });
+                  }, 101);
+                });
+              }, 100);
+            });
+          });
+        });
+      });
+    });
+
+    it("Document where indexed field is absent or not a date are ignored", function (done) {
+      d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
+        d.insert({ hello: 'world1', exp: new Date() }, function () {
+          d.insert({ hello: 'world2', exp: "not a date" }, function () {
+            d.insert({ hello: 'world3' }, function () {
+              setTimeout(function () {
+                d.find({}, function (err, docs) {
+                  assert.isNull(err);
+                  docs.length.should.equal(3);
+
+                  setTimeout(function () {
+                    d.find({}, function (err, docs) {
+                      assert.isNull(err);
+                      docs.length.should.equal(2);
+
+
+                      docs[0].hello.should.not.equal('world1');
+                      docs[1].hello.should.not.equal('world1');
+
+                      done();
+                    });
+                  }, 101);
+                });
+              }, 100);
+            });
+          });
+        });
+      });
+    });
+
+  });   // ==== End of '#getCandidates' ==== //
+
+
+  describe('Find', function () {
+
+    it('Can find all documents if an empty query is used', function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with empty object
+        d.find({}, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(3);
+          _.pluck(docs, 'somedata').should.contain('ok');
+          _.pluck(docs, 'somedata').should.contain('another');
+          _.find(docs, function (d) { return d.somedata === 'another' }).plus.should.equal('additional data');
+          _.pluck(docs, 'somedata').should.contain('again');
+          return cb();
+        });
+      }
+      ], done);
+    });
+
+    it('Can find all documents matching a basic query', function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that will return docs
+        d.find({ somedata: 'again' }, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(2);
+          _.pluck(docs, 'somedata').should.not.contain('ok');
+          return cb();
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.find({ somedata: 'nope' }, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(0);
+          return cb();
+        });
+      }
+      ], done);
+    });
+
+    it('Can find one document matching a basic query and return null if none is found', function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that will return docs
+        d.findOne({ somedata: 'ok' }, function (err, doc) {
+          assert.isNull(err);
+          Object.keys(doc).length.should.equal(2);
+          doc.somedata.should.equal('ok');
+          assert.isDefined(doc._id);
+          return cb();
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.findOne({ somedata: 'nope' }, function (err, doc) {
+          assert.isNull(err);
+          assert.isNull(doc);
+          return cb();
+        });
+      }
+      ], done);
+    });
+
+    it('Can find dates and objects (non JS-native types)', function (done) {
+      var date1 = new Date(1234543)
+        , date2 = new Date(9999)
+        ;
+
+      d.insert({ now: date1, sth: { name: 'nedb' } }, function () {
+        d.findOne({ now: date1 }, function (err, doc) {
+          assert.isNull(err);
+          doc.sth.name.should.equal('nedb');
+
+          d.findOne({ now: date2 }, function (err, doc) {
+            assert.isNull(err);
+            assert.isNull(doc);
+
+            d.findOne({ sth: { name: 'nedb' } }, function (err, doc) {
+              assert.isNull(err);
+              doc.sth.name.should.equal('nedb');
+
+              d.findOne({ sth: { name: 'other' } }, function (err, doc) {
+                assert.isNull(err);
+                assert.isNull(doc);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use dot-notation to query subfields', function (done) {
+      d.insert({ greeting: { english: 'hello' } }, function () {
+        d.findOne({ "greeting.english": 'hello' }, function (err, doc) {
+          assert.isNull(err);
+          doc.greeting.english.should.equal('hello');
+
+          d.findOne({ "greeting.english": 'hellooo' }, function (err, doc) {
+            assert.isNull(err);
+            assert.isNull(doc);
+
+            d.findOne({ "greeting.englis": 'hello' }, function (err, doc) {
+              assert.isNull(err);
+              assert.isNull(doc);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('Array fields match if any element matches', function (done) {
+      d.insert({ fruits: ['pear', 'apple', 'banana'] }, function (err, doc1) {
+        d.insert({ fruits: ['coconut', 'orange', 'pear'] }, function (err, doc2) {
+          d.insert({ fruits: ['banana'] }, function (err, doc3) {
+            d.find({ fruits: 'pear' }, function (err, docs) {
+              assert.isNull(err);
+              docs.length.should.equal(2);
+              _.pluck(docs, '_id').should.contain(doc1._id);
+              _.pluck(docs, '_id').should.contain(doc2._id);
+
+              d.find({ fruits: 'banana' }, function (err, docs) {
+                assert.isNull(err);
+                docs.length.should.equal(2);
+                _.pluck(docs, '_id').should.contain(doc1._id);
+                _.pluck(docs, '_id').should.contain(doc3._id);
+
+                d.find({ fruits: 'doesntexist' }, function (err, docs) {
+                  assert.isNull(err);
+                  docs.length.should.equal(0);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Returns an error if the query is not well formed', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.find({ $or: { hello: 'world' } }, function (err, docs) {
+          assert.isDefined(err);
+          assert.isUndefined(docs);
+
+          d.findOne({ $or: { hello: 'world' } }, function (err, doc) {
+            assert.isDefined(err);
+            assert.isUndefined(doc);
+
+            done();
+          });
+        });
+      });
+    });
+
+    it('Changing the documents returned by find or findOne do not change the database state', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function () {
+        d.findOne({ a: 2 }, function (err, doc) {
+          doc.hello = 'changed';
+
+          d.findOne({ a: 2 }, function (err, doc) {
+            doc.hello.should.equal('world');
+
+            d.find({ a: 2 }, function (err, docs) {
+              docs[0].hello = 'changed';
+
+              d.findOne({ a: 2 }, function (err, doc) {
+                doc.hello.should.equal('world');
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use sort, skip and limit if the callback is not passed to find but to exec', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function () {
+        d.insert({ a: 24, hello: 'earth' }, function () {
+          d.insert({ a: 13, hello: 'blueplanet' }, function () {
+            d.insert({ a: 15, hello: 'home' }, function () {
+              d.find({}).sort({ a: 1 }).limit(2).exec(function (err, docs) {
+                assert.isNull(err);
+                docs.length.should.equal(2);
+                docs[0].hello.should.equal('world');
+                docs[1].hello.should.equal('blueplanet');
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+     it('Can use sort and skip if the callback is not passed to findOne but to exec', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function () {
+        d.insert({ a: 24, hello: 'earth' }, function () {
+          d.insert({ a: 13, hello: 'blueplanet' }, function () {
+            d.insert({ a: 15, hello: 'home' }, function () {
+              // No skip no query
+              d.findOne({}).sort({ a: 1 }).exec(function (err, doc) {
+                assert.isNull(err);
+                doc.hello.should.equal('world');
+
+                // A query
+                d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).exec(function (err, doc) {
+                  assert.isNull(err);
+                  doc.hello.should.equal('home');
+
+                  // And a skip
+                  d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).skip(1).exec(function (err, doc) {
+                    assert.isNull(err);
+                    doc.hello.should.equal('earth');
+
+                    // No result
+                    d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).skip(2).exec(function (err, doc) {
+                      assert.isNull(err);
+                      assert.isNull(doc);
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use projections in find, normal or cursor way', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function (err, doc0) {
+        d.insert({ a: 24, hello: 'earth' }, function (err, doc1) {
+          d.find({ a: 2 }, { a: 0, _id: 0 }, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            assert.deepEqual(docs[0], { hello: 'world' });
+
+            d.find({ a: 2 }, { a: 0, _id: 0 }).exec(function (err, docs) {
+              assert.isNull(err);
+              docs.length.should.equal(1);
+              assert.deepEqual(docs[0], { hello: 'world' });
+
+              // Can't use both modes at once if not _id
+              d.find({ a: 2 }, { a: 0, hello: 1 }, function (err, docs) {
+                assert.isNotNull(err);
+                assert.isUndefined(docs);
+
+                d.find({ a: 2 }, { a: 0, hello: 1 }).exec(function (err, docs) {
+                  assert.isNotNull(err);
+                  assert.isUndefined(docs);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can use projections in findOne, normal or cursor way', function (done) {
+      d.insert({ a: 2, hello: 'world' }, function (err, doc0) {
+        d.insert({ a: 24, hello: 'earth' }, function (err, doc1) {
+          d.findOne({ a: 2 }, { a: 0, _id: 0 }, function (err, doc) {
+            assert.isNull(err);
+            assert.deepEqual(doc, { hello: 'world' });
+
+            d.findOne({ a: 2 }, { a: 0, _id: 0 }).exec(function (err, doc) {
+              assert.isNull(err);
+              assert.deepEqual(doc, { hello: 'world' });
+
+              // Can't use both modes at once if not _id
+              d.findOne({ a: 2 }, { a: 0, hello: 1 }, function (err, doc) {
+                assert.isNotNull(err);
+                assert.isUndefined(doc);
+
+                d.findOne({ a: 2 }, { a: 0, hello: 1 }).exec(function (err, doc) {
+                  assert.isNotNull(err);
+                  assert.isUndefined(doc);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+  });   // ==== End of 'Find' ==== //
+
+  describe('Count', function() {
+
+    it('Count all documents if an empty query is used', function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with empty object
+        d.count({}, function (err, docs) {
+          assert.isNull(err);
+          docs.should.equal(3);
+          return cb();
+        });
+      }
+      ], done);
+    });
+
+    it('Count all documents matching a basic query', function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that will return docs
+        d.count({ somedata: 'again' }, function (err, docs) {
+          assert.isNull(err);
+          docs.should.equal(2);
+          return cb();
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.count({ somedata: 'nope' }, function (err, docs) {
+          assert.isNull(err);
+          docs.should.equal(0);
+          return cb();
+        });
+      }
+      ], done);
+    });
+
+    it('Array fields match if any element matches', function (done) {
+      d.insert({ fruits: ['pear', 'apple', 'banana'] }, function (err, doc1) {
+        d.insert({ fruits: ['coconut', 'orange', 'pear'] }, function (err, doc2) {
+          d.insert({ fruits: ['banana'] }, function (err, doc3) {
+            d.count({ fruits: 'pear' }, function (err, docs) {
+              assert.isNull(err);
+              docs.should.equal(2);
+
+              d.count({ fruits: 'banana' }, function (err, docs) {
+                assert.isNull(err);
+                docs.should.equal(2);
+
+                d.count({ fruits: 'doesntexist' }, function (err, docs) {
+                  assert.isNull(err);
+                  docs.should.equal(0);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Returns an error if the query is not well formed', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.count({ $or: { hello: 'world' } }, function (err, docs) {
+          assert.isDefined(err);
+          assert.isUndefined(docs);
+
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('Update', function () {
+
+    it("If the query doesn't match anything, database is not modified", function (done) {
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err) {
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+            d.insert({ somedata: 'another' }, function (err) { return cb(err); });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.update({ somedata: 'nope' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
+          assert.isNull(err);
+          n.should.equal(0);
+
+          d.find({}, function (err, docs) {
+            var doc1 = _.find(docs, function (d) { return d.somedata === 'ok'; })
+              , doc2 = _.find(docs, function (d) { return d.somedata === 'again'; })
+              , doc3 = _.find(docs, function (d) { return d.somedata === 'another'; })
+              ;
+
+            docs.length.should.equal(3);
+            assert.isUndefined(_.find(docs, function (d) { return d.newDoc === 'yes'; }));
+
+            assert.deepEqual(doc1, { _id: doc1._id, somedata: 'ok' });
+            assert.deepEqual(doc2, { _id: doc2._id, somedata: 'again', plus: 'additional data' });
+            assert.deepEqual(doc3, { _id: doc3._id, somedata: 'another' });
+
+            return cb();
+          });
+        });
+      }
+      ], done);
+    });
+
+    it("If timestampData option is set, update the updatedAt field", function (done) {
+      var beginning = Date.now();
+      d = new Datastore({ filename: testDb, autoload: true, timestampData: true });
+      d.insert({ hello: 'world' }, function (err, insertedDoc) {
+        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound);
+        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound);
+        Object.keys(insertedDoc).length.should.equal(4);
+
+        // Wait 100ms before performing the update
+        setTimeout(function () {
+          var step1 = Date.now();
+          d.update({ _id: insertedDoc._id }, { $set: { hello: 'mars' } }, {}, function () {
+            d.find({ _id: insertedDoc._id }, function (err, docs) {
+              docs.length.should.equal(1);
+              Object.keys(docs[0]).length.should.equal(4);
+              docs[0]._id.should.equal(insertedDoc._id);
+              docs[0].createdAt.should.equal(insertedDoc.createdAt);
+              docs[0].hello.should.equal('mars');
+              assert.isAbove(docs[0].updatedAt.getTime() - beginning, 99);   // updatedAt modified
+              assert.isBelow(docs[0].updatedAt.getTime() - step1, reloadTimeUpperBound);   // updatedAt modified
+
+              done();
+            });
+          })
+        }, 100);
+      });
+    });
+
+    it("Can update multiple documents matching the query", function (done) {
+      var id1, id2, id3;
+
+      // Test DB state after update and reload
+      function testPostUpdateState (cb) {
+        d.find({}, function (err, docs) {
+          var doc1 = _.find(docs, function (d) { return d._id === id1; })
+            , doc2 = _.find(docs, function (d) { return d._id === id2; })
+            , doc3 = _.find(docs, function (d) { return d._id === id3; })
+            ;
+
+          docs.length.should.equal(3);
+
+          Object.keys(doc1).length.should.equal(2);
+          doc1.somedata.should.equal('ok');
+          doc1._id.should.equal(id1);
+
+          Object.keys(doc2).length.should.equal(2);
+          doc2.newDoc.should.equal('yes');
+          doc2._id.should.equal(id2);
+
+          Object.keys(doc3).length.should.equal(2);
+          doc3.newDoc.should.equal('yes');
+          doc3._id.should.equal(id3);
+
+          return cb();
+        });
+      }
+
+      // Actually launch the tests
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err, doc1) {
+          id1 = doc1._id;
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+            id2 = doc2._id;
+            d.insert({ somedata: 'again' }, function (err, doc3) {
+              id3 = doc3._id;
+              return cb(err);
+            });
+          });
+        });
+      }
+      , function (cb) {
+        d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
+          assert.isNull(err);
+          n.should.equal(2);
+          return cb();
+        });
+      }
+      , async.apply(testPostUpdateState)
+      , function (cb) {
+        d.loadDatabase(function (err) { cb(err); });
+      }
+      , async.apply(testPostUpdateState)
+      ], done);
+    });
+
+    it("Can update only one document matching the query", function (done) {
+      var id1, id2, id3;
+
+      // Test DB state after update and reload
+      function testPostUpdateState (cb) {
+        d.find({}, function (err, docs) {
+          var doc1 = _.find(docs, function (d) { return d._id === id1; })
+            , doc2 = _.find(docs, function (d) { return d._id === id2; })
+            , doc3 = _.find(docs, function (d) { return d._id === id3; })
+            ;
+
+          docs.length.should.equal(3);
+
+          assert.deepEqual(doc1, { somedata: 'ok', _id: doc1._id });
+
+          // doc2 or doc3 was modified. Since we sort on _id and it is random
+          // it can be either of two situations
+          try {
+            assert.deepEqual(doc2, { newDoc: 'yes', _id: doc2._id });
+            assert.deepEqual(doc3, { somedata: 'again', _id: doc3._id });
+          } catch (e) {
+            assert.deepEqual(doc2, { somedata: 'again', plus: 'additional data', _id: doc2._id });
+            assert.deepEqual(doc3, { newDoc: 'yes', _id: doc3._id });
+          }
+
+          return cb();
+        });
+      }
+
+      // Actually launch the test
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err, doc1) {
+          id1 = doc1._id;
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+            id2 = doc2._id;
+            d.insert({ somedata: 'again' }, function (err, doc3) {
+              id3 = doc3._id;
+              return cb(err);
+            });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: false }, function (err, n) {
+          assert.isNull(err);
+          n.should.equal(1);
+          return cb();
+        });
+      }
+      , async.apply(testPostUpdateState)
+      , function (cb) {
+        d.loadDatabase(function (err) { return cb(err); });
+      }
+      , async.apply(testPostUpdateState)   // The persisted state has been updated
+      ], done);
+    });
+
+    describe('Upserts', function () {
+
+      it('Can perform upserts if needed', function (done) {
+        d.update({ impossible: 'db is empty anyway' }, { newDoc: true }, {}, function (err, nr, upsert) {
+          assert.isNull(err);
+          nr.should.equal(0);
+          assert.isUndefined(upsert);
+
+          d.find({}, function (err, docs) {
+            docs.length.should.equal(0);   // Default option for upsert is false
+
+            d.update({ impossible: 'db is empty anyway' }, { something: "created ok" }, { upsert: true }, function (err, nr, newDoc) {
+              assert.isNull(err);
+              nr.should.equal(1);
+              newDoc.something.should.equal("created ok");
+              assert.isDefined(newDoc._id);
+
+              d.find({}, function (err, docs) {
+                docs.length.should.equal(1);   // Default option for upsert is false
+                docs[0].something.should.equal("created ok");
+
+                // Modifying the returned upserted document doesn't modify the database
+                newDoc.newField = true;
+                d.find({}, function (err, docs) {
+                  docs[0].something.should.equal("created ok");
+                  assert.isUndefined(docs[0].newField);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('If the update query is a normal object with no modifiers, it is the doc that will be upserted', function (done) {
+        d.update({ $or: [{ a: 4 }, { a: 5 }] }, { hello: 'world', bloup: 'blap' }, { upsert: true }, function (err) {
+          d.find({}, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            var doc = docs[0];
+            Object.keys(doc).length.should.equal(3);
+            doc.hello.should.equal('world');
+            doc.bloup.should.equal('blap');
+            done();
+          });
+        });
+      });
+
+      it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 1', function (done) {
+        d.update({ $or: [{ a: 4 }, { a: 5 }] }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
+          d.find({ hello: 'world' }, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            var doc = docs[0];
+            Object.keys(doc).length.should.equal(3);
+            doc.hello.should.equal('world');
+            doc.bloup.should.equal(3);
+            done();
+          });
+        });
+      });
+
+      it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 2', function (done) {
+        d.update({ $or: [{ a: 4 }, { a: 5 }], cac: 'rrr' }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
+          d.find({ hello: 'world' }, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            var doc = docs[0];
+            Object.keys(doc).length.should.equal(4);
+            doc.cac.should.equal('rrr');
+            doc.hello.should.equal('world');
+            doc.bloup.should.equal(3);
+            done();
+          });
+        });
+      });
+
+      it('Performing upsert with badly formatted fields yields a standard error not an exception', function(done) {
+        d.update({_id: '1234'}, { $set: { $$badfield: 5 }}, { upsert: true }, function(err, doc) {
+          assert.isDefined(err);
+          done();
+        })
+      });
+
+
+    });   // ==== End of 'Upserts' ==== //
+
+    it('Cannot perform update if the update query is not either registered-modifiers-only or copy-only, or contain badly formatted fields', function (done) {
+      d.insert({ something: 'yup' }, function () {
+        d.update({}, { boom: { $badfield: 5 } }, { multi: false }, function (err) {
+          assert.isDefined(err);
+
+          d.update({}, { boom: { "bad.field": 5 } }, { multi: false }, function (err) {
+            assert.isDefined(err);
+
+            d.update({}, { $inc: { test: 5 }, mixed: 'rrr' }, { multi: false }, function (err) {
+              assert.isDefined(err);
+
+              d.update({}, { $inexistent: { test: 5 } }, { multi: false }, function (err) {
+                assert.isDefined(err);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can update documents using multiple modifiers', function (done) {
+      var id;
+
+      d.insert({ something: 'yup', other: 40 }, function (err, newDoc) {
+        id = newDoc._id;
+
+        d.update({}, { $set: { something: 'changed' }, $inc: { other: 10 } }, { multi: false }, function (err, nr) {
+          assert.isNull(err);
+          nr.should.equal(1);
+
+          d.findOne({ _id: id }, function (err, doc) {
+            Object.keys(doc).length.should.equal(3);
+            doc._id.should.equal(id);
+            doc.something.should.equal('changed');
+            doc.other.should.equal(50);
+
+            done();
+          });
+        });
+      });
+    });
+
+    it('Can upsert a document even with modifiers', function (done) {
+      d.update({ bloup: 'blap' }, { $set: { hello: 'world' } }, { upsert: true }, function (err, nr, newDoc) {
+        assert.isNull(err);
+        nr.should.equal(1);
+        newDoc.bloup.should.equal('blap');
+        newDoc.hello.should.equal('world');
+        assert.isDefined(newDoc._id);
+
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+          Object.keys(docs[0]).length.should.equal(3);
+          docs[0].hello.should.equal('world');
+          docs[0].bloup.should.equal('blap');
+          assert.isDefined(docs[0]._id);
+
+          done();
+        });
+      });
+    });
+
+    it('When using modifiers, the only way to update subdocs is with the dot-notation', function (done) {
+      d.insert({ bloup: { blip: "blap", other: true } }, function () {
+        // Correct methos
+        d.update({}, { $set: { "bloup.blip": "hello" } }, {}, function () {
+          d.findOne({}, function (err, doc) {
+            doc.bloup.blip.should.equal("hello");
+            doc.bloup.other.should.equal(true);
+
+            // Wrong
+            d.update({}, { $set: { bloup: { blip: "ola" } } }, {}, function () {
+              d.findOne({}, function (err, doc) {
+                doc.bloup.blip.should.equal("ola");
+                assert.isUndefined(doc.bloup.other);   // This information was lost
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Returns an error if the query is not well formed', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.update({ $or: { hello: 'world' } }, { a: 1 }, {}, function (err, nr, upsert) {
+          assert.isDefined(err);
+          assert.isUndefined(nr);
+          assert.isUndefined(upsert);
+
+          done();
+        });
+      });
+    });
+
+    it('If an error is thrown by a modifier, the database state is not changed', function (done) {
+      d.insert({ hello: 'world' }, function (err, newDoc) {
+        d.update({}, { $inc: { hello: 4 } }, {}, function (err, nr) {
+          assert.isDefined(err);
+          assert.isUndefined(nr);
+
+          d.find({}, function (err, docs) {
+            assert.deepEqual(docs, [ { _id: newDoc._id, hello: 'world' } ]);
+
+            done();
+          });
+        });
+      });
+    });
+
+    it('Cant change the _id of a document', function (done) {
+      d.insert({ a: 2 }, function (err, newDoc) {
+        d.update({ a: 2 }, { a: 2, _id: 'nope' }, {}, function (err) {
+          assert.isDefined(err);
+
+          d.find({}, function (err, docs) {
+            docs.length.should.equal(1);
+            Object.keys(docs[0]).length.should.equal(2);
+            docs[0].a.should.equal(2);
+            docs[0]._id.should.equal(newDoc._id);
+
+            d.update({ a: 2 }, { $set: { _id: 'nope' } }, {}, function (err) {
+              assert.isDefined(err);
+
+              d.find({}, function (err, docs) {
+                docs.length.should.equal(1);
+                Object.keys(docs[0]).length.should.equal(2);
+                docs[0].a.should.equal(2);
+                docs[0]._id.should.equal(newDoc._id);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Non-multi updates are persistent', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.update({ a: 2 }, { $set: { hello: 'changed' } }, {}, function (err) {
+            assert.isNull(err);
+
+            d.find({}, function (err, docs) {
+              docs.sort(function (a, b) { return a.a - b.a; });
+              docs.length.should.equal(2);
+              _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
+              _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+
+              // Even after a reload the database state hasn't changed
+              d.loadDatabase(function (err) {
+                assert.isNull(err);
+
+                d.find({}, function (err, docs) {
+                  docs.sort(function (a, b) { return a.a - b.a; });
+                  docs.length.should.equal(2);
+                  _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
+                  _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Multi updates are persistent', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+            d.update({ a: { $in: [1, 2] } }, { $set: { hello: 'changed' } }, { multi: true }, function (err) {
+              assert.isNull(err);
+
+              d.find({}, function (err, docs) {
+                docs.sort(function (a, b) { return a.a - b.a; });
+                docs.length.should.equal(3);
+                _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'changed' }).should.equal(true);
+                _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+                _.isEqual(docs[2], { _id: doc3._id, a:5, hello: 'pluton' }).should.equal(true);
+
+                // Even after a reload the database state hasn't changed
+                d.loadDatabase(function (err) {
+                  assert.isNull(err);
+
+                  d.find({}, function (err, docs) {
+                    docs.sort(function (a, b) { return a.a - b.a; });
+                    docs.length.should.equal(3);
+                    _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'changed' }).should.equal(true);
+                    _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+                    _.isEqual(docs[2], { _id: doc3._id, a:5, hello: 'pluton' }).should.equal(true);
+
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can update without the options arg (will use defaults then)', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+            d.update({ a: 2 }, { $inc: { a: 10 } }, function (err, nr) {
+              assert.isNull(err);
+              nr.should.equal(1);
+              d.find({}, function (err, docs) {
+                var d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                  , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+                  , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
+                  ;
+
+                d1.a.should.equal(1);
+                d2.a.should.equal(12);
+                d3.a.should.equal(5);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('If a multi update fails on one document, previous updates should be rolled back', function (done) {
+      d.ensureIndex({ fieldName: 'a' });
+      d.insert({ a: 4 }, function (err, doc1) {
+        d.insert({ a: 5 }, function (err, doc2) {
+          d.insert({ a: 'abc' }, function (err, doc3) {
+            // With this query, candidates are always returned in the order 4, 5, 'abc' so it's always the last one which fails
+            d.update({ a: { $in: [4, 5, 'abc'] } }, { $inc: { a: 10 } }, { multi: true }, function (err) {
+              assert.isDefined(err);
+
+              // No index modified
+              _.each(d.indexes, function (index) {
+                var docs = index.getAll()
+                  , d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                  , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+                  , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
+                  ;
+
+                // All changes rolled back, including those that didn't trigger an error
+                d1.a.should.equal(4);
+                d2.a.should.equal(5);
+                d3.a.should.equal('abc');
+              });
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('If an index constraint is violated by an update, all changes should be rolled back', function (done) {
+      d.ensureIndex({ fieldName: 'a', unique: true });
+      d.insert({ a: 4 }, function (err, doc1) {
+        d.insert({ a: 5 }, function (err, doc2) {
+          // With this query, candidates are always returned in the order 4, 5, 'abc' so it's always the last one which fails
+           d.update({ a: { $in: [4, 5, 'abc'] } }, { $set: { a: 10 } }, { multi: true }, function (err) {
+            assert.isDefined(err);
+
+            // Check that no index was modified
+            _.each(d.indexes, function (index) {
+              var docs = index.getAll()
+              , d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+              , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+              ;
+
+              d1.a.should.equal(4);
+              d2.a.should.equal(5);
+            });
+
+            done();
+          });
+        });
+      });
+    });
+
+    it("If options.returnUpdatedDocs is true, return all matched docs", function (done) {
+      d.insert([{ a: 4 }, { a: 5 }, { a: 6 }], function (err, docs) {
+        docs.length.should.equal(3);
+
+        d.update({ a: 7 }, { $set: { u: 1 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
+          num.should.equal(0);
+          updatedDocs.length.should.equal(0);
+
+          d.update({ a: 5 }, { $set: { u: 2 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
+            num.should.equal(1);
+            updatedDocs.length.should.equal(1);
+            updatedDocs[0].a.should.equal(5);
+            updatedDocs[0].u.should.equal(2);
+
+            d.update({ a: { $in: [4, 6] } }, { $set: { u: 3 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
+              num.should.equal(2);
+              updatedDocs.length.should.equal(2);
+              updatedDocs[0].u.should.equal(3);
+              updatedDocs[1].u.should.equal(3);
+              if (updatedDocs[0].a === 4) {
+                updatedDocs[0].a.should.equal(4);
+                updatedDocs[1].a.should.equal(6);
+              } else {
+                updatedDocs[0].a.should.equal(6);
+                updatedDocs[1].a.should.equal(4);
+              }
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it("createdAt property is unchanged and updatedAt correct after an update, even a complete document replacement", function (done) {
+      var d2 = new Datastore({ inMemoryOnly: true, timestampData: true });
+      d2.insert({ a: 1 });
+      d2.findOne({ a: 1 }, function (err, doc) {
+        var createdAt = doc.createdAt.getTime();
+
+        // Modifying update
+        setTimeout(function () {
+          d2.update({ a: 1 }, { $set: { b: 2 } }, {});
+          d2.findOne({ a: 1 }, function (err, doc) {
+            doc.createdAt.getTime().should.equal(createdAt);
+            assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5);
+
+            // Complete replacement
+            setTimeout(function () {
+              d2.update({ a: 1 }, { c: 3 }, {});
+              d2.findOne({ c: 3 }, function (err, doc) {
+                doc.createdAt.getTime().should.equal(createdAt);
+                assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5);
+
+                done();
+              });
+            }, 20);
+          });
+        }, 20);
+      });
+    });
+
+
+    describe("Callback signature", function () {
+
+      it("Regular update, multi false", function (done) {
+        d.insert({ a: 1 });
+        d.insert({ a: 2 });
+
+        // returnUpdatedDocs set to false
+        d.update({ a: 1 }, { $set: { b: 20 } }, {}, function (err, numAffected, affectedDocuments, upsert) {
+          assert.isNull(err);
+          numAffected.should.equal(1);
+          assert.isUndefined(affectedDocuments);
+          assert.isUndefined(upsert);
+
+          // returnUpdatedDocs set to true
+          d.update({ a: 1 }, { $set: { b: 21 } }, { returnUpdatedDocs: true }, function (err, numAffected, affectedDocuments, upsert) {
+            assert.isNull(err);
+            numAffected.should.equal(1);
+            affectedDocuments.a.should.equal(1);
+            affectedDocuments.b.should.equal(21);
+            assert.isUndefined(upsert);
+
+            done();
+          });
+        });
+      });
+
+      it("Regular update, multi true", function (done) {
+        d.insert({ a: 1 });
+        d.insert({ a: 2 });
+
+        // returnUpdatedDocs set to false
+        d.update({}, { $set: { b: 20 } }, { multi: true }, function (err, numAffected, affectedDocuments, upsert) {
+          assert.isNull(err);
+          numAffected.should.equal(2);
+          assert.isUndefined(affectedDocuments);
+          assert.isUndefined(upsert);
+
+          // returnUpdatedDocs set to true
+          d.update({}, { $set: { b: 21 } }, { multi: true, returnUpdatedDocs: true }, function (err, numAffected, affectedDocuments, upsert) {
+            assert.isNull(err);
+            numAffected.should.equal(2);
+            affectedDocuments.length.should.equal(2);
+            assert.isUndefined(upsert);
+
+            done();
+          });
+        });
+      });
+
+      it("Upsert", function (done) {
+        d.insert({ a: 1 });
+        d.insert({ a: 2 });
+
+        // Upsert flag not set
+        d.update({ a: 3 }, { $set: { b: 20 } }, {}, function (err, numAffected, affectedDocuments, upsert) {
+          assert.isNull(err);
+          numAffected.should.equal(0);
+          assert.isUndefined(affectedDocuments);
+          assert.isUndefined(upsert);
+
+          // Upsert flag set
+          d.update({ a: 3 }, { $set: { b: 21 } }, { upsert: true }, function (err, numAffected, affectedDocuments, upsert) {
+            assert.isNull(err);
+            numAffected.should.equal(1);
+            affectedDocuments.a.should.equal(3);
+            affectedDocuments.b.should.equal(21);
+            upsert.should.equal(true);
+
+            d.find({}, function (err, docs) {
+              docs.length.should.equal(3);
+              done();
+            });
+          });
+        });
+      });
+
+
+    });   // ==== End of 'Update - Callback signature' ==== //
+
+  });   // ==== End of 'Update' ==== //
+
+
+  describe('Remove', function () {
+
+    it('Can remove multiple documents', function (done) {
+      var id1, id2, id3;
+
+      // Test DB status
+      function testPostUpdateState (cb) {
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+
+          Object.keys(docs[0]).length.should.equal(2);
+          docs[0]._id.should.equal(id1);
+          docs[0].somedata.should.equal('ok');
+
+          return cb();
+        });
+      }
+
+      // Actually launch the test
+      async.waterfall([
+      function (cb) {
+        d.insert({ somedata: 'ok' }, function (err, doc1) {
+          id1 = doc1._id;
+          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+            id2 = doc2._id;
+            d.insert({ somedata: 'again' }, function (err, doc3) {
+              id3 = doc3._id;
+              return cb(err);
+            });
+          });
+        });
+      }
+      , function (cb) {   // Test with query that doesn't match anything
+        d.remove({ somedata: 'again' }, { multi: true }, function (err, n) {
+          assert.isNull(err);
+          n.should.equal(2);
+          return cb();
+        });
+      }
+      , async.apply(testPostUpdateState)
+      , function (cb) {
+        d.loadDatabase(function (err) { return cb(err); });
+      }
+      , async.apply(testPostUpdateState)
+      ], done);
+    });
+
+    // This tests concurrency issues
+    it('Remove can be called multiple times in parallel and everything that needs to be removed will be', function (done) {
+      d.insert({ planet: 'Earth' }, function () {
+        d.insert({ planet: 'Mars' }, function () {
+          d.insert({ planet: 'Saturn' }, function () {
+            d.find({}, function (err, docs) {
+              docs.length.should.equal(3);
+
+              // Remove two docs simultaneously
+              var toRemove = ['Mars', 'Saturn'];
+              async.each(toRemove, function(planet, cb) {
+                d.remove({ planet: planet }, function (err) { return cb(err); });
+              }, function (err) {
+                d.find({}, function (err, docs) {
+                  docs.length.should.equal(1);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Returns an error if the query is not well formed', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.remove({ $or: { hello: 'world' } }, {}, function (err, nr, upsert) {
+          assert.isDefined(err);
+          assert.isUndefined(nr);
+          assert.isUndefined(upsert);
+
+          done();
+        });
+      });
+    });
+
+    it('Non-multi removes are persistent', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a:3, hello: 'moto' }, function (err, doc3) {
+            d.remove({ a: 2 }, {}, function (err) {
+              assert.isNull(err);
+
+              d.find({}, function (err, docs) {
+                docs.sort(function (a, b) { return a.a - b.a; });
+                docs.length.should.equal(2);
+                _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
+                _.isEqual(docs[1], { _id: doc3._id, a:3, hello: 'moto' }).should.equal(true);
+
+                // Even after a reload the database state hasn't changed
+                d.loadDatabase(function (err) {
+                  assert.isNull(err);
+
+                  d.find({}, function (err, docs) {
+                    docs.sort(function (a, b) { return a.a - b.a; });
+                    docs.length.should.equal(2);
+                    _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
+                    _.isEqual(docs[1], { _id: doc3._id, a:3, hello: 'moto' }).should.equal(true);
+
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Multi removes are persistent', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a:3, hello: 'moto' }, function (err, doc3) {
+            d.remove({ a: { $in: [1, 3] } }, { multi: true }, function (err) {
+              assert.isNull(err);
+
+              d.find({}, function (err, docs) {
+                docs.length.should.equal(1);
+                _.isEqual(docs[0], { _id: doc2._id, a:2, hello: 'earth' }).should.equal(true);
+
+                // Even after a reload the database state hasn't changed
+                d.loadDatabase(function (err) {
+                  assert.isNull(err);
+
+                  d.find({}, function (err, docs) {
+                    docs.length.should.equal(1);
+                    _.isEqual(docs[0], { _id: doc2._id, a:2, hello: 'earth' }).should.equal(true);
+
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('Can remove without the options arg (will use defaults then)', function (done) {
+      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+            d.remove({ a: 2 }, function (err, nr) {
+              assert.isNull(err);
+              nr.should.equal(1);
+              d.find({}, function (err, docs) {
+                var d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                  , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+                  , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
+                  ;
+
+                d1.a.should.equal(1);
+                assert.isUndefined(d2);
+                d3.a.should.equal(5);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+  });   // ==== End of 'Remove' ==== //
+
+
+  describe('Using indexes', function () {
+
+    describe('ensureIndex and index initialization in database loading', function () {
+
+      it('ensureIndex can be called right after a loadDatabase and be initialized and filled correctly', function (done) {
+        var now = new Date()
+          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+                      model.serialize({ _id: "bbb", z: "2", hello: 'world' }) + '\n' +
+                      model.serialize({ _id: "ccc", z: "3", nested: { today: now } })
+          ;
+
+        d.getAllData().length.should.equal(0);
+
+        fs.writeFile(testDb, rawData, 'utf8', function () {
+          d.loadDatabase(function () {
+            d.getAllData().length.should.equal(3);
+
+            assert.deepEqual(Object.keys(d.indexes), ['_id']);
+
+            d.ensureIndex({ fieldName: 'z' });
+            d.indexes.z.fieldName.should.equal('z');
+            d.indexes.z.unique.should.equal(false);
+            d.indexes.z.sparse.should.equal(false);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(3);
+            d.indexes.z.tree.search('1')[0].should.equal(d.getAllData()[0]);
+            d.indexes.z.tree.search('2')[0].should.equal(d.getAllData()[1]);
+            d.indexes.z.tree.search('3')[0].should.equal(d.getAllData()[2]);
+
+            done();
+          });
+        });
+      });
+
+      it('ensureIndex can be called twice on the same field, the second call will ahve no effect', function (done) {
+        Object.keys(d.indexes).length.should.equal(1);
+        Object.keys(d.indexes)[0].should.equal("_id");
+
+        d.insert({ planet: "Earth" }, function () {
+          d.insert({ planet: "Mars" }, function () {
+            d.find({}, function (err, docs) {
+              docs.length.should.equal(2);
+
+              d.ensureIndex({ fieldName: "planet" }, function (err) {
+                assert.isNull(err);
+                Object.keys(d.indexes).length.should.equal(2);
+                Object.keys(d.indexes)[0].should.equal("_id");
+                Object.keys(d.indexes)[1].should.equal("planet");
+
+                d.indexes.planet.getAll().length.should.equal(2);
+
+                // This second call has no effect, documents don't get inserted twice in the index
+                d.ensureIndex({ fieldName: "planet" }, function (err) {
+                  assert.isNull(err);
+                  Object.keys(d.indexes).length.should.equal(2);
+                  Object.keys(d.indexes)[0].should.equal("_id");
+                  Object.keys(d.indexes)[1].should.equal("planet");
+
+                  d.indexes.planet.getAll().length.should.equal(2);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('ensureIndex can be called after the data set was modified and the index still be correct', function (done) {
+        var rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+                      model.serialize({ _id: "bbb", z: "2", hello: 'world' })
+          ;
+
+        d.getAllData().length.should.equal(0);
+
+        fs.writeFile(testDb, rawData, 'utf8', function () {
+          d.loadDatabase(function () {
+            d.getAllData().length.should.equal(2);
+
+            assert.deepEqual(Object.keys(d.indexes), ['_id']);
+
+            d.insert({ z: "12", yes: 'yes' }, function (err, newDoc1) {
+              d.insert({ z: "14", nope: 'nope' }, function (err, newDoc2) {
+                d.remove({ z: "2" }, {}, function () {
+                  d.update({ z: "1" }, { $set: { 'yes': 'yep' } }, {}, function () {
+                    assert.deepEqual(Object.keys(d.indexes), ['_id']);
+
+                    d.ensureIndex({ fieldName: 'z' });
+                    d.indexes.z.fieldName.should.equal('z');
+                    d.indexes.z.unique.should.equal(false);
+                    d.indexes.z.sparse.should.equal(false);
+                    d.indexes.z.tree.getNumberOfKeys().should.equal(3);
+
+                    // The pointers in the _id and z indexes are the same
+                    d.indexes.z.tree.search('1')[0].should.equal(d.indexes._id.getMatching('aaa')[0]);
+                    d.indexes.z.tree.search('12')[0].should.equal(d.indexes._id.getMatching(newDoc1._id)[0]);
+                    d.indexes.z.tree.search('14')[0].should.equal(d.indexes._id.getMatching(newDoc2._id)[0]);
+
+                    // The data in the z index is correct
+                    d.find({}, function (err, docs) {
+                      var doc0 = _.find(docs, function (doc) { return doc._id === 'aaa'; })
+                        , doc1 = _.find(docs, function (doc) { return doc._id === newDoc1._id; })
+                        , doc2 = _.find(docs, function (doc) { return doc._id === newDoc2._id; })
+                        ;
+
+                      docs.length.should.equal(3);
+
+                      assert.deepEqual(doc0, { _id: "aaa", z: "1", a: 2, ages: [1, 5, 12], yes: 'yep' });
+                      assert.deepEqual(doc1, { _id: newDoc1._id, z: "12", yes: 'yes' });
+                      assert.deepEqual(doc2, { _id: newDoc2._id, z: "14", nope: 'nope' });
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('ensureIndex can be called before a loadDatabase and still be initialized and filled correctly', function (done) {
+        var now = new Date()
+          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+                      model.serialize({ _id: "bbb", z: "2", hello: 'world' }) + '\n' +
+                      model.serialize({ _id: "ccc", z: "3", nested: { today: now } })
+          ;
+
+        d.getAllData().length.should.equal(0);
+
+        d.ensureIndex({ fieldName: 'z' });
+        d.indexes.z.fieldName.should.equal('z');
+        d.indexes.z.unique.should.equal(false);
+        d.indexes.z.sparse.should.equal(false);
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        fs.writeFile(testDb, rawData, 'utf8', function () {
+          d.loadDatabase(function () {
+            var doc1 = _.find(d.getAllData(), function (doc) { return doc.z === "1"; })
+              , doc2 = _.find(d.getAllData(), function (doc) { return doc.z === "2"; })
+              , doc3 = _.find(d.getAllData(), function (doc) { return doc.z === "3"; })
+              ;
+
+            d.getAllData().length.should.equal(3);
+
+            d.indexes.z.tree.getNumberOfKeys().should.equal(3);
+            d.indexes.z.tree.search('1')[0].should.equal(doc1);
+            d.indexes.z.tree.search('2')[0].should.equal(doc2);
+            d.indexes.z.tree.search('3')[0].should.equal(doc3);
+
+            done();
+          });
+        });
+      });
+
+      it('Can initialize multiple indexes on a database load', function (done) {
+        var now = new Date()
+          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+                      model.serialize({ _id: "bbb", z: "2", a: 'world' }) + '\n' +
+                      model.serialize({ _id: "ccc", z: "3", a: { today: now } })
+          ;
+
+        d.getAllData().length.should.equal(0);
+        d.ensureIndex({ fieldName: 'z' }, function () {
+          d.ensureIndex({ fieldName: 'a' }, function () {
+            d.indexes.a.tree.getNumberOfKeys().should.equal(0);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+            fs.writeFile(testDb, rawData, 'utf8', function () {
+              d.loadDatabase(function (err) {
+                var doc1 = _.find(d.getAllData(), function (doc) { return doc.z === "1"; })
+                  , doc2 = _.find(d.getAllData(), function (doc) { return doc.z === "2"; })
+                  , doc3 = _.find(d.getAllData(), function (doc) { return doc.z === "3"; })
+                  ;
+
+                assert.isNull(err);
+                d.getAllData().length.should.equal(3);
+
+                d.indexes.z.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.z.tree.search('1')[0].should.equal(doc1);
+                d.indexes.z.tree.search('2')[0].should.equal(doc2);
+                d.indexes.z.tree.search('3')[0].should.equal(doc3);
+
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.a.tree.search(2)[0].should.equal(doc1);
+                d.indexes.a.tree.search('world')[0].should.equal(doc2);
+                d.indexes.a.tree.search({ today: now })[0].should.equal(doc3);
+
+                done();
+              });
+            });
+          });
+
+        });
+      });
+
+      it('If a unique constraint is not respected, database loading will not work and no data will be inserted', function (done) {
+        var now = new Date()
+          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+                      model.serialize({ _id: "bbb", z: "2", a: 'world' }) + '\n' +
+                      model.serialize({ _id: "ccc", z: "1", a: { today: now } })
+          ;
+
+        d.getAllData().length.should.equal(0);
+
+        d.ensureIndex({ fieldName: 'z', unique: true });
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        fs.writeFile(testDb, rawData, 'utf8', function () {
+          d.loadDatabase(function (err) {
+            err.errorType.should.equal('uniqueViolated');
+            err.key.should.equal("1");
+            d.getAllData().length.should.equal(0);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+            done();
+          });
+        });
+      });
+
+      it('If a unique constraint is not respected, ensureIndex will return an error and not create an index', function (done) {
+        d.insert({ a: 1, b: 4 }, function () {
+          d.insert({ a: 2, b: 45 }, function () {
+            d.insert({ a: 1, b: 3 }, function () {
+              d.ensureIndex({ fieldName: 'b' }, function (err) {
+                assert.isNull(err);
+
+                d.ensureIndex({ fieldName: 'a', unique: true }, function (err) {
+                  err.errorType.should.equal('uniqueViolated');
+                  assert.deepEqual(Object.keys(d.indexes), ['_id', 'b']);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('Can remove an index', function (done) {
+        d.ensureIndex({ fieldName: 'e' }, function (err) {
+          assert.isNull(err);
+
+          Object.keys(d.indexes).length.should.equal(2);
+          assert.isNotNull(d.indexes.e);
+
+          d.removeIndex("e", function (err) {
+            assert.isNull(err);
+            Object.keys(d.indexes).length.should.equal(1);
+            assert.isUndefined(d.indexes.e);
+
+            done();
+          });
+        });
+      });
+
+    });   // ==== End of 'ensureIndex and index initialization in database loading' ==== //
+
+
+    describe('Indexing newly inserted documents', function () {
+
+      it('Newly inserted documents are indexed', function (done) {
+        d.ensureIndex({ fieldName: 'z' });
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+
+          d.insert({ a: 5, z: 'nope' }, function (err, newDoc) {
+            d.indexes.z.tree.getNumberOfKeys().should.equal(2);
+            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc]);
+
+            done();
+          });
+        });
+      });
+
+      it('If multiple indexes are defined, the document is inserted in all of them', function (done) {
+        d.ensureIndex({ fieldName: 'z' });
+        d.ensureIndex({ fieldName: 'ya' });
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        d.insert({ a: 2, z: 'yes', ya: 'indeed' }, function (err, newDoc) {
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+          d.indexes.ya.tree.getNumberOfKeys().should.equal(1);
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+          assert.deepEqual(d.indexes.ya.getMatching('indeed'), [newDoc]);
+
+          d.insert({ a: 5, z: 'nope', ya: 'sure' }, function (err, newDoc2) {
+            d.indexes.z.tree.getNumberOfKeys().should.equal(2);
+            d.indexes.ya.tree.getNumberOfKeys().should.equal(2);
+            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc2]);
+            assert.deepEqual(d.indexes.ya.getMatching('sure'), [newDoc2]);
+
+            done();
+          });
+        });
+      });
+
+      it('Can insert two docs at the same key for a non unique index', function (done) {
+        d.ensureIndex({ fieldName: 'z' });
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+
+          d.insert({ a: 5, z: 'yes' }, function (err, newDoc2) {
+            d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc, newDoc2]);
+
+            done();
+          });
+        });
+      });
+
+      it('If the index has a unique constraint, an error is thrown if it is violated and the data is not modified', function (done) {
+        d.ensureIndex({ fieldName: 'z', unique: true });
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+
+        d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+
+          d.insert({ a: 5, z: 'yes' }, function (err) {
+            err.errorType.should.equal('uniqueViolated');
+            err.key.should.equal('yes');
+
+            // Index didn't change
+            d.indexes.z.tree.getNumberOfKeys().should.equal(1);
+            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+
+            // Data didn't change
+            assert.deepEqual(d.getAllData(), [newDoc]);
+            d.loadDatabase(function () {
+              d.getAllData().length.should.equal(1);
+              assert.deepEqual(d.getAllData()[0], newDoc);
+
+              done();
+            });
+          });
+        });
+      });
+
+      it('If an index has a unique constraint, other indexes cannot be modified when it raises an error', function (done) {
+        d.ensureIndex({ fieldName: 'nonu1' });
+        d.ensureIndex({ fieldName: 'uni', unique: true });
+        d.ensureIndex({ fieldName: 'nonu2' });
+
+        d.insert({ nonu1: 'yes', nonu2: 'yes2', uni: 'willfail' }, function (err, newDoc) {
+          assert.isNull(err);
+          d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1);
+          d.indexes.uni.tree.getNumberOfKeys().should.equal(1);
+          d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1);
+
+          d.insert({ nonu1: 'no', nonu2: 'no2', uni: 'willfail' }, function (err) {
+            err.errorType.should.equal('uniqueViolated');
+
+            // No index was modified
+            d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1);
+            d.indexes.uni.tree.getNumberOfKeys().should.equal(1);
+            d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1);
+
+            assert.deepEqual(d.indexes.nonu1.getMatching('yes'), [newDoc]);
+            assert.deepEqual(d.indexes.uni.getMatching('willfail'), [newDoc]);
+            assert.deepEqual(d.indexes.nonu2.getMatching('yes2'), [newDoc]);
+
+            done();
+          });
+        });
+      });
+
+      it('Unique indexes prevent you from inserting two docs where the field is undefined except if theyre sparse', function (done) {
+        d.ensureIndex({ fieldName: 'zzz', unique: true });
+        d.indexes.zzz.tree.getNumberOfKeys().should.equal(0);
+
+        d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
+          d.indexes.zzz.tree.getNumberOfKeys().should.equal(1);
+          assert.deepEqual(d.indexes.zzz.getMatching(undefined), [newDoc]);
+
+          d.insert({ a: 5, z: 'other' }, function (err) {
+            err.errorType.should.equal('uniqueViolated');
+            assert.isUndefined(err.key);
+
+            d.ensureIndex({ fieldName: 'yyy', unique: true, sparse: true });
+
+            d.insert({ a: 5, z: 'other', zzz: 'set' }, function (err) {
+              assert.isNull(err);
+              d.indexes.yyy.getAll().length.should.equal(0);   // Nothing indexed
+              d.indexes.zzz.getAll().length.should.equal(2);
+
+              done();
+            });
+          });
+        });
+      });
+
+      it('Insertion still works as before with indexing', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'b' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, doc2) {
+            d.find({}, function (err, docs) {
+              assert.deepEqual(doc1, _.find(docs, function (d) { return d._id === doc1._id; }));
+              assert.deepEqual(doc2, _.find(docs, function (d) { return d._id === doc2._id; }));
+
+              done();
+            });
+          });
+        });
+      });
+
+      it('All indexes point to the same data as the main index on _id', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, doc2) {
+            d.find({}, function (err, docs) {
+              docs.length.should.equal(2);
+              d.getAllData().length.should.equal(2);
+
+              d.indexes._id.getMatching(doc1._id).length.should.equal(1);
+              d.indexes.a.getMatching(1).length.should.equal(1);
+              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0]);
+
+              d.indexes._id.getMatching(doc2._id).length.should.equal(1);
+              d.indexes.a.getMatching(2).length.should.equal(1);
+              d.indexes._id.getMatching(doc2._id)[0].should.equal(d.indexes.a.getMatching(2)[0]);
+
+              done();
+            });
+          });
+        });
+      });
+
+      it('If a unique constraint is violated, no index is changed, including the main one', function (done) {
+        d.ensureIndex({ fieldName: 'a', unique: true });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
+          d.insert({ a: 1, b: 'si' }, function (err) {
+            assert.isDefined(err);
+
+            d.find({}, function (err, docs) {
+              docs.length.should.equal(1);
+              d.getAllData().length.should.equal(1);
+
+              d.indexes._id.getMatching(doc1._id).length.should.equal(1);
+              d.indexes.a.getMatching(1).length.should.equal(1);
+              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0]);
+
+              d.indexes.a.getMatching(2).length.should.equal(0);
+
+              done();
+            });
+          });
+        });
+      });
+
+    });   // ==== End of 'Indexing newly inserted documents' ==== //
+
+    describe('Updating indexes upon document update', function () {
+
+      it('Updating docs still works as before with indexing', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, _doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, _doc2) {
+            d.update({ a: 1 }, { $set: { a: 456, b: 'no' } }, {}, function (err, nr) {
+              var data = d.getAllData()
+                , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
+                , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
+                ;
+
+              assert.isNull(err);
+              nr.should.equal(1);
+
+              data.length.should.equal(2);
+              assert.deepEqual(doc1, { a: 456, b: 'no', _id: _doc1._id });
+              assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id });
+
+              d.update({}, { $inc: { a: 10 }, $set: { b: 'same' } }, { multi: true }, function (err, nr) {
+                var data = d.getAllData()
+                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
+                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
+                  ;
+
+                assert.isNull(err);
+                nr.should.equal(2);
+
+                data.length.should.equal(2);
+                assert.deepEqual(doc1, { a: 466, b: 'same', _id: _doc1._id });
+                assert.deepEqual(doc2, { a: 12, b: 'same', _id: _doc2._id });
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it('Indexes get updated when a document (or multiple documents) is updated', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'b' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, doc2) {
+            // Simple update
+            d.update({ a: 1 }, { $set: { a: 456, b: 'no' } }, {}, function (err, nr) {
+              assert.isNull(err);
+              nr.should.equal(1);
+
+              d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+              d.indexes.a.getMatching(456)[0]._id.should.equal(doc1._id);
+              d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id);
+
+              d.indexes.b.tree.getNumberOfKeys().should.equal(2);
+              d.indexes.b.getMatching('no')[0]._id.should.equal(doc1._id);
+              d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id);
+
+              // The same pointers are shared between all indexes
+              d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+              d.indexes.b.tree.getNumberOfKeys().should.equal(2);
+              d.indexes._id.tree.getNumberOfKeys().should.equal(2);
+              d.indexes.a.getMatching(456)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
+              d.indexes.b.getMatching('no')[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
+              d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+              d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+
+              // Multi update
+              d.update({}, { $inc: { a: 10 }, $set: { b: 'same' } }, { multi: true }, function (err, nr) {
+                assert.isNull(err);
+                nr.should.equal(2);
+
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.a.getMatching(466)[0]._id.should.equal(doc1._id);
+                d.indexes.a.getMatching(12)[0]._id.should.equal(doc2._id);
+
+                d.indexes.b.tree.getNumberOfKeys().should.equal(1);
+                d.indexes.b.getMatching('same').length.should.equal(2);
+                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc1._id);
+                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc2._id);
+
+                // The same pointers are shared between all indexes
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(1);
+                d.indexes.b.getAll().length.should.equal(2);
+                d.indexes._id.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.a.getMatching(466)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
+                d.indexes.a.getMatching(12)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+                // Can't test the pointers in b as their order is randomized, but it is the same as with a
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it('If a simple update violates a contraint, all changes are rolled back and an error is thrown', function (done) {
+        d.ensureIndex({ fieldName: 'a', unique: true });
+        d.ensureIndex({ fieldName: 'b', unique: true });
+        d.ensureIndex({ fieldName: 'c', unique: true });
+
+        d.insert({ a: 1, b: 10, c: 100 }, function (err, _doc1) {
+          d.insert({ a: 2, b: 20, c: 200 }, function (err, _doc2) {
+            d.insert({ a: 3, b: 30, c: 300 }, function (err, _doc3) {
+              // Will conflict with doc3
+              d.update({ a: 2 }, { $inc: { a: 10, c: 1000 }, $set: { b: 30 } }, {}, function (err) {
+                var data = d.getAllData()
+                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
+                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
+                  , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
+                  ;
+
+                err.errorType.should.equal('uniqueViolated');
+
+                // Data left unchanged
+                data.length.should.equal(3);
+                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id });
+                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id });
+                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id });
+
+                // All indexes left unchanged and pointing to the same docs
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.a.getMatching(1)[0].should.equal(doc1);
+                d.indexes.a.getMatching(2)[0].should.equal(doc2);
+                d.indexes.a.getMatching(3)[0].should.equal(doc3);
+
+                d.indexes.b.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.b.getMatching(10)[0].should.equal(doc1);
+                d.indexes.b.getMatching(20)[0].should.equal(doc2);
+                d.indexes.b.getMatching(30)[0].should.equal(doc3);
+
+                d.indexes.c.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.c.getMatching(100)[0].should.equal(doc1);
+                d.indexes.c.getMatching(200)[0].should.equal(doc2);
+                d.indexes.c.getMatching(300)[0].should.equal(doc3);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it('If a multi update violates a contraint, all changes are rolled back and an error is thrown', function (done) {
+        d.ensureIndex({ fieldName: 'a', unique: true });
+        d.ensureIndex({ fieldName: 'b', unique: true });
+        d.ensureIndex({ fieldName: 'c', unique: true });
+
+        d.insert({ a: 1, b: 10, c: 100 }, function (err, _doc1) {
+          d.insert({ a: 2, b: 20, c: 200 }, function (err, _doc2) {
+            d.insert({ a: 3, b: 30, c: 300 }, function (err, _doc3) {
+              // Will conflict with doc3
+              d.update({ a: { $in: [1, 2] } }, { $inc: { a: 10, c: 1000 }, $set: { b: 30 } }, { multi: true }, function (err) {
+                var data = d.getAllData()
+                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
+                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
+                  , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
+                  ;
+
+                err.errorType.should.equal('uniqueViolated');
+
+                // Data left unchanged
+                data.length.should.equal(3);
+                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id });
+                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id });
+                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id });
+
+                // All indexes left unchanged and pointing to the same docs
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.a.getMatching(1)[0].should.equal(doc1);
+                d.indexes.a.getMatching(2)[0].should.equal(doc2);
+                d.indexes.a.getMatching(3)[0].should.equal(doc3);
+
+                d.indexes.b.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.b.getMatching(10)[0].should.equal(doc1);
+                d.indexes.b.getMatching(20)[0].should.equal(doc2);
+                d.indexes.b.getMatching(30)[0].should.equal(doc3);
+
+                d.indexes.c.tree.getNumberOfKeys().should.equal(3);
+                d.indexes.c.getMatching(100)[0].should.equal(doc1);
+                d.indexes.c.getMatching(200)[0].should.equal(doc2);
+                d.indexes.c.getMatching(300)[0].should.equal(doc3);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+
+    });   // ==== End of 'Updating indexes upon document update' ==== //
+
+    describe('Updating indexes upon document remove', function () {
+
+      it('Removing docs still works as before with indexing', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, _doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, _doc2) {
+            d.insert({ a: 3, b: 'coin' }, function (err, _doc3) {
+              d.remove({ a: 1 }, {}, function (err, nr) {
+                var data = d.getAllData()
+                , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
+                , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
+                ;
+
+                assert.isNull(err);
+                nr.should.equal(1);
+
+                data.length.should.equal(2);
+                assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id });
+                assert.deepEqual(doc3, { a: 3, b: 'coin', _id: _doc3._id });
+
+                d.remove({ a: { $in: [2, 3] } }, { multi: true }, function (err, nr) {
+                  var data = d.getAllData()
+                  ;
+
+                  assert.isNull(err);
+                  nr.should.equal(2);
+                  data.length.should.equal(0);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('Indexes get updated when a document (or multiple documents) is removed', function (done) {
+        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'b' });
+
+        d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
+          d.insert({ a: 2, b: 'si' }, function (err, doc2) {
+            d.insert({ a: 3, b: 'coin' }, function (err, doc3) {
+              // Simple remove
+              d.remove({ a: 1 }, {}, function (err, nr) {
+                assert.isNull(err);
+                nr.should.equal(1);
+
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id);
+                d.indexes.a.getMatching(3)[0]._id.should.equal(doc3._id);
+
+                d.indexes.b.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id);
+                d.indexes.b.getMatching('coin')[0]._id.should.equal(doc3._id);
+
+                // The same pointers are shared between all indexes
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(2);
+                d.indexes._id.tree.getNumberOfKeys().should.equal(2);
+                d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+                d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+                d.indexes.a.getMatching(3)[0].should.equal(d.indexes._id.getMatching(doc3._id)[0]);
+                d.indexes.b.getMatching('coin')[0].should.equal(d.indexes._id.getMatching(doc3._id)[0]);
+
+                // Multi remove
+                d.remove({}, { multi: true }, function (err, nr) {
+                  assert.isNull(err);
+                  nr.should.equal(2);
+
+                  d.indexes.a.tree.getNumberOfKeys().should.equal(0);
+                  d.indexes.b.tree.getNumberOfKeys().should.equal(0);
+                  d.indexes._id.tree.getNumberOfKeys().should.equal(0);
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+    });   // ==== End of 'Updating indexes upon document remove' ==== //
+
+
+    describe('Persisting indexes', function () {
+
+      it('Indexes are persisted to a separate file and recreated upon reload', function (done) {
+        var persDb = "workspace/persistIndexes.db"
+          , db
+          ;
+
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
+        db = new Datastore({ filename: persDb, autoload: true });
+
+        Object.keys(db.indexes).length.should.equal(1);
+        Object.keys(db.indexes)[0].should.equal("_id");
+
+        db.insert({ planet: "Earth" }, function (err) {
+          assert.isNull(err);
+          db.insert({ planet: "Mars" }, function (err) {
+            assert.isNull(err);
+
+            db.ensureIndex({ fieldName: "planet" }, function (err) {
+              Object.keys(db.indexes).length.should.equal(2);
+              Object.keys(db.indexes)[0].should.equal("_id");
+              Object.keys(db.indexes)[1].should.equal("planet");
+              db.indexes._id.getAll().length.should.equal(2);
+              db.indexes.planet.getAll().length.should.equal(2);
+              db.indexes.planet.fieldName.should.equal("planet");
+
+              // After a reload the indexes are recreated
+              db = new Datastore({ filename: persDb });
+              db.loadDatabase(function (err) {
+                assert.isNull(err);
+                Object.keys(db.indexes).length.should.equal(2);
+                Object.keys(db.indexes)[0].should.equal("_id");
+                Object.keys(db.indexes)[1].should.equal("planet");
+                db.indexes._id.getAll().length.should.equal(2);
+                db.indexes.planet.getAll().length.should.equal(2);
+                db.indexes.planet.fieldName.should.equal("planet");
+
+                // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
+                db = new Datastore({ filename: persDb });
+                db.loadDatabase(function (err) {
+                  assert.isNull(err);
+                  Object.keys(db.indexes).length.should.equal(2);
+                  Object.keys(db.indexes)[0].should.equal("_id");
+                  Object.keys(db.indexes)[1].should.equal("planet");
+                  db.indexes._id.getAll().length.should.equal(2);
+                  db.indexes.planet.getAll().length.should.equal(2);
+                  db.indexes.planet.fieldName.should.equal("planet");
+
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('Indexes are persisted with their options and recreated even if some db operation happen between loads', function (done) {
+        var persDb = "workspace/persistIndexes.db"
+          , db
+        ;
+
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
+        db = new Datastore({ filename: persDb, autoload: true });
+
+        Object.keys(db.indexes).length.should.equal(1);
+        Object.keys(db.indexes)[0].should.equal("_id");
+
+        db.insert({ planet: "Earth" }, function (err) {
+          assert.isNull(err);
+          db.insert({ planet: "Mars" }, function (err) {
+            assert.isNull(err);
+
+            db.ensureIndex({ fieldName: "planet", unique: true, sparse: false }, function (err) {
+              Object.keys(db.indexes).length.should.equal(2);
+              Object.keys(db.indexes)[0].should.equal("_id");
+              Object.keys(db.indexes)[1].should.equal("planet");
+              db.indexes._id.getAll().length.should.equal(2);
+              db.indexes.planet.getAll().length.should.equal(2);
+              db.indexes.planet.unique.should.equal(true);
+              db.indexes.planet.sparse.should.equal(false);
+
+              db.insert({ planet: "Jupiter" }, function (err) {
+                assert.isNull(err);
+
+                // After a reload the indexes are recreated
+                db = new Datastore({ filename: persDb });
+                db.loadDatabase(function (err) {
+                  assert.isNull(err);
+                  Object.keys(db.indexes).length.should.equal(2);
+                  Object.keys(db.indexes)[0].should.equal("_id");
+                  Object.keys(db.indexes)[1].should.equal("planet");
+                  db.indexes._id.getAll().length.should.equal(3);
+                  db.indexes.planet.getAll().length.should.equal(3);
+                  db.indexes.planet.unique.should.equal(true);
+                  db.indexes.planet.sparse.should.equal(false);
+
+                  db.ensureIndex({ fieldName: 'bloup', unique: false, sparse: true }, function (err) {
+                    assert.isNull(err);
+                    Object.keys(db.indexes).length.should.equal(3);
+                    Object.keys(db.indexes)[0].should.equal("_id");
+                    Object.keys(db.indexes)[1].should.equal("planet");
+                    Object.keys(db.indexes)[2].should.equal("bloup");
+                    db.indexes._id.getAll().length.should.equal(3);
+                    db.indexes.planet.getAll().length.should.equal(3);
+                    db.indexes.bloup.getAll().length.should.equal(0);
+                    db.indexes.planet.unique.should.equal(true);
+                    db.indexes.planet.sparse.should.equal(false);
+                    db.indexes.bloup.unique.should.equal(false);
+                    db.indexes.bloup.sparse.should.equal(true);
+
+                    // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
+                    db = new Datastore({ filename: persDb });
+                    db.loadDatabase(function (err) {
+                      assert.isNull(err);
+                      Object.keys(db.indexes).length.should.equal(3);
+                      Object.keys(db.indexes)[0].should.equal("_id");
+                      Object.keys(db.indexes)[1].should.equal("planet");
+                      Object.keys(db.indexes)[2].should.equal("bloup");
+                      db.indexes._id.getAll().length.should.equal(3);
+                      db.indexes.planet.getAll().length.should.equal(3);
+                      db.indexes.bloup.getAll().length.should.equal(0);
+                      db.indexes.planet.unique.should.equal(true);
+                      db.indexes.planet.sparse.should.equal(false);
+                      db.indexes.bloup.unique.should.equal(false);
+                      db.indexes.bloup.sparse.should.equal(true);
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+
+      it('Indexes can also be removed and the remove persisted', function (done) {
+        var persDb = "workspace/persistIndexes.db"
+          , db
+        ;
+
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
+        db = new Datastore({ filename: persDb, autoload: true });
+
+        Object.keys(db.indexes).length.should.equal(1);
+        Object.keys(db.indexes)[0].should.equal("_id");
+
+        db.insert({ planet: "Earth" }, function (err) {
+          assert.isNull(err);
+          db.insert({ planet: "Mars" }, function (err) {
+            assert.isNull(err);
+
+            db.ensureIndex({ fieldName: "planet" }, function (err) {
+              assert.isNull(err);
+              db.ensureIndex({ fieldName: "another" }, function (err) {
+                assert.isNull(err);
+                Object.keys(db.indexes).length.should.equal(3);
+                Object.keys(db.indexes)[0].should.equal("_id");
+                Object.keys(db.indexes)[1].should.equal("planet");
+                Object.keys(db.indexes)[2].should.equal("another");
+                db.indexes._id.getAll().length.should.equal(2);
+                db.indexes.planet.getAll().length.should.equal(2);
+                db.indexes.planet.fieldName.should.equal("planet");
+
+                // After a reload the indexes are recreated
+                db = new Datastore({ filename: persDb });
+                db.loadDatabase(function (err) {
+                  assert.isNull(err);
+                  Object.keys(db.indexes).length.should.equal(3);
+                  Object.keys(db.indexes)[0].should.equal("_id");
+                  Object.keys(db.indexes)[1].should.equal("planet");
+                  Object.keys(db.indexes)[2].should.equal("another");
+                  db.indexes._id.getAll().length.should.equal(2);
+                  db.indexes.planet.getAll().length.should.equal(2);
+                  db.indexes.planet.fieldName.should.equal("planet");
+
+                  // Index is removed
+                  db.removeIndex("planet", function (err) {
+                    assert.isNull(err);
+                    Object.keys(db.indexes).length.should.equal(2);
+                    Object.keys(db.indexes)[0].should.equal("_id");
+                    Object.keys(db.indexes)[1].should.equal("another");
+                    db.indexes._id.getAll().length.should.equal(2);
+
+                    // After a reload indexes are preserved
+                    db = new Datastore({ filename: persDb });
+                    db.loadDatabase(function (err) {
+                      assert.isNull(err);
+                      Object.keys(db.indexes).length.should.equal(2);
+                      Object.keys(db.indexes)[0].should.equal("_id");
+                      Object.keys(db.indexes)[1].should.equal("another");
+                      db.indexes._id.getAll().length.should.equal(2);
+
+                      // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
+                      db = new Datastore({ filename: persDb });
+                      db.loadDatabase(function (err) {
+                        assert.isNull(err);
+                        Object.keys(db.indexes).length.should.equal(2);
+                        Object.keys(db.indexes)[0].should.equal("_id");
+                        Object.keys(db.indexes)[1].should.equal("another");
+                        db.indexes._id.getAll().length.should.equal(2);
+
+                        done();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+
+    });   // ==== End of 'Persisting indexes' ====
+
+    it('Results of getMatching should never contain duplicates', function (done) {
+      d.ensureIndex({ fieldName: 'bad' });
+      d.insert({ bad: ['a', 'b'] }, function () {
+        d.getCandidates({ bad: { $in: ['a', 'b'] } }, function (err, res) {
+          res.length.should.equal(1);
+          done();
+        });
+      });
+    });
+
+  });   // ==== End of 'Using indexes' ==== //
+
+
+});

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -1,383 +1,397 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , testDb = 'workspace/test.db'
-  , fs = require('fs')
-  , path = require('path')
-  , _ = require('underscore')
-  , async = require('async')
-  , model = require('../src/nedb/model')
-  , Datastore = require('../src/nedb/datastore')
-  , Persistence = require('../src/nedb/persistence')
-  , reloadTimeUpperBound = 60;   // In ms, an upper bound for the reload time used to check createdAt and updatedAt
-  ;
+const should = require('chai').should()
+const assert = require('chai').assert
+const testDb = 'workspace/test.db'
+const fs = require('fs')
+const path = require('path')
+const _ = require('underscore')
+const async = require('async')
+const model = require('../src/nedb/model')
+const Datastore = require('../src/nedb/datastore')
+const Persistence = require('../src/nedb/persistence')
+const reloadTimeUpperBound = 60   // In ms, an upper bound for the reload time used to check createdAt and updatedAt
 
 
 describe('Database', function () {
-  var d;
+  let d
 
   beforeEach(function (done) {
-    d = new Datastore({ filename: testDb });
-    d.filename.should.equal(testDb);
-    d.inMemoryOnly.should.equal(false);
+    d = new Datastore({ filename: testDb })
+    d.filename.should.equal(testDb)
+    d.inMemoryOnly.should.equal(false)
 
     async.waterfall([
       function (cb) {
         Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
           fs.exists(testDb, function (exists) {
             if (exists) {
-              fs.unlink(testDb, cb);
-            } else { return cb(); }
-          });
-        });
+              fs.unlink(testDb, cb)
+            } else { return cb() }
+          })
+        })
       }
-    , function (cb) {
+      , function (cb) {
         d.loadDatabase(function (err) {
-          assert.isNull(err);
-          d.getAllData().length.should.equal(0);
-          return cb();
-        });
+          assert.isNull(err)
+          d.getAllData().length.should.equal(0)
+          return cb()
+        })
       }
-    ], done);
-  });
+    ], done)
+  })
 
   it('Constructor compatibility with v0.6-', function () {
-    var dbef = new Datastore('somefile');
-    dbef.filename.should.equal('somefile');
-    dbef.inMemoryOnly.should.equal(false);
+    let dbef = new Datastore('somefile')
+    dbef.filename.should.equal('somefile')
+    dbef.inMemoryOnly.should.equal(false)
 
-    var dbef = new Datastore('');
-    assert.isNull(dbef.filename);
-    dbef.inMemoryOnly.should.equal(true);
+    dbef = new Datastore('')
+    assert.isNull(dbef.filename)
+    dbef.inMemoryOnly.should.equal(true)
 
-    var dbef = new Datastore();
-    assert.isNull(dbef.filename);
-    dbef.inMemoryOnly.should.equal(true);
-  });
+    dbef = new Datastore()
+    assert.isNull(dbef.filename)
+    dbef.inMemoryOnly.should.equal(true)
+  })
 
   describe('Autoloading', function () {
 
     it('Can autoload a database and query it right away', function (done) {
-      var fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({ _id: '2', a: 5, planet: 'Mars' }) + '\n'
-        , autoDb = 'workspace/auto.db'
-        , db
-        ;
+      const fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({
+        _id: '2',
+        a: 5,
+        planet: 'Mars'
+      }) + '\n'
+      const autoDb = 'workspace/auto.db'
+      let db
 
-      fs.writeFileSync(autoDb, fileStr, 'utf8');
+      fs.writeFileSync(autoDb, fileStr, 'utf8')
       db = new Datastore({ filename: autoDb, autoload: true })
 
       db.find({}, function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(2);
-        done();
-      });
-    });
+        assert.isNull(err)
+        docs.length.should.equal(2)
+        done()
+      })
+    })
 
     it('Throws if autoload fails', function (done) {
-      var fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({ _id: '2', a: 5, planet: 'Mars' }) + '\n' + '{"$$indexCreated":{"fieldName":"a","unique":true}}'
-        , autoDb = 'workspace/auto.db'
-        , db
-        ;
+      const fileStr = model.serialize({ _id: '1', a: 5, planet: 'Earth' }) + '\n' + model.serialize({
+        _id: '2',
+        a: 5,
+        planet: 'Mars'
+      }) + '\n' + '{"$$indexCreated":{"fieldName":"a","unique":true}}'
+      const autoDb = 'workspace/auto.db'
+      let db
 
-      fs.writeFileSync(autoDb, fileStr, 'utf8');
+      fs.writeFileSync(autoDb, fileStr, 'utf8')
 
       // Check the loadDatabase generated an error
       function onload (err) {
-        err.errorType.should.equal('uniqueViolated');
-        done();
+        err.errorType.should.equal('uniqueViolated')
+        done()
       }
 
       db = new Datastore({ filename: autoDb, autoload: true, onload: onload })
 
       db.find({}, function (err, docs) {
-        done(new Error("Find should not be executed since autoload failed"));
-      });
-    });
+        done(new Error('Find should not be executed since autoload failed'))
+      })
+    })
 
-  });
+  })
 
   describe('Insert', function () {
 
     it('Able to insert a document in the database, setting an _id if none provided, and retrieve it even after a reload', function (done) {
       d.find({}, function (err, docs) {
-        docs.length.should.equal(0);
+        docs.length.should.equal(0)
 
         d.insert({ somedata: 'ok' }, function (err) {
           // The data was correctly updated
           d.find({}, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            Object.keys(docs[0]).length.should.equal(2);
-            docs[0].somedata.should.equal('ok');
-            assert.isDefined(docs[0]._id);
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            Object.keys(docs[0]).length.should.equal(2)
+            docs[0].somedata.should.equal('ok')
+            assert.isDefined(docs[0]._id)
 
             // After a reload the data has been correctly persisted
             d.loadDatabase(function (err) {
               d.find({}, function (err, docs) {
-                assert.isNull(err);
-                docs.length.should.equal(1);
-                Object.keys(docs[0]).length.should.equal(2);
-                docs[0].somedata.should.equal('ok');
-                assert.isDefined(docs[0]._id);
+                assert.isNull(err)
+                docs.length.should.equal(1)
+                Object.keys(docs[0]).length.should.equal(2)
+                docs[0].somedata.should.equal('ok')
+                assert.isDefined(docs[0]._id)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can insert multiple documents in the database', function (done) {
       d.find({}, function (err, docs) {
-        docs.length.should.equal(0);
+        docs.length.should.equal(0)
 
         d.insert({ somedata: 'ok' }, function (err) {
           d.insert({ somedata: 'another' }, function (err) {
             d.insert({ somedata: 'again' }, function (err) {
               d.find({}, function (err, docs) {
-                docs.length.should.equal(3);
-                _.pluck(docs, 'somedata').should.contain('ok');
-                _.pluck(docs, 'somedata').should.contain('another');
-                _.pluck(docs, 'somedata').should.contain('again');
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                docs.length.should.equal(3)
+                _.pluck(docs, 'somedata').should.contain('ok')
+                _.pluck(docs, 'somedata').should.contain('another')
+                _.pluck(docs, 'somedata').should.contain('again')
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can insert and get back from DB complex objects with all primitive and secondary types', function (done) {
-      var da = new Date()
-        , obj = { a: ['ee', 'ff', 42], date: da, subobj: { a: 'b', b: 'c' } }
-        ;
+      const da = new Date()
+      const obj = { a: ['ee', 'ff', 42], date: da, subobj: { a: 'b', b: 'c' } }
 
       d.insert(obj, function (err) {
         d.findOne({}, function (err, res) {
-          assert.isNull(err);
-          res.a.length.should.equal(3);
-          res.a[0].should.equal('ee');
-          res.a[1].should.equal('ff');
-          res.a[2].should.equal(42);
-          res.date.getTime().should.equal(da.getTime());
-          res.subobj.a.should.equal('b');
-          res.subobj.b.should.equal('c');
+          assert.isNull(err)
+          res.a.length.should.equal(3)
+          res.a[0].should.equal('ee')
+          res.a[1].should.equal('ff')
+          res.a[2].should.equal(42)
+          res.date.getTime().should.equal(da.getTime())
+          res.subobj.a.should.equal('b')
+          res.subobj.b.should.equal('c')
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('If an object returned from the DB is modified and refetched, the original value should be found', function (done) {
       d.insert({ a: 'something' }, function () {
         d.findOne({}, function (err, doc) {
-          doc.a.should.equal('something');
-          doc.a = 'another thing';
-          doc.a.should.equal('another thing');
+          doc.a.should.equal('something')
+          doc.a = 'another thing'
+          doc.a.should.equal('another thing')
 
           // Re-fetching with findOne should yield the persisted value
           d.findOne({}, function (err, doc) {
-            doc.a.should.equal('something');
-            doc.a = 'another thing';
-            doc.a.should.equal('another thing');
+            doc.a.should.equal('something')
+            doc.a = 'another thing'
+            doc.a.should.equal('another thing')
 
             // Re-fetching with find should yield the persisted value
             d.find({}, function (err, docs) {
-              docs[0].a.should.equal('something');
+              docs[0].a.should.equal('something')
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
     it('Cannot insert a doc that has a field beginning with a $ sign', function (done) {
       d.insert({ $something: 'atest' }, function (err) {
-        assert.isDefined(err);
-        done();
-      });
-    });
+        assert.isDefined(err)
+        done()
+      })
+    })
 
     it('If an _id is already given when we insert a document, use that instead of generating a random one', function (done) {
       d.insert({ _id: 'test', stuff: true }, function (err, newDoc) {
-        if (err) { return done(err); }
+        if (err) { return done(err) }
 
-        newDoc.stuff.should.equal(true);
-        newDoc._id.should.equal('test');
+        newDoc.stuff.should.equal(true)
+        newDoc._id.should.equal('test')
 
         d.insert({ _id: 'test', otherstuff: 42 }, function (err) {
-          err.errorType.should.equal('uniqueViolated');
+          err.errorType.should.equal('uniqueViolated')
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('Modifying the insertedDoc after an insert doesnt change the copy saved in the database', function (done) {
       d.insert({ a: 2, hello: 'world' }, function (err, newDoc) {
-        newDoc.hello = 'changed';
+        newDoc.hello = 'changed'
 
         d.findOne({ a: 2 }, function (err, doc) {
-          doc.hello.should.equal('world');
-          done();
-        });
-      });
-    });
+          doc.hello.should.equal('world')
+          done()
+        })
+      })
+    })
 
     it('Can insert an array of documents at once', function (done) {
-      var docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }];
+      const docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }]
 
       d.insert(docs, function (err) {
         d.find({}, function (err, docs) {
-          var data;
+          let data
 
-          docs.length.should.equal(2);
-          _.find(docs, function (doc) { return doc.a === 5; }).b.should.equal('hello');
-          _.find(docs, function (doc) { return doc.a === 42; }).b.should.equal('world');
+          docs.length.should.equal(2)
+          _.find(docs, function (doc) { return doc.a === 5 }).b.should.equal('hello')
+          _.find(docs, function (doc) { return doc.a === 42 }).b.should.equal('world')
 
           // The data has been persisted correctly
-          data = _.filter(fs.readFileSync(testDb, 'utf8').split('\n'), function (line) { return line.length > 0; });
-          data.length.should.equal(2);
-          model.deserialize(data[0]).a.should.equal(5);
-          model.deserialize(data[0]).b.should.equal('hello');
-          model.deserialize(data[1]).a.should.equal(42);
-          model.deserialize(data[1]).b.should.equal('world');
+          data = _.filter(fs.readFileSync(testDb, 'utf8').split('\n'), function (line) { return line.length > 0 })
+          data.length.should.equal(2)
+          model.deserialize(data[0]).a.should.equal(5)
+          model.deserialize(data[0]).b.should.equal('hello')
+          model.deserialize(data[1]).a.should.equal(42)
+          model.deserialize(data[1]).b.should.equal('world')
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('If a bulk insert violates a constraint, all changes are rolled back', function (done) {
-      var docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }, { a: 5, b: 'bloup' }, { a: 7 }];
+      const docs = [{ a: 5, b: 'hello' }, { a: 42, b: 'world' }, { a: 5, b: 'bloup' }, { a: 7 }]
 
       d.ensureIndex({ fieldName: 'a', unique: true }, function () {   // Important to specify callback here to make sure filesystem synced
         d.insert(docs, function (err) {
-          err.errorType.should.equal('uniqueViolated');
+          err.errorType.should.equal('uniqueViolated')
 
           d.find({}, function (err, docs) {
             // Datafile only contains index definition
-            var datafileContents = model.deserialize(fs.readFileSync(testDb, 'utf8'));
-            assert.deepEqual(datafileContents, { $$indexCreated: { fieldName: 'a', unique: true } });
+            const datafileContents = model.deserialize(fs.readFileSync(testDb, 'utf8'))
+            assert.deepEqual(datafileContents, { $$indexCreated: { fieldName: 'a', unique: true } })
 
-            docs.length.should.equal(0);
+            docs.length.should.equal(0)
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
-    it("If timestampData option is set, a createdAt field is added and persisted", function (done) {
-      var newDoc = { hello: 'world' }, beginning = Date.now();
-      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+    it('If timestampData option is set, a createdAt field is added and persisted', function (done) {
+      const newDoc = { hello: 'world' }, beginning = Date.now()
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true })
       d.find({}, function (err, docs) {
-        assert.isNull(err);
-        docs.length.should.equal(0);
+        assert.isNull(err)
+        docs.length.should.equal(0)
 
         d.insert(newDoc, function (err, insertedDoc) {
           // No side effect on given input
-          assert.deepEqual(newDoc, { hello: 'world' });
+          assert.deepEqual(newDoc, { hello: 'world' })
           // Insert doc has two new fields, _id and createdAt
-          insertedDoc.hello.should.equal('world');
-          assert.isDefined(insertedDoc.createdAt);
-          assert.isDefined(insertedDoc.updatedAt);
-          insertedDoc.createdAt.should.equal(insertedDoc.updatedAt);
-          assert.isDefined(insertedDoc._id);
-          Object.keys(insertedDoc).length.should.equal(4);
-          assert.isBelow(Math.abs(insertedDoc.createdAt.getTime() - beginning), reloadTimeUpperBound);   // No more than 30ms should have elapsed (worst case, if there is a flush)
+          insertedDoc.hello.should.equal('world')
+          assert.isDefined(insertedDoc.createdAt)
+          assert.isDefined(insertedDoc.updatedAt)
+          insertedDoc.createdAt.should.equal(insertedDoc.updatedAt)
+          assert.isDefined(insertedDoc._id)
+          Object.keys(insertedDoc).length.should.equal(4)
+          assert.isBelow(Math.abs(insertedDoc.createdAt.getTime() - beginning), reloadTimeUpperBound)   // No more than 30ms should have elapsed (worst case, if there is a flush)
 
           // Modifying results of insert doesn't change the cache
-          insertedDoc.bloup = "another";
-          Object.keys(insertedDoc).length.should.equal(5);
+          insertedDoc.bloup = 'another'
+          Object.keys(insertedDoc).length.should.equal(5)
 
           d.find({}, function (err, docs) {
-            docs.length.should.equal(1);
-            assert.deepEqual(newDoc, { hello: 'world' });
-            assert.deepEqual({ hello: 'world', _id: insertedDoc._id, createdAt: insertedDoc.createdAt, updatedAt: insertedDoc.updatedAt }, docs[0]);
+            docs.length.should.equal(1)
+            assert.deepEqual(newDoc, { hello: 'world' })
+            assert.deepEqual({
+              hello: 'world',
+              _id: insertedDoc._id,
+              createdAt: insertedDoc.createdAt,
+              updatedAt: insertedDoc.updatedAt
+            }, docs[0])
 
             // All data correctly persisted on disk
             d.loadDatabase(function () {
               d.find({}, function (err, docs) {
-                docs.length.should.equal(1);
-                assert.deepEqual(newDoc, { hello: 'world' });
-                assert.deepEqual({ hello: 'world', _id: insertedDoc._id, createdAt: insertedDoc.createdAt, updatedAt: insertedDoc.updatedAt }, docs[0]);
+                docs.length.should.equal(1)
+                assert.deepEqual(newDoc, { hello: 'world' })
+                assert.deepEqual({
+                  hello: 'world',
+                  _id: insertedDoc._id,
+                  createdAt: insertedDoc.createdAt,
+                  updatedAt: insertedDoc.updatedAt
+                }, docs[0])
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
-    it("If timestampData option not set, don't create a createdAt and a updatedAt field", function (done) {
+    it('If timestampData option not set, don\'t create a createdAt and a updatedAt field', function (done) {
       d.insert({ hello: 'world' }, function (err, insertedDoc) {
-        Object.keys(insertedDoc).length.should.equal(2);
-        assert.isUndefined(insertedDoc.createdAt);
-        assert.isUndefined(insertedDoc.updatedAt);
+        Object.keys(insertedDoc).length.should.equal(2)
+        assert.isUndefined(insertedDoc.createdAt)
+        assert.isUndefined(insertedDoc.updatedAt)
 
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
-          assert.deepEqual(docs[0], insertedDoc);
+          docs.length.should.equal(1)
+          assert.deepEqual(docs[0], insertedDoc)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
-    it("If timestampData is set but createdAt is specified by user, don't change it", function (done) {
-      var newDoc = { hello: 'world', createdAt: new Date(234) }, beginning = Date.now();
-      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+    it('If timestampData is set but createdAt is specified by user, don\'t change it', function (done) {
+      const newDoc = { hello: 'world', createdAt: new Date(234) }, beginning = Date.now()
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true })
       d.insert(newDoc, function (err, insertedDoc) {
-        Object.keys(insertedDoc).length.should.equal(4);
-        insertedDoc.createdAt.getTime().should.equal(234);   // Not modified
-        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound);   // Created
+        Object.keys(insertedDoc).length.should.equal(4)
+        insertedDoc.createdAt.getTime().should.equal(234)   // Not modified
+        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound)   // Created
 
         d.find({}, function (err, docs) {
-          assert.deepEqual(insertedDoc, docs[0]);
+          assert.deepEqual(insertedDoc, docs[0])
 
           d.loadDatabase(function () {
             d.find({}, function (err, docs) {
-              assert.deepEqual(insertedDoc, docs[0]);
+              assert.deepEqual(insertedDoc, docs[0])
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
-    it("If timestampData is set but updatedAt is specified by user, don't change it", function (done) {
-      var newDoc = { hello: 'world', updatedAt: new Date(234) }, beginning = Date.now();
-      d = new Datastore({ filename: testDb, timestampData: true, autoload: true });
+    it('If timestampData is set but updatedAt is specified by user, don\'t change it', function (done) {
+      const newDoc = { hello: 'world', updatedAt: new Date(234) }, beginning = Date.now()
+      d = new Datastore({ filename: testDb, timestampData: true, autoload: true })
       d.insert(newDoc, function (err, insertedDoc) {
-        Object.keys(insertedDoc).length.should.equal(4);
-        insertedDoc.updatedAt.getTime().should.equal(234);   // Not modified
-        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound);   // Created
+        Object.keys(insertedDoc).length.should.equal(4)
+        insertedDoc.updatedAt.getTime().should.equal(234)   // Not modified
+        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound)   // Created
 
         d.find({}, function (err, docs) {
-          assert.deepEqual(insertedDoc, docs[0]);
+          assert.deepEqual(insertedDoc, docs[0])
 
           d.loadDatabase(function () {
             d.find({}, function (err, docs) {
-              assert.deepEqual(insertedDoc, docs[0]);
+              assert.deepEqual(insertedDoc, docs[0])
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
     it('Can insert a doc with id 0', function (done) {
       d.insert({ _id: 0, hello: 'world' }, function (err, doc) {
-        doc._id.should.equal(0);
-        doc.hello.should.equal('world');
-        done();
-      });
-    });
+        doc._id.should.equal(0)
+        doc.hello.should.equal('world')
+        done()
+      })
+    })
 
     /**
      * Complicated behavior here. Basically we need to test that when a user function throws an exception, it is not caught
@@ -391,38 +405,36 @@ describe('Database', function () {
      * Note: maybe using an in-memory only NeDB would give us an easier solution
      */
     it('If the callback throws an uncaught exception, do not catch it inside findOne, this is userspace concern', function (done) {
-      var tryCount = 0
-        , currentUncaughtExceptionHandlers = process.listeners('uncaughtException')
-        , i
-        ;
+      let tryCount = 0
+      const currentUncaughtExceptionHandlers = process.listeners('uncaughtException')
+      let i
 
-      process.removeAllListeners('uncaughtException');
+      process.removeAllListeners('uncaughtException')
 
       process.on('uncaughtException', function MINE (ex) {
-        process.removeAllListeners('uncaughtException');
+        process.removeAllListeners('uncaughtException')
 
         for (i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
-          process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+          process.on('uncaughtException', currentUncaughtExceptionHandlers[i])
         }
 
-        ex.message.should.equal('SOME EXCEPTION');
-        done();
-      });
+        ex.message.should.equal('SOME EXCEPTION')
+        done()
+      })
 
       d.insert({ a: 5 }, function () {
-        d.findOne({ a : 5}, function (err, doc) {
+        d.findOne({ a: 5 }, function (err, doc) {
           if (tryCount === 0) {
-            tryCount += 1;
-            throw new Error('SOME EXCEPTION');
+            tryCount += 1
+            throw new Error('SOME EXCEPTION')
           } else {
-            done(new Error('Callback was called twice'));
+            done(new Error('Callback was called twice'))
           }
-        });
-      });
-    });
+        })
+      })
+    })
 
-  });   // ==== End of 'Insert' ==== //
-
+  })   // ==== End of 'Insert' ==== //
 
   describe('#getCandidates', function () {
 
@@ -433,22 +445,21 @@ describe('Database', function () {
             d.insert({ tf: 4, an: 'other' }, function (err, _doc2) {
               d.insert({ tf: 9 }, function () {
                 d.getCandidates({ r: 6, tf: 4 }, function (err, data) {
-                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
-                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
-                    ;
+                  const doc1 = _.find(data, function (d) { return d._id === _doc1._id })
+                  const doc2 = _.find(data, function (d) { return d._id === _doc2._id })
 
-                  data.length.should.equal(2);
-                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 });
-                  assert.deepEqual(doc2, { _id: doc2._id, tf: 4, an: 'other' });
+                  data.length.should.equal(2)
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 })
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 4, an: 'other' })
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use an index to get docs with a $in match', function (done) {
       d.ensureIndex({ fieldName: 'tf' }, function (err) {
@@ -457,22 +468,21 @@ describe('Database', function () {
             d.insert({ tf: 4, an: 'other' }, function (err) {
               d.insert({ tf: 9 }, function (err, _doc2) {
                 d.getCandidates({ r: 6, tf: { $in: [6, 9, 5] } }, function (err, data) {
-                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
-                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
-                    ;
+                  const doc1 = _.find(data, function (d) { return d._id === _doc1._id })
+                  const doc2 = _.find(data, function (d) { return d._id === _doc2._id })
 
-                  data.length.should.equal(2);
-                  assert.deepEqual(doc1, { _id: doc1._id, tf: 6 });
-                  assert.deepEqual(doc2, { _id: doc2._id, tf: 9 });
+                  data.length.should.equal(2)
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 6 })
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 9 })
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('If no index can be used, return the whole database', function (done) {
       d.ensureIndex({ fieldName: 'tf' }, function (err) {
@@ -481,26 +491,25 @@ describe('Database', function () {
             d.insert({ tf: 4, an: 'other' }, function (err, _doc3) {
               d.insert({ tf: 9 }, function (err, _doc4) {
                 d.getCandidates({ r: 6, notf: { $in: [6, 9, 5] } }, function (err, data) {
-                  var doc1 = _.find(data, function (d) { return d._id === _doc1._id; })
-                    , doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
-                    , doc3 = _.find(data, function (d) { return d._id === _doc3._id; })
-                    , doc4 = _.find(data, function (d) { return d._id === _doc4._id; })
-                    ;
+                  const doc1 = _.find(data, function (d) { return d._id === _doc1._id })
+                  const doc2 = _.find(data, function (d) { return d._id === _doc2._id })
+                  const doc3 = _.find(data, function (d) { return d._id === _doc3._id })
+                  const doc4 = _.find(data, function (d) { return d._id === _doc4._id })
 
-                  data.length.should.equal(4);
-                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 });
-                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 });
-                  assert.deepEqual(doc3, { _id: doc3._id, tf: 4, an: 'other' });
-                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 });
+                  data.length.should.equal(4)
+                  assert.deepEqual(doc1, { _id: doc1._id, tf: 4 })
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 })
+                  assert.deepEqual(doc3, { _id: doc3._id, tf: 4, an: 'other' })
+                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 })
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use indexes for comparison matches', function (done) {
       d.ensureIndex({ fieldName: 'tf' }, function (err) {
@@ -509,325 +518,321 @@ describe('Database', function () {
             d.insert({ tf: 4, an: 'other' }, function (err, _doc3) {
               d.insert({ tf: 9 }, function (err, _doc4) {
                 d.getCandidates({ r: 6, tf: { $lte: 9, $gte: 6 } }, function (err, data) {
-                  var doc2 = _.find(data, function (d) { return d._id === _doc2._id; })
-                    , doc4 = _.find(data, function (d) { return d._id === _doc4._id; })
-                    ;
+                  const doc2 = _.find(data, function (d) { return d._id === _doc2._id })
+                  const doc4 = _.find(data, function (d) { return d._id === _doc4._id })
 
-                  data.length.should.equal(2);
-                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 });
-                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 });
+                  data.length.should.equal(2)
+                  assert.deepEqual(doc2, { _id: doc2._id, tf: 6 })
+                  assert.deepEqual(doc4, { _id: doc4._id, tf: 9 })
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
-    it("Can set a TTL index that expires documents", function (done) {
+    it('Can set a TTL index that expires documents', function (done) {
       d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
         d.insert({ hello: 'world', exp: new Date() }, function () {
           setTimeout(function () {
             d.findOne({}, function (err, doc) {
-              assert.isNull(err);
-              doc.hello.should.equal('world');
+              assert.isNull(err)
+              doc.hello.should.equal('world')
 
               setTimeout(function () {
                 d.findOne({}, function (err, doc) {
-                  assert.isNull(err);
-                  assert.isNull(doc);
+                  assert.isNull(err)
+                  assert.isNull(doc)
 
                   d.on('compaction.done', function () {
                     // After compaction, no more mention of the document, correctly removed
-                    var datafileContents = fs.readFileSync(testDb, 'utf8');
-                    datafileContents.split('\n').length.should.equal(2);
-                    assert.isNull(datafileContents.match(/world/));
+                    const datafileContents = fs.readFileSync(testDb, 'utf8')
+                    datafileContents.split('\n').length.should.equal(2)
+                    assert.isNull(datafileContents.match(/world/))
 
                     // New datastore on same datafile is empty
-                    var d2 = new Datastore({ filename: testDb, autoload: true });
+                    const d2 = new Datastore({ filename: testDb, autoload: true })
                     d2.findOne({}, function (err, doc) {
-                      assert.isNull(err);
-                      assert.isNull(doc);
+                      assert.isNull(err)
+                      assert.isNull(doc)
 
-                      done();
-                    });
-                  });
+                      done()
+                    })
+                  })
 
-                  d.persistence.compactDatafile();
-                });
-              }, 101);
-            });
-          }, 100);
-        });
-      });
-    });
+                  d.persistence.compactDatafile()
+                })
+              }, 101)
+            })
+          }, 100)
+        })
+      })
+    })
 
-    it("TTL indexes can expire multiple documents and only what needs to be expired", function (done) {
+    it('TTL indexes can expire multiple documents and only what needs to be expired', function (done) {
       d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
         d.insert({ hello: 'world1', exp: new Date() }, function () {
           d.insert({ hello: 'world2', exp: new Date() }, function () {
             d.insert({ hello: 'world3', exp: new Date((new Date()).getTime() + 100) }, function () {
               setTimeout(function () {
                 d.find({}, function (err, docs) {
-                  assert.isNull(err);
-                  docs.length.should.equal(3);
+                  assert.isNull(err)
+                  docs.length.should.equal(3)
 
                   setTimeout(function () {
                     d.find({}, function (err, docs) {
-                      assert.isNull(err);
-                      docs.length.should.equal(1);
-                      docs[0].hello.should.equal('world3');
+                      assert.isNull(err)
+                      docs.length.should.equal(1)
+                      docs[0].hello.should.equal('world3')
 
                       setTimeout(function () {
                         d.find({}, function (err, docs) {
-                          assert.isNull(err);
-                          docs.length.should.equal(0);
+                          assert.isNull(err)
+                          docs.length.should.equal(0)
 
-                          done();
-                        });
-                      }, 101);
-                    });
-                  }, 101);
-                });
-              }, 100);
-            });
-          });
-        });
-      });
-    });
+                          done()
+                        })
+                      }, 101)
+                    })
+                  }, 101)
+                })
+              }, 100)
+            })
+          })
+        })
+      })
+    })
 
-    it("Document where indexed field is absent or not a date are ignored", function (done) {
+    it('Document where indexed field is absent or not a date are ignored', function (done) {
       d.ensureIndex({ fieldName: 'exp', expireAfterSeconds: 0.2 }, function () {
         d.insert({ hello: 'world1', exp: new Date() }, function () {
-          d.insert({ hello: 'world2', exp: "not a date" }, function () {
+          d.insert({ hello: 'world2', exp: 'not a date' }, function () {
             d.insert({ hello: 'world3' }, function () {
               setTimeout(function () {
                 d.find({}, function (err, docs) {
-                  assert.isNull(err);
-                  docs.length.should.equal(3);
+                  assert.isNull(err)
+                  docs.length.should.equal(3)
 
                   setTimeout(function () {
                     d.find({}, function (err, docs) {
-                      assert.isNull(err);
-                      docs.length.should.equal(2);
+                      assert.isNull(err)
+                      docs.length.should.equal(2)
 
+                      docs[0].hello.should.not.equal('world1')
+                      docs[1].hello.should.not.equal('world1')
 
-                      docs[0].hello.should.not.equal('world1');
-                      docs[1].hello.should.not.equal('world1');
+                      done()
+                    })
+                  }, 101)
+                })
+              }, 100)
+            })
+          })
+        })
+      })
+    })
 
-                      done();
-                    });
-                  }, 101);
-                });
-              }, 100);
-            });
-          });
-        });
-      });
-    });
-
-  });   // ==== End of '#getCandidates' ==== //
-
+  })   // ==== End of '#getCandidates' ==== //
 
   describe('Find', function () {
 
     it('Can find all documents if an empty query is used', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with empty object
-        d.find({}, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(3);
-          _.pluck(docs, 'somedata').should.contain('ok');
-          _.pluck(docs, 'somedata').should.contain('another');
-          _.find(docs, function (d) { return d.somedata === 'another' }).plus.should.equal('additional data');
-          _.pluck(docs, 'somedata').should.contain('again');
-          return cb();
-        });
-      }
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'again' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with empty object
+          d.find({}, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(3)
+            _.pluck(docs, 'somedata').should.contain('ok')
+            _.pluck(docs, 'somedata').should.contain('another')
+            _.find(docs, function (d) { return d.somedata === 'another' }).plus.should.equal('additional data')
+            _.pluck(docs, 'somedata').should.contain('again')
+            return cb()
+          })
+        }
+      ], done)
+    })
 
     it('Can find all documents matching a basic query', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that will return docs
-        d.find({ somedata: 'again' }, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(2);
-          _.pluck(docs, 'somedata').should.not.contain('ok');
-          return cb();
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.find({ somedata: 'nope' }, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(0);
-          return cb();
-        });
-      }
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'again' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that will return docs
+          d.find({ somedata: 'again' }, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            _.pluck(docs, 'somedata').should.not.contain('ok')
+            return cb()
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.find({ somedata: 'nope' }, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            return cb()
+          })
+        }
+      ], done)
+    })
 
     it('Can find one document matching a basic query and return null if none is found', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that will return docs
-        d.findOne({ somedata: 'ok' }, function (err, doc) {
-          assert.isNull(err);
-          Object.keys(doc).length.should.equal(2);
-          doc.somedata.should.equal('ok');
-          assert.isDefined(doc._id);
-          return cb();
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.findOne({ somedata: 'nope' }, function (err, doc) {
-          assert.isNull(err);
-          assert.isNull(doc);
-          return cb();
-        });
-      }
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'again' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that will return docs
+          d.findOne({ somedata: 'ok' }, function (err, doc) {
+            assert.isNull(err)
+            Object.keys(doc).length.should.equal(2)
+            doc.somedata.should.equal('ok')
+            assert.isDefined(doc._id)
+            return cb()
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.findOne({ somedata: 'nope' }, function (err, doc) {
+            assert.isNull(err)
+            assert.isNull(doc)
+            return cb()
+          })
+        }
+      ], done)
+    })
 
     it('Can find dates and objects (non JS-native types)', function (done) {
-      var date1 = new Date(1234543)
-        , date2 = new Date(9999)
-        ;
+      const date1 = new Date(1234543)
+      const date2 = new Date(9999)
 
       d.insert({ now: date1, sth: { name: 'nedb' } }, function () {
         d.findOne({ now: date1 }, function (err, doc) {
-          assert.isNull(err);
-          doc.sth.name.should.equal('nedb');
+          assert.isNull(err)
+          doc.sth.name.should.equal('nedb')
 
           d.findOne({ now: date2 }, function (err, doc) {
-            assert.isNull(err);
-            assert.isNull(doc);
+            assert.isNull(err)
+            assert.isNull(doc)
 
             d.findOne({ sth: { name: 'nedb' } }, function (err, doc) {
-              assert.isNull(err);
-              doc.sth.name.should.equal('nedb');
+              assert.isNull(err)
+              doc.sth.name.should.equal('nedb')
 
               d.findOne({ sth: { name: 'other' } }, function (err, doc) {
-                assert.isNull(err);
-                assert.isNull(doc);
+                assert.isNull(err)
+                assert.isNull(doc)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use dot-notation to query subfields', function (done) {
       d.insert({ greeting: { english: 'hello' } }, function () {
-        d.findOne({ "greeting.english": 'hello' }, function (err, doc) {
-          assert.isNull(err);
-          doc.greeting.english.should.equal('hello');
+        d.findOne({ 'greeting.english': 'hello' }, function (err, doc) {
+          assert.isNull(err)
+          doc.greeting.english.should.equal('hello')
 
-          d.findOne({ "greeting.english": 'hellooo' }, function (err, doc) {
-            assert.isNull(err);
-            assert.isNull(doc);
+          d.findOne({ 'greeting.english': 'hellooo' }, function (err, doc) {
+            assert.isNull(err)
+            assert.isNull(doc)
 
-            d.findOne({ "greeting.englis": 'hello' }, function (err, doc) {
-              assert.isNull(err);
-              assert.isNull(doc);
+            d.findOne({ 'greeting.englis': 'hello' }, function (err, doc) {
+              assert.isNull(err)
+              assert.isNull(doc)
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
     it('Array fields match if any element matches', function (done) {
       d.insert({ fruits: ['pear', 'apple', 'banana'] }, function (err, doc1) {
         d.insert({ fruits: ['coconut', 'orange', 'pear'] }, function (err, doc2) {
           d.insert({ fruits: ['banana'] }, function (err, doc3) {
             d.find({ fruits: 'pear' }, function (err, docs) {
-              assert.isNull(err);
-              docs.length.should.equal(2);
-              _.pluck(docs, '_id').should.contain(doc1._id);
-              _.pluck(docs, '_id').should.contain(doc2._id);
+              assert.isNull(err)
+              docs.length.should.equal(2)
+              _.pluck(docs, '_id').should.contain(doc1._id)
+              _.pluck(docs, '_id').should.contain(doc2._id)
 
               d.find({ fruits: 'banana' }, function (err, docs) {
-                assert.isNull(err);
-                docs.length.should.equal(2);
-                _.pluck(docs, '_id').should.contain(doc1._id);
-                _.pluck(docs, '_id').should.contain(doc3._id);
+                assert.isNull(err)
+                docs.length.should.equal(2)
+                _.pluck(docs, '_id').should.contain(doc1._id)
+                _.pluck(docs, '_id').should.contain(doc3._id)
 
                 d.find({ fruits: 'doesntexist' }, function (err, docs) {
-                  assert.isNull(err);
-                  docs.length.should.equal(0);
+                  assert.isNull(err)
+                  docs.length.should.equal(0)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Returns an error if the query is not well formed', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.find({ $or: { hello: 'world' } }, function (err, docs) {
-          assert.isDefined(err);
-          assert.isUndefined(docs);
+          assert.isDefined(err)
+          assert.isUndefined(docs)
 
           d.findOne({ $or: { hello: 'world' } }, function (err, doc) {
-            assert.isDefined(err);
-            assert.isUndefined(doc);
+            assert.isDefined(err)
+            assert.isUndefined(doc)
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('Changing the documents returned by find or findOne do not change the database state', function (done) {
       d.insert({ a: 2, hello: 'world' }, function () {
         d.findOne({ a: 2 }, function (err, doc) {
-          doc.hello = 'changed';
+          doc.hello = 'changed'
 
           d.findOne({ a: 2 }, function (err, doc) {
-            doc.hello.should.equal('world');
+            doc.hello.should.equal('world')
 
             d.find({ a: 2 }, function (err, docs) {
-              docs[0].hello = 'changed';
+              docs[0].hello = 'changed'
 
               d.findOne({ a: 2 }, function (err, doc) {
-                doc.hello.should.equal('world');
+                doc.hello.should.equal('world')
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use sort, skip and limit if the callback is not passed to find but to exec', function (done) {
       d.insert({ a: 2, hello: 'world' }, function () {
@@ -835,947 +840,961 @@ describe('Database', function () {
           d.insert({ a: 13, hello: 'blueplanet' }, function () {
             d.insert({ a: 15, hello: 'home' }, function () {
               d.find({}).sort({ a: 1 }).limit(2).exec(function (err, docs) {
-                assert.isNull(err);
-                docs.length.should.equal(2);
-                docs[0].hello.should.equal('world');
-                docs[1].hello.should.equal('blueplanet');
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                assert.isNull(err)
+                docs.length.should.equal(2)
+                docs[0].hello.should.equal('world')
+                docs[1].hello.should.equal('blueplanet')
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
-     it('Can use sort and skip if the callback is not passed to findOne but to exec', function (done) {
+    it('Can use sort and skip if the callback is not passed to findOne but to exec', function (done) {
       d.insert({ a: 2, hello: 'world' }, function () {
         d.insert({ a: 24, hello: 'earth' }, function () {
           d.insert({ a: 13, hello: 'blueplanet' }, function () {
             d.insert({ a: 15, hello: 'home' }, function () {
               // No skip no query
               d.findOne({}).sort({ a: 1 }).exec(function (err, doc) {
-                assert.isNull(err);
-                doc.hello.should.equal('world');
+                assert.isNull(err)
+                doc.hello.should.equal('world')
 
                 // A query
                 d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).exec(function (err, doc) {
-                  assert.isNull(err);
-                  doc.hello.should.equal('home');
+                  assert.isNull(err)
+                  doc.hello.should.equal('home')
 
                   // And a skip
                   d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).skip(1).exec(function (err, doc) {
-                    assert.isNull(err);
-                    doc.hello.should.equal('earth');
+                    assert.isNull(err)
+                    doc.hello.should.equal('earth')
 
                     // No result
                     d.findOne({ a: { $gt: 14 } }).sort({ a: 1 }).skip(2).exec(function (err, doc) {
-                      assert.isNull(err);
-                      assert.isNull(doc);
+                      assert.isNull(err)
+                      assert.isNull(doc)
 
-                      done();
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                      done()
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use projections in find, normal or cursor way', function (done) {
       d.insert({ a: 2, hello: 'world' }, function (err, doc0) {
         d.insert({ a: 24, hello: 'earth' }, function (err, doc1) {
           d.find({ a: 2 }, { a: 0, _id: 0 }, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            assert.deepEqual(docs[0], { hello: 'world' });
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            assert.deepEqual(docs[0], { hello: 'world' })
 
             d.find({ a: 2 }, { a: 0, _id: 0 }).exec(function (err, docs) {
-              assert.isNull(err);
-              docs.length.should.equal(1);
-              assert.deepEqual(docs[0], { hello: 'world' });
+              assert.isNull(err)
+              docs.length.should.equal(1)
+              assert.deepEqual(docs[0], { hello: 'world' })
 
               // Can't use both modes at once if not _id
               d.find({ a: 2 }, { a: 0, hello: 1 }, function (err, docs) {
-                assert.isNotNull(err);
-                assert.isUndefined(docs);
+                assert.isNotNull(err)
+                assert.isUndefined(docs)
 
                 d.find({ a: 2 }, { a: 0, hello: 1 }).exec(function (err, docs) {
-                  assert.isNotNull(err);
-                  assert.isUndefined(docs);
+                  assert.isNotNull(err)
+                  assert.isUndefined(docs)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can use projections in findOne, normal or cursor way', function (done) {
       d.insert({ a: 2, hello: 'world' }, function (err, doc0) {
         d.insert({ a: 24, hello: 'earth' }, function (err, doc1) {
           d.findOne({ a: 2 }, { a: 0, _id: 0 }, function (err, doc) {
-            assert.isNull(err);
-            assert.deepEqual(doc, { hello: 'world' });
+            assert.isNull(err)
+            assert.deepEqual(doc, { hello: 'world' })
 
             d.findOne({ a: 2 }, { a: 0, _id: 0 }).exec(function (err, doc) {
-              assert.isNull(err);
-              assert.deepEqual(doc, { hello: 'world' });
+              assert.isNull(err)
+              assert.deepEqual(doc, { hello: 'world' })
 
               // Can't use both modes at once if not _id
               d.findOne({ a: 2 }, { a: 0, hello: 1 }, function (err, doc) {
-                assert.isNotNull(err);
-                assert.isUndefined(doc);
+                assert.isNotNull(err)
+                assert.isUndefined(doc)
 
                 d.findOne({ a: 2 }, { a: 0, hello: 1 }).exec(function (err, doc) {
-                  assert.isNotNull(err);
-                  assert.isUndefined(doc);
+                  assert.isNotNull(err)
+                  assert.isUndefined(doc)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
-  });   // ==== End of 'Find' ==== //
+  })   // ==== End of 'Find' ==== //
 
-  describe('Count', function() {
+  describe('Count', function () {
 
     it('Count all documents if an empty query is used', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with empty object
-        d.count({}, function (err, docs) {
-          assert.isNull(err);
-          docs.should.equal(3);
-          return cb();
-        });
-      }
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'another', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'again' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with empty object
+          d.count({}, function (err, docs) {
+            assert.isNull(err)
+            docs.should.equal(3)
+            return cb()
+          })
+        }
+      ], done)
+    })
 
     it('Count all documents matching a basic query', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'again' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that will return docs
-        d.count({ somedata: 'again' }, function (err, docs) {
-          assert.isNull(err);
-          docs.should.equal(2);
-          return cb();
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.count({ somedata: 'nope' }, function (err, docs) {
-          assert.isNull(err);
-          docs.should.equal(0);
-          return cb();
-        });
-      }
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'again' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that will return docs
+          d.count({ somedata: 'again' }, function (err, docs) {
+            assert.isNull(err)
+            docs.should.equal(2)
+            return cb()
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.count({ somedata: 'nope' }, function (err, docs) {
+            assert.isNull(err)
+            docs.should.equal(0)
+            return cb()
+          })
+        }
+      ], done)
+    })
 
     it('Array fields match if any element matches', function (done) {
       d.insert({ fruits: ['pear', 'apple', 'banana'] }, function (err, doc1) {
         d.insert({ fruits: ['coconut', 'orange', 'pear'] }, function (err, doc2) {
           d.insert({ fruits: ['banana'] }, function (err, doc3) {
             d.count({ fruits: 'pear' }, function (err, docs) {
-              assert.isNull(err);
-              docs.should.equal(2);
+              assert.isNull(err)
+              docs.should.equal(2)
 
               d.count({ fruits: 'banana' }, function (err, docs) {
-                assert.isNull(err);
-                docs.should.equal(2);
+                assert.isNull(err)
+                docs.should.equal(2)
 
                 d.count({ fruits: 'doesntexist' }, function (err, docs) {
-                  assert.isNull(err);
-                  docs.should.equal(0);
+                  assert.isNull(err)
+                  docs.should.equal(0)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Returns an error if the query is not well formed', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.count({ $or: { hello: 'world' } }, function (err, docs) {
-          assert.isDefined(err);
-          assert.isUndefined(docs);
+          assert.isDefined(err)
+          assert.isUndefined(docs)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
-  });
+  })
 
   describe('Update', function () {
 
-    it("If the query doesn't match anything, database is not modified", function (done) {
+    it('If the query doesn\'t match anything, database is not modified', function (done) {
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err) {
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
-            d.insert({ somedata: 'another' }, function (err) { return cb(err); });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.update({ somedata: 'nope' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
-          assert.isNull(err);
-          n.should.equal(0);
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err) {
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err) {
+              d.insert({ somedata: 'another' }, function (err) { return cb(err) })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.update({ somedata: 'nope' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
+            assert.isNull(err)
+            n.should.equal(0)
 
-          d.find({}, function (err, docs) {
-            var doc1 = _.find(docs, function (d) { return d.somedata === 'ok'; })
-              , doc2 = _.find(docs, function (d) { return d.somedata === 'again'; })
-              , doc3 = _.find(docs, function (d) { return d.somedata === 'another'; })
-              ;
+            d.find({}, function (err, docs) {
+              const doc1 = _.find(docs, function (d) { return d.somedata === 'ok' })
+              const doc2 = _.find(docs, function (d) { return d.somedata === 'again' })
+              const doc3 = _.find(docs, function (d) { return d.somedata === 'another' })
 
-            docs.length.should.equal(3);
-            assert.isUndefined(_.find(docs, function (d) { return d.newDoc === 'yes'; }));
+              docs.length.should.equal(3)
+              assert.isUndefined(_.find(docs, function (d) { return d.newDoc === 'yes' }))
 
-            assert.deepEqual(doc1, { _id: doc1._id, somedata: 'ok' });
-            assert.deepEqual(doc2, { _id: doc2._id, somedata: 'again', plus: 'additional data' });
-            assert.deepEqual(doc3, { _id: doc3._id, somedata: 'another' });
+              assert.deepEqual(doc1, { _id: doc1._id, somedata: 'ok' })
+              assert.deepEqual(doc2, { _id: doc2._id, somedata: 'again', plus: 'additional data' })
+              assert.deepEqual(doc3, { _id: doc3._id, somedata: 'another' })
 
-            return cb();
-          });
-        });
-      }
-      ], done);
-    });
+              return cb()
+            })
+          })
+        }
+      ], done)
+    })
 
-    it("If timestampData option is set, update the updatedAt field", function (done) {
-      var beginning = Date.now();
-      d = new Datastore({ filename: testDb, autoload: true, timestampData: true });
+    it('If timestampData option is set, update the updatedAt field', function (done) {
+      const beginning = Date.now()
+      d = new Datastore({ filename: testDb, autoload: true, timestampData: true })
       d.insert({ hello: 'world' }, function (err, insertedDoc) {
-        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound);
-        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound);
-        Object.keys(insertedDoc).length.should.equal(4);
+        assert.isBelow(insertedDoc.updatedAt.getTime() - beginning, reloadTimeUpperBound)
+        assert.isBelow(insertedDoc.createdAt.getTime() - beginning, reloadTimeUpperBound)
+        Object.keys(insertedDoc).length.should.equal(4)
 
         // Wait 100ms before performing the update
         setTimeout(function () {
-          var step1 = Date.now();
+          const step1 = Date.now()
           d.update({ _id: insertedDoc._id }, { $set: { hello: 'mars' } }, {}, function () {
             d.find({ _id: insertedDoc._id }, function (err, docs) {
-              docs.length.should.equal(1);
-              Object.keys(docs[0]).length.should.equal(4);
-              docs[0]._id.should.equal(insertedDoc._id);
-              docs[0].createdAt.should.equal(insertedDoc.createdAt);
-              docs[0].hello.should.equal('mars');
-              assert.isAbove(docs[0].updatedAt.getTime() - beginning, 99);   // updatedAt modified
-              assert.isBelow(docs[0].updatedAt.getTime() - step1, reloadTimeUpperBound);   // updatedAt modified
+              docs.length.should.equal(1)
+              Object.keys(docs[0]).length.should.equal(4)
+              docs[0]._id.should.equal(insertedDoc._id)
+              docs[0].createdAt.should.equal(insertedDoc.createdAt)
+              docs[0].hello.should.equal('mars')
+              assert.isAbove(docs[0].updatedAt.getTime() - beginning, 99)   // updatedAt modified
+              assert.isBelow(docs[0].updatedAt.getTime() - step1, reloadTimeUpperBound)   // updatedAt modified
 
-              done();
-            });
+              done()
+            })
           })
-        }, 100);
-      });
-    });
+        }, 100)
+      })
+    })
 
-    it("Can update multiple documents matching the query", function (done) {
-      var id1, id2, id3;
+    it('Can update multiple documents matching the query', function (done) {
+      let id1
+      let id2
+      let id3
 
       // Test DB state after update and reload
       function testPostUpdateState (cb) {
         d.find({}, function (err, docs) {
-          var doc1 = _.find(docs, function (d) { return d._id === id1; })
-            , doc2 = _.find(docs, function (d) { return d._id === id2; })
-            , doc3 = _.find(docs, function (d) { return d._id === id3; })
-            ;
+          const doc1 = _.find(docs, function (d) { return d._id === id1 })
+          const doc2 = _.find(docs, function (d) { return d._id === id2 })
+          const doc3 = _.find(docs, function (d) { return d._id === id3 })
 
-          docs.length.should.equal(3);
+          docs.length.should.equal(3)
 
-          Object.keys(doc1).length.should.equal(2);
-          doc1.somedata.should.equal('ok');
-          doc1._id.should.equal(id1);
+          Object.keys(doc1).length.should.equal(2)
+          doc1.somedata.should.equal('ok')
+          doc1._id.should.equal(id1)
 
-          Object.keys(doc2).length.should.equal(2);
-          doc2.newDoc.should.equal('yes');
-          doc2._id.should.equal(id2);
+          Object.keys(doc2).length.should.equal(2)
+          doc2.newDoc.should.equal('yes')
+          doc2._id.should.equal(id2)
 
-          Object.keys(doc3).length.should.equal(2);
-          doc3.newDoc.should.equal('yes');
-          doc3._id.should.equal(id3);
+          Object.keys(doc3).length.should.equal(2)
+          doc3.newDoc.should.equal('yes')
+          doc3._id.should.equal(id3)
 
-          return cb();
-        });
+          return cb()
+        })
       }
 
       // Actually launch the tests
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err, doc1) {
-          id1 = doc1._id;
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
-            id2 = doc2._id;
-            d.insert({ somedata: 'again' }, function (err, doc3) {
-              id3 = doc3._id;
-              return cb(err);
-            });
-          });
-        });
-      }
-      , function (cb) {
-        d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
-          assert.isNull(err);
-          n.should.equal(2);
-          return cb();
-        });
-      }
-      , async.apply(testPostUpdateState)
-      , function (cb) {
-        d.loadDatabase(function (err) { cb(err); });
-      }
-      , async.apply(testPostUpdateState)
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err, doc1) {
+            id1 = doc1._id
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+              id2 = doc2._id
+              d.insert({ somedata: 'again' }, function (err, doc3) {
+                id3 = doc3._id
+                return cb(err)
+              })
+            })
+          })
+        }
+        , function (cb) {
+          d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: true }, function (err, n) {
+            assert.isNull(err)
+            n.should.equal(2)
+            return cb()
+          })
+        }
+        , async.apply(testPostUpdateState)
+        , function (cb) {
+          d.loadDatabase(function (err) { cb(err) })
+        }
+        , async.apply(testPostUpdateState)
+      ], done)
+    })
 
-    it("Can update only one document matching the query", function (done) {
-      var id1, id2, id3;
+    it('Can update only one document matching the query', function (done) {
+      let id1
+      let id2
+      let id3
 
       // Test DB state after update and reload
       function testPostUpdateState (cb) {
         d.find({}, function (err, docs) {
-          var doc1 = _.find(docs, function (d) { return d._id === id1; })
-            , doc2 = _.find(docs, function (d) { return d._id === id2; })
-            , doc3 = _.find(docs, function (d) { return d._id === id3; })
-            ;
+          const doc1 = _.find(docs, function (d) { return d._id === id1 })
+          const doc2 = _.find(docs, function (d) { return d._id === id2 })
+          const doc3 = _.find(docs, function (d) { return d._id === id3 })
 
-          docs.length.should.equal(3);
+          docs.length.should.equal(3)
 
-          assert.deepEqual(doc1, { somedata: 'ok', _id: doc1._id });
+          assert.deepEqual(doc1, { somedata: 'ok', _id: doc1._id })
 
           // doc2 or doc3 was modified. Since we sort on _id and it is random
           // it can be either of two situations
           try {
-            assert.deepEqual(doc2, { newDoc: 'yes', _id: doc2._id });
-            assert.deepEqual(doc3, { somedata: 'again', _id: doc3._id });
+            assert.deepEqual(doc2, { newDoc: 'yes', _id: doc2._id })
+            assert.deepEqual(doc3, { somedata: 'again', _id: doc3._id })
           } catch (e) {
-            assert.deepEqual(doc2, { somedata: 'again', plus: 'additional data', _id: doc2._id });
-            assert.deepEqual(doc3, { newDoc: 'yes', _id: doc3._id });
+            assert.deepEqual(doc2, { somedata: 'again', plus: 'additional data', _id: doc2._id })
+            assert.deepEqual(doc3, { newDoc: 'yes', _id: doc3._id })
           }
 
-          return cb();
-        });
+          return cb()
+        })
       }
 
       // Actually launch the test
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err, doc1) {
-          id1 = doc1._id;
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
-            id2 = doc2._id;
-            d.insert({ somedata: 'again' }, function (err, doc3) {
-              id3 = doc3._id;
-              return cb(err);
-            });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: false }, function (err, n) {
-          assert.isNull(err);
-          n.should.equal(1);
-          return cb();
-        });
-      }
-      , async.apply(testPostUpdateState)
-      , function (cb) {
-        d.loadDatabase(function (err) { return cb(err); });
-      }
-      , async.apply(testPostUpdateState)   // The persisted state has been updated
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err, doc1) {
+            id1 = doc1._id
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+              id2 = doc2._id
+              d.insert({ somedata: 'again' }, function (err, doc3) {
+                id3 = doc3._id
+                return cb(err)
+              })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.update({ somedata: 'again' }, { newDoc: 'yes' }, { multi: false }, function (err, n) {
+            assert.isNull(err)
+            n.should.equal(1)
+            return cb()
+          })
+        }
+        , async.apply(testPostUpdateState)
+        , function (cb) {
+          d.loadDatabase(function (err) { return cb(err) })
+        }
+        , async.apply(testPostUpdateState)   // The persisted state has been updated
+      ], done)
+    })
 
     describe('Upserts', function () {
 
       it('Can perform upserts if needed', function (done) {
         d.update({ impossible: 'db is empty anyway' }, { newDoc: true }, {}, function (err, nr, upsert) {
-          assert.isNull(err);
-          nr.should.equal(0);
-          assert.isUndefined(upsert);
+          assert.isNull(err)
+          nr.should.equal(0)
+          assert.isUndefined(upsert)
 
           d.find({}, function (err, docs) {
-            docs.length.should.equal(0);   // Default option for upsert is false
+            docs.length.should.equal(0)   // Default option for upsert is false
 
-            d.update({ impossible: 'db is empty anyway' }, { something: "created ok" }, { upsert: true }, function (err, nr, newDoc) {
-              assert.isNull(err);
-              nr.should.equal(1);
-              newDoc.something.should.equal("created ok");
-              assert.isDefined(newDoc._id);
+            d.update({ impossible: 'db is empty anyway' }, { something: 'created ok' }, { upsert: true }, function (err, nr, newDoc) {
+              assert.isNull(err)
+              nr.should.equal(1)
+              newDoc.something.should.equal('created ok')
+              assert.isDefined(newDoc._id)
 
               d.find({}, function (err, docs) {
-                docs.length.should.equal(1);   // Default option for upsert is false
-                docs[0].something.should.equal("created ok");
+                docs.length.should.equal(1)   // Default option for upsert is false
+                docs[0].something.should.equal('created ok')
 
                 // Modifying the returned upserted document doesn't modify the database
-                newDoc.newField = true;
+                newDoc.newField = true
                 d.find({}, function (err, docs) {
-                  docs[0].something.should.equal("created ok");
-                  assert.isUndefined(docs[0].newField);
+                  docs[0].something.should.equal('created ok')
+                  assert.isUndefined(docs[0].newField)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('If the update query is a normal object with no modifiers, it is the doc that will be upserted', function (done) {
         d.update({ $or: [{ a: 4 }, { a: 5 }] }, { hello: 'world', bloup: 'blap' }, { upsert: true }, function (err) {
           d.find({}, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            var doc = docs[0];
-            Object.keys(doc).length.should.equal(3);
-            doc.hello.should.equal('world');
-            doc.bloup.should.equal('blap');
-            done();
-          });
-        });
-      });
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            const doc = docs[0]
+            Object.keys(doc).length.should.equal(3)
+            doc.hello.should.equal('world')
+            doc.bloup.should.equal('blap')
+            done()
+          })
+        })
+      })
 
       it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 1', function (done) {
-        d.update({ $or: [{ a: 4 }, { a: 5 }] }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
+        d.update({ $or: [{ a: 4 }, { a: 5 }] }, {
+          $set: { hello: 'world' },
+          $inc: { bloup: 3 }
+        }, { upsert: true }, function (err) {
           d.find({ hello: 'world' }, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            var doc = docs[0];
-            Object.keys(doc).length.should.equal(3);
-            doc.hello.should.equal('world');
-            doc.bloup.should.equal(3);
-            done();
-          });
-        });
-      });
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            const doc = docs[0]
+            Object.keys(doc).length.should.equal(3)
+            doc.hello.should.equal('world')
+            doc.bloup.should.equal(3)
+            done()
+          })
+        })
+      })
 
       it('If the update query contains modifiers, it is applied to the object resulting from removing all operators from the find query 2', function (done) {
-        d.update({ $or: [{ a: 4 }, { a: 5 }], cac: 'rrr' }, { $set: { hello: 'world' }, $inc: { bloup: 3 } }, { upsert: true }, function (err) {
+        d.update({ $or: [{ a: 4 }, { a: 5 }], cac: 'rrr' }, {
+          $set: { hello: 'world' },
+          $inc: { bloup: 3 }
+        }, { upsert: true }, function (err) {
           d.find({ hello: 'world' }, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            var doc = docs[0];
-            Object.keys(doc).length.should.equal(4);
-            doc.cac.should.equal('rrr');
-            doc.hello.should.equal('world');
-            doc.bloup.should.equal(3);
-            done();
-          });
-        });
-      });
-
-      it('Performing upsert with badly formatted fields yields a standard error not an exception', function(done) {
-        d.update({_id: '1234'}, { $set: { $$badfield: 5 }}, { upsert: true }, function(err, doc) {
-          assert.isDefined(err);
-          done();
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            const doc = docs[0]
+            Object.keys(doc).length.should.equal(4)
+            doc.cac.should.equal('rrr')
+            doc.hello.should.equal('world')
+            doc.bloup.should.equal(3)
+            done()
+          })
         })
-      });
+      })
 
+      it('Performing upsert with badly formatted fields yields a standard error not an exception', function (done) {
+        d.update({ _id: '1234' }, { $set: { $$badfield: 5 } }, { upsert: true }, function (err, doc) {
+          assert.isDefined(err)
+          done()
+        })
+      })
 
-    });   // ==== End of 'Upserts' ==== //
+    })   // ==== End of 'Upserts' ==== //
 
     it('Cannot perform update if the update query is not either registered-modifiers-only or copy-only, or contain badly formatted fields', function (done) {
       d.insert({ something: 'yup' }, function () {
         d.update({}, { boom: { $badfield: 5 } }, { multi: false }, function (err) {
-          assert.isDefined(err);
+          assert.isDefined(err)
 
-          d.update({}, { boom: { "bad.field": 5 } }, { multi: false }, function (err) {
-            assert.isDefined(err);
+          d.update({}, { boom: { 'bad.field': 5 } }, { multi: false }, function (err) {
+            assert.isDefined(err)
 
             d.update({}, { $inc: { test: 5 }, mixed: 'rrr' }, { multi: false }, function (err) {
-              assert.isDefined(err);
+              assert.isDefined(err)
 
               d.update({}, { $inexistent: { test: 5 } }, { multi: false }, function (err) {
-                assert.isDefined(err);
+                assert.isDefined(err)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can update documents using multiple modifiers', function (done) {
-      var id;
+      let id
 
       d.insert({ something: 'yup', other: 40 }, function (err, newDoc) {
-        id = newDoc._id;
+        id = newDoc._id
 
         d.update({}, { $set: { something: 'changed' }, $inc: { other: 10 } }, { multi: false }, function (err, nr) {
-          assert.isNull(err);
-          nr.should.equal(1);
+          assert.isNull(err)
+          nr.should.equal(1)
 
           d.findOne({ _id: id }, function (err, doc) {
-            Object.keys(doc).length.should.equal(3);
-            doc._id.should.equal(id);
-            doc.something.should.equal('changed');
-            doc.other.should.equal(50);
+            Object.keys(doc).length.should.equal(3)
+            doc._id.should.equal(id)
+            doc.something.should.equal('changed')
+            doc.other.should.equal(50)
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('Can upsert a document even with modifiers', function (done) {
       d.update({ bloup: 'blap' }, { $set: { hello: 'world' } }, { upsert: true }, function (err, nr, newDoc) {
-        assert.isNull(err);
-        nr.should.equal(1);
-        newDoc.bloup.should.equal('blap');
-        newDoc.hello.should.equal('world');
-        assert.isDefined(newDoc._id);
+        assert.isNull(err)
+        nr.should.equal(1)
+        newDoc.bloup.should.equal('blap')
+        newDoc.hello.should.equal('world')
+        assert.isDefined(newDoc._id)
 
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
-          Object.keys(docs[0]).length.should.equal(3);
-          docs[0].hello.should.equal('world');
-          docs[0].bloup.should.equal('blap');
-          assert.isDefined(docs[0]._id);
+          docs.length.should.equal(1)
+          Object.keys(docs[0]).length.should.equal(3)
+          docs[0].hello.should.equal('world')
+          docs[0].bloup.should.equal('blap')
+          assert.isDefined(docs[0]._id)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('When using modifiers, the only way to update subdocs is with the dot-notation', function (done) {
-      d.insert({ bloup: { blip: "blap", other: true } }, function () {
+      d.insert({ bloup: { blip: 'blap', other: true } }, function () {
         // Correct methos
-        d.update({}, { $set: { "bloup.blip": "hello" } }, {}, function () {
+        d.update({}, { $set: { 'bloup.blip': 'hello' } }, {}, function () {
           d.findOne({}, function (err, doc) {
-            doc.bloup.blip.should.equal("hello");
-            doc.bloup.other.should.equal(true);
+            doc.bloup.blip.should.equal('hello')
+            doc.bloup.other.should.equal(true)
 
             // Wrong
-            d.update({}, { $set: { bloup: { blip: "ola" } } }, {}, function () {
+            d.update({}, { $set: { bloup: { blip: 'ola' } } }, {}, function () {
               d.findOne({}, function (err, doc) {
-                doc.bloup.blip.should.equal("ola");
-                assert.isUndefined(doc.bloup.other);   // This information was lost
+                doc.bloup.blip.should.equal('ola')
+                assert.isUndefined(doc.bloup.other)   // This information was lost
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Returns an error if the query is not well formed', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.update({ $or: { hello: 'world' } }, { a: 1 }, {}, function (err, nr, upsert) {
-          assert.isDefined(err);
-          assert.isUndefined(nr);
-          assert.isUndefined(upsert);
+          assert.isDefined(err)
+          assert.isUndefined(nr)
+          assert.isUndefined(upsert)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('If an error is thrown by a modifier, the database state is not changed', function (done) {
       d.insert({ hello: 'world' }, function (err, newDoc) {
         d.update({}, { $inc: { hello: 4 } }, {}, function (err, nr) {
-          assert.isDefined(err);
-          assert.isUndefined(nr);
+          assert.isDefined(err)
+          assert.isUndefined(nr)
 
           d.find({}, function (err, docs) {
-            assert.deepEqual(docs, [ { _id: newDoc._id, hello: 'world' } ]);
+            assert.deepEqual(docs, [{ _id: newDoc._id, hello: 'world' }])
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('Cant change the _id of a document', function (done) {
       d.insert({ a: 2 }, function (err, newDoc) {
         d.update({ a: 2 }, { a: 2, _id: 'nope' }, {}, function (err) {
-          assert.isDefined(err);
+          assert.isDefined(err)
 
           d.find({}, function (err, docs) {
-            docs.length.should.equal(1);
-            Object.keys(docs[0]).length.should.equal(2);
-            docs[0].a.should.equal(2);
-            docs[0]._id.should.equal(newDoc._id);
+            docs.length.should.equal(1)
+            Object.keys(docs[0]).length.should.equal(2)
+            docs[0].a.should.equal(2)
+            docs[0]._id.should.equal(newDoc._id)
 
             d.update({ a: 2 }, { $set: { _id: 'nope' } }, {}, function (err) {
-              assert.isDefined(err);
+              assert.isDefined(err)
 
               d.find({}, function (err, docs) {
-                docs.length.should.equal(1);
-                Object.keys(docs[0]).length.should.equal(2);
-                docs[0].a.should.equal(2);
-                docs[0]._id.should.equal(newDoc._id);
+                docs.length.should.equal(1)
+                Object.keys(docs[0]).length.should.equal(2)
+                docs[0].a.should.equal(2)
+                docs[0]._id.should.equal(newDoc._id)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Non-multi updates are persistent', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
           d.update({ a: 2 }, { $set: { hello: 'changed' } }, {}, function (err) {
-            assert.isNull(err);
+            assert.isNull(err)
 
             d.find({}, function (err, docs) {
-              docs.sort(function (a, b) { return a.a - b.a; });
-              docs.length.should.equal(2);
-              _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
-              _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+              docs.sort(function (a, b) { return a.a - b.a })
+              docs.length.should.equal(2)
+              _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'world' }).should.equal(true)
+              _.isEqual(docs[1], { _id: doc2._id, a: 2, hello: 'changed' }).should.equal(true)
 
               // Even after a reload the database state hasn't changed
               d.loadDatabase(function (err) {
-                assert.isNull(err);
+                assert.isNull(err)
 
                 d.find({}, function (err, docs) {
-                  docs.sort(function (a, b) { return a.a - b.a; });
-                  docs.length.should.equal(2);
-                  _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
-                  _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
+                  docs.sort(function (a, b) { return a.a - b.a })
+                  docs.length.should.equal(2)
+                  _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'world' }).should.equal(true)
+                  _.isEqual(docs[1], { _id: doc2._id, a: 2, hello: 'changed' }).should.equal(true)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Multi updates are persistent', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
-          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a: 5, hello: 'pluton' }, function (err, doc3) {
             d.update({ a: { $in: [1, 2] } }, { $set: { hello: 'changed' } }, { multi: true }, function (err) {
-              assert.isNull(err);
+              assert.isNull(err)
 
               d.find({}, function (err, docs) {
-                docs.sort(function (a, b) { return a.a - b.a; });
-                docs.length.should.equal(3);
-                _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'changed' }).should.equal(true);
-                _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
-                _.isEqual(docs[2], { _id: doc3._id, a:5, hello: 'pluton' }).should.equal(true);
+                docs.sort(function (a, b) { return a.a - b.a })
+                docs.length.should.equal(3)
+                _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'changed' }).should.equal(true)
+                _.isEqual(docs[1], { _id: doc2._id, a: 2, hello: 'changed' }).should.equal(true)
+                _.isEqual(docs[2], { _id: doc3._id, a: 5, hello: 'pluton' }).should.equal(true)
 
                 // Even after a reload the database state hasn't changed
                 d.loadDatabase(function (err) {
-                  assert.isNull(err);
+                  assert.isNull(err)
 
                   d.find({}, function (err, docs) {
-                    docs.sort(function (a, b) { return a.a - b.a; });
-                    docs.length.should.equal(3);
-                    _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'changed' }).should.equal(true);
-                    _.isEqual(docs[1], { _id: doc2._id, a:2, hello: 'changed' }).should.equal(true);
-                    _.isEqual(docs[2], { _id: doc3._id, a:5, hello: 'pluton' }).should.equal(true);
+                    docs.sort(function (a, b) { return a.a - b.a })
+                    docs.length.should.equal(3)
+                    _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'changed' }).should.equal(true)
+                    _.isEqual(docs[1], { _id: doc2._id, a: 2, hello: 'changed' }).should.equal(true)
+                    _.isEqual(docs[2], { _id: doc3._id, a: 5, hello: 'pluton' }).should.equal(true)
 
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                    done()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can update without the options arg (will use defaults then)', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
-          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a: 5, hello: 'pluton' }, function (err, doc3) {
             d.update({ a: 2 }, { $inc: { a: 10 } }, function (err, nr) {
-              assert.isNull(err);
-              nr.should.equal(1);
+              assert.isNull(err)
+              nr.should.equal(1)
               d.find({}, function (err, docs) {
-                var d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
-                  , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
-                  , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
-                  ;
+                const d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                const d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+                const d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
 
-                d1.a.should.equal(1);
-                d2.a.should.equal(12);
-                d3.a.should.equal(5);
+                d1.a.should.equal(1)
+                d2.a.should.equal(12)
+                d3.a.should.equal(5)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('If a multi update fails on one document, previous updates should be rolled back', function (done) {
-      d.ensureIndex({ fieldName: 'a' });
+      d.ensureIndex({ fieldName: 'a' })
       d.insert({ a: 4 }, function (err, doc1) {
         d.insert({ a: 5 }, function (err, doc2) {
           d.insert({ a: 'abc' }, function (err, doc3) {
             // With this query, candidates are always returned in the order 4, 5, 'abc' so it's always the last one which fails
             d.update({ a: { $in: [4, 5, 'abc'] } }, { $inc: { a: 10 } }, { multi: true }, function (err) {
-              assert.isDefined(err);
+              assert.isDefined(err)
 
               // No index modified
               _.each(d.indexes, function (index) {
-                var docs = index.getAll()
-                  , d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
-                  , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
-                  , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
-                  ;
+                const docs = index.getAll()
+                const d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                const d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
+                const d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
 
                 // All changes rolled back, including those that didn't trigger an error
-                d1.a.should.equal(4);
-                d2.a.should.equal(5);
-                d3.a.should.equal('abc');
-              });
+                d1.a.should.equal(4)
+                d2.a.should.equal(5)
+                d3.a.should.equal('abc')
+              })
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
     it('If an index constraint is violated by an update, all changes should be rolled back', function (done) {
-      d.ensureIndex({ fieldName: 'a', unique: true });
+      d.ensureIndex({ fieldName: 'a', unique: true })
       d.insert({ a: 4 }, function (err, doc1) {
         d.insert({ a: 5 }, function (err, doc2) {
           // With this query, candidates are always returned in the order 4, 5, 'abc' so it's always the last one which fails
-           d.update({ a: { $in: [4, 5, 'abc'] } }, { $set: { a: 10 } }, { multi: true }, function (err) {
-            assert.isDefined(err);
+          d.update({ a: { $in: [4, 5, 'abc'] } }, { $set: { a: 10 } }, { multi: true }, function (err) {
+            assert.isDefined(err)
 
             // Check that no index was modified
             _.each(d.indexes, function (index) {
-              var docs = index.getAll()
-              , d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
-              , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
-              ;
+              const docs = index.getAll()
+              const d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+              const d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
 
-              d1.a.should.equal(4);
-              d2.a.should.equal(5);
-            });
+              d1.a.should.equal(4)
+              d2.a.should.equal(5)
+            })
 
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
-    it("If options.returnUpdatedDocs is true, return all matched docs", function (done) {
+    it('If options.returnUpdatedDocs is true, return all matched docs', function (done) {
       d.insert([{ a: 4 }, { a: 5 }, { a: 6 }], function (err, docs) {
-        docs.length.should.equal(3);
+        docs.length.should.equal(3)
 
-        d.update({ a: 7 }, { $set: { u: 1 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
-          num.should.equal(0);
-          updatedDocs.length.should.equal(0);
+        d.update({ a: 7 }, { $set: { u: 1 } }, {
+          multi: true,
+          returnUpdatedDocs: true
+        }, function (err, num, updatedDocs) {
+          num.should.equal(0)
+          updatedDocs.length.should.equal(0)
 
-          d.update({ a: 5 }, { $set: { u: 2 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
-            num.should.equal(1);
-            updatedDocs.length.should.equal(1);
-            updatedDocs[0].a.should.equal(5);
-            updatedDocs[0].u.should.equal(2);
+          d.update({ a: 5 }, { $set: { u: 2 } }, {
+            multi: true,
+            returnUpdatedDocs: true
+          }, function (err, num, updatedDocs) {
+            num.should.equal(1)
+            updatedDocs.length.should.equal(1)
+            updatedDocs[0].a.should.equal(5)
+            updatedDocs[0].u.should.equal(2)
 
-            d.update({ a: { $in: [4, 6] } }, { $set: { u: 3 } }, { multi: true, returnUpdatedDocs: true }, function (err, num, updatedDocs) {
-              num.should.equal(2);
-              updatedDocs.length.should.equal(2);
-              updatedDocs[0].u.should.equal(3);
-              updatedDocs[1].u.should.equal(3);
+            d.update({ a: { $in: [4, 6] } }, { $set: { u: 3 } }, {
+              multi: true,
+              returnUpdatedDocs: true
+            }, function (err, num, updatedDocs) {
+              num.should.equal(2)
+              updatedDocs.length.should.equal(2)
+              updatedDocs[0].u.should.equal(3)
+              updatedDocs[1].u.should.equal(3)
               if (updatedDocs[0].a === 4) {
-                updatedDocs[0].a.should.equal(4);
-                updatedDocs[1].a.should.equal(6);
+                updatedDocs[0].a.should.equal(4)
+                updatedDocs[1].a.should.equal(6)
               } else {
-                updatedDocs[0].a.should.equal(6);
-                updatedDocs[1].a.should.equal(4);
+                updatedDocs[0].a.should.equal(6)
+                updatedDocs[1].a.should.equal(4)
               }
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
-    it("createdAt property is unchanged and updatedAt correct after an update, even a complete document replacement", function (done) {
-      var d2 = new Datastore({ inMemoryOnly: true, timestampData: true });
-      d2.insert({ a: 1 });
+    it('createdAt property is unchanged and updatedAt correct after an update, even a complete document replacement', function (done) {
+      const d2 = new Datastore({ inMemoryOnly: true, timestampData: true })
+      d2.insert({ a: 1 })
       d2.findOne({ a: 1 }, function (err, doc) {
-        var createdAt = doc.createdAt.getTime();
+        const createdAt = doc.createdAt.getTime()
 
         // Modifying update
         setTimeout(function () {
-          d2.update({ a: 1 }, { $set: { b: 2 } }, {});
+          d2.update({ a: 1 }, { $set: { b: 2 } }, {})
           d2.findOne({ a: 1 }, function (err, doc) {
-            doc.createdAt.getTime().should.equal(createdAt);
-            assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5);
+            doc.createdAt.getTime().should.equal(createdAt)
+            assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5)
 
             // Complete replacement
             setTimeout(function () {
-              d2.update({ a: 1 }, { c: 3 }, {});
+              d2.update({ a: 1 }, { c: 3 }, {})
               d2.findOne({ c: 3 }, function (err, doc) {
-                doc.createdAt.getTime().should.equal(createdAt);
-                assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5);
+                doc.createdAt.getTime().should.equal(createdAt)
+                assert.isBelow(Date.now() - doc.updatedAt.getTime(), 5)
 
-                done();
-              });
-            }, 20);
-          });
-        }, 20);
-      });
-    });
+                done()
+              })
+            }, 20)
+          })
+        }, 20)
+      })
+    })
 
+    describe('Callback signature', function () {
 
-    describe("Callback signature", function () {
-
-      it("Regular update, multi false", function (done) {
-        d.insert({ a: 1 });
-        d.insert({ a: 2 });
+      it('Regular update, multi false', function (done) {
+        d.insert({ a: 1 })
+        d.insert({ a: 2 })
 
         // returnUpdatedDocs set to false
         d.update({ a: 1 }, { $set: { b: 20 } }, {}, function (err, numAffected, affectedDocuments, upsert) {
-          assert.isNull(err);
-          numAffected.should.equal(1);
-          assert.isUndefined(affectedDocuments);
-          assert.isUndefined(upsert);
+          assert.isNull(err)
+          numAffected.should.equal(1)
+          assert.isUndefined(affectedDocuments)
+          assert.isUndefined(upsert)
 
           // returnUpdatedDocs set to true
           d.update({ a: 1 }, { $set: { b: 21 } }, { returnUpdatedDocs: true }, function (err, numAffected, affectedDocuments, upsert) {
-            assert.isNull(err);
-            numAffected.should.equal(1);
-            affectedDocuments.a.should.equal(1);
-            affectedDocuments.b.should.equal(21);
-            assert.isUndefined(upsert);
+            assert.isNull(err)
+            numAffected.should.equal(1)
+            affectedDocuments.a.should.equal(1)
+            affectedDocuments.b.should.equal(21)
+            assert.isUndefined(upsert)
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
-      it("Regular update, multi true", function (done) {
-        d.insert({ a: 1 });
-        d.insert({ a: 2 });
+      it('Regular update, multi true', function (done) {
+        d.insert({ a: 1 })
+        d.insert({ a: 2 })
 
         // returnUpdatedDocs set to false
         d.update({}, { $set: { b: 20 } }, { multi: true }, function (err, numAffected, affectedDocuments, upsert) {
-          assert.isNull(err);
-          numAffected.should.equal(2);
-          assert.isUndefined(affectedDocuments);
-          assert.isUndefined(upsert);
+          assert.isNull(err)
+          numAffected.should.equal(2)
+          assert.isUndefined(affectedDocuments)
+          assert.isUndefined(upsert)
 
           // returnUpdatedDocs set to true
-          d.update({}, { $set: { b: 21 } }, { multi: true, returnUpdatedDocs: true }, function (err, numAffected, affectedDocuments, upsert) {
-            assert.isNull(err);
-            numAffected.should.equal(2);
-            affectedDocuments.length.should.equal(2);
-            assert.isUndefined(upsert);
+          d.update({}, { $set: { b: 21 } }, {
+            multi: true,
+            returnUpdatedDocs: true
+          }, function (err, numAffected, affectedDocuments, upsert) {
+            assert.isNull(err)
+            numAffected.should.equal(2)
+            affectedDocuments.length.should.equal(2)
+            assert.isUndefined(upsert)
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
-      it("Upsert", function (done) {
-        d.insert({ a: 1 });
-        d.insert({ a: 2 });
+      it('Upsert', function (done) {
+        d.insert({ a: 1 })
+        d.insert({ a: 2 })
 
         // Upsert flag not set
         d.update({ a: 3 }, { $set: { b: 20 } }, {}, function (err, numAffected, affectedDocuments, upsert) {
-          assert.isNull(err);
-          numAffected.should.equal(0);
-          assert.isUndefined(affectedDocuments);
-          assert.isUndefined(upsert);
+          assert.isNull(err)
+          numAffected.should.equal(0)
+          assert.isUndefined(affectedDocuments)
+          assert.isUndefined(upsert)
 
           // Upsert flag set
           d.update({ a: 3 }, { $set: { b: 21 } }, { upsert: true }, function (err, numAffected, affectedDocuments, upsert) {
-            assert.isNull(err);
-            numAffected.should.equal(1);
-            affectedDocuments.a.should.equal(3);
-            affectedDocuments.b.should.equal(21);
-            upsert.should.equal(true);
+            assert.isNull(err)
+            numAffected.should.equal(1)
+            affectedDocuments.a.should.equal(3)
+            affectedDocuments.b.should.equal(21)
+            upsert.should.equal(true)
 
             d.find({}, function (err, docs) {
-              docs.length.should.equal(3);
-              done();
-            });
-          });
-        });
-      });
+              docs.length.should.equal(3)
+              done()
+            })
+          })
+        })
+      })
 
+    })   // ==== End of 'Update - Callback signature' ==== //
 
-    });   // ==== End of 'Update - Callback signature' ==== //
-
-  });   // ==== End of 'Update' ==== //
-
+  })   // ==== End of 'Update' ==== //
 
   describe('Remove', function () {
 
     it('Can remove multiple documents', function (done) {
-      var id1, id2, id3;
+      let id1
+      let id2
+      let id3
 
       // Test DB status
       function testPostUpdateState (cb) {
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
+          docs.length.should.equal(1)
 
-          Object.keys(docs[0]).length.should.equal(2);
-          docs[0]._id.should.equal(id1);
-          docs[0].somedata.should.equal('ok');
+          Object.keys(docs[0]).length.should.equal(2)
+          docs[0]._id.should.equal(id1)
+          docs[0].somedata.should.equal('ok')
 
-          return cb();
-        });
+          return cb()
+        })
       }
 
       // Actually launch the test
       async.waterfall([
-      function (cb) {
-        d.insert({ somedata: 'ok' }, function (err, doc1) {
-          id1 = doc1._id;
-          d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
-            id2 = doc2._id;
-            d.insert({ somedata: 'again' }, function (err, doc3) {
-              id3 = doc3._id;
-              return cb(err);
-            });
-          });
-        });
-      }
-      , function (cb) {   // Test with query that doesn't match anything
-        d.remove({ somedata: 'again' }, { multi: true }, function (err, n) {
-          assert.isNull(err);
-          n.should.equal(2);
-          return cb();
-        });
-      }
-      , async.apply(testPostUpdateState)
-      , function (cb) {
-        d.loadDatabase(function (err) { return cb(err); });
-      }
-      , async.apply(testPostUpdateState)
-      ], done);
-    });
+        function (cb) {
+          d.insert({ somedata: 'ok' }, function (err, doc1) {
+            id1 = doc1._id
+            d.insert({ somedata: 'again', plus: 'additional data' }, function (err, doc2) {
+              id2 = doc2._id
+              d.insert({ somedata: 'again' }, function (err, doc3) {
+                id3 = doc3._id
+                return cb(err)
+              })
+            })
+          })
+        }
+        , function (cb) {   // Test with query that doesn't match anything
+          d.remove({ somedata: 'again' }, { multi: true }, function (err, n) {
+            assert.isNull(err)
+            n.should.equal(2)
+            return cb()
+          })
+        }
+        , async.apply(testPostUpdateState)
+        , function (cb) {
+          d.loadDatabase(function (err) { return cb(err) })
+        }
+        , async.apply(testPostUpdateState)
+      ], done)
+    })
 
     // This tests concurrency issues
     it('Remove can be called multiple times in parallel and everything that needs to be removed will be', function (done) {
@@ -1783,1094 +1802,1075 @@ describe('Database', function () {
         d.insert({ planet: 'Mars' }, function () {
           d.insert({ planet: 'Saturn' }, function () {
             d.find({}, function (err, docs) {
-              docs.length.should.equal(3);
+              docs.length.should.equal(3)
 
               // Remove two docs simultaneously
-              var toRemove = ['Mars', 'Saturn'];
-              async.each(toRemove, function(planet, cb) {
-                d.remove({ planet: planet }, function (err) { return cb(err); });
+              const toRemove = ['Mars', 'Saturn']
+              async.each(toRemove, function (planet, cb) {
+                d.remove({ planet: planet }, function (err) { return cb(err) })
               }, function (err) {
                 d.find({}, function (err, docs) {
-                  docs.length.should.equal(1);
+                  docs.length.should.equal(1)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Returns an error if the query is not well formed', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.remove({ $or: { hello: 'world' } }, {}, function (err, nr, upsert) {
-          assert.isDefined(err);
-          assert.isUndefined(nr);
-          assert.isUndefined(upsert);
+          assert.isDefined(err)
+          assert.isUndefined(nr)
+          assert.isUndefined(upsert)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('Non-multi removes are persistent', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
-          d.insert({ a:3, hello: 'moto' }, function (err, doc3) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a: 3, hello: 'moto' }, function (err, doc3) {
             d.remove({ a: 2 }, {}, function (err) {
-              assert.isNull(err);
+              assert.isNull(err)
 
               d.find({}, function (err, docs) {
-                docs.sort(function (a, b) { return a.a - b.a; });
-                docs.length.should.equal(2);
-                _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
-                _.isEqual(docs[1], { _id: doc3._id, a:3, hello: 'moto' }).should.equal(true);
+                docs.sort(function (a, b) { return a.a - b.a })
+                docs.length.should.equal(2)
+                _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'world' }).should.equal(true)
+                _.isEqual(docs[1], { _id: doc3._id, a: 3, hello: 'moto' }).should.equal(true)
 
                 // Even after a reload the database state hasn't changed
                 d.loadDatabase(function (err) {
-                  assert.isNull(err);
+                  assert.isNull(err)
 
                   d.find({}, function (err, docs) {
-                    docs.sort(function (a, b) { return a.a - b.a; });
-                    docs.length.should.equal(2);
-                    _.isEqual(docs[0], { _id: doc1._id, a:1, hello: 'world' }).should.equal(true);
-                    _.isEqual(docs[1], { _id: doc3._id, a:3, hello: 'moto' }).should.equal(true);
+                    docs.sort(function (a, b) { return a.a - b.a })
+                    docs.length.should.equal(2)
+                    _.isEqual(docs[0], { _id: doc1._id, a: 1, hello: 'world' }).should.equal(true)
+                    _.isEqual(docs[1], { _id: doc3._id, a: 3, hello: 'moto' }).should.equal(true)
 
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                    done()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Multi removes are persistent', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
-          d.insert({ a:3, hello: 'moto' }, function (err, doc3) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a: 3, hello: 'moto' }, function (err, doc3) {
             d.remove({ a: { $in: [1, 3] } }, { multi: true }, function (err) {
-              assert.isNull(err);
+              assert.isNull(err)
 
               d.find({}, function (err, docs) {
-                docs.length.should.equal(1);
-                _.isEqual(docs[0], { _id: doc2._id, a:2, hello: 'earth' }).should.equal(true);
+                docs.length.should.equal(1)
+                _.isEqual(docs[0], { _id: doc2._id, a: 2, hello: 'earth' }).should.equal(true)
 
                 // Even after a reload the database state hasn't changed
                 d.loadDatabase(function (err) {
-                  assert.isNull(err);
+                  assert.isNull(err)
 
                   d.find({}, function (err, docs) {
-                    docs.length.should.equal(1);
-                    _.isEqual(docs[0], { _id: doc2._id, a:2, hello: 'earth' }).should.equal(true);
+                    docs.length.should.equal(1)
+                    _.isEqual(docs[0], { _id: doc2._id, a: 2, hello: 'earth' }).should.equal(true)
 
-                    done();
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                    done()
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('Can remove without the options arg (will use defaults then)', function (done) {
-      d.insert({ a:1, hello: 'world' }, function (err, doc1) {
-        d.insert({ a:2, hello: 'earth' }, function (err, doc2) {
-          d.insert({ a:5, hello: 'pluton' }, function (err, doc3) {
+      d.insert({ a: 1, hello: 'world' }, function (err, doc1) {
+        d.insert({ a: 2, hello: 'earth' }, function (err, doc2) {
+          d.insert({ a: 5, hello: 'pluton' }, function (err, doc3) {
             d.remove({ a: 2 }, function (err, nr) {
-              assert.isNull(err);
-              nr.should.equal(1);
+              assert.isNull(err)
+              nr.should.equal(1)
               d.find({}, function (err, docs) {
-                var d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
+                const d1 = _.find(docs, function (doc) { return doc._id === doc1._id })
                   , d2 = _.find(docs, function (doc) { return doc._id === doc2._id })
                   , d3 = _.find(docs, function (doc) { return doc._id === doc3._id })
-                  ;
 
-                d1.a.should.equal(1);
-                assert.isUndefined(d2);
-                d3.a.should.equal(5);
+                d1.a.should.equal(1)
+                assert.isUndefined(d2)
+                d3.a.should.equal(5)
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
-  });   // ==== End of 'Remove' ==== //
-
+  })   // ==== End of 'Remove' ==== //
 
   describe('Using indexes', function () {
 
     describe('ensureIndex and index initialization in database loading', function () {
 
       it('ensureIndex can be called right after a loadDatabase and be initialized and filled correctly', function (done) {
-        var now = new Date()
-          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-                      model.serialize({ _id: "bbb", z: "2", hello: 'world' }) + '\n' +
-                      model.serialize({ _id: "ccc", z: "3", nested: { today: now } })
-          ;
+        const now = new Date()
+        const rawData = model.serialize({ _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+          model.serialize({ _id: 'bbb', z: '2', hello: 'world' }) + '\n' +
+          model.serialize({ _id: 'ccc', z: '3', nested: { today: now } })
 
-        d.getAllData().length.should.equal(0);
+        d.getAllData().length.should.equal(0)
 
         fs.writeFile(testDb, rawData, 'utf8', function () {
           d.loadDatabase(function () {
-            d.getAllData().length.should.equal(3);
+            d.getAllData().length.should.equal(3)
 
-            assert.deepEqual(Object.keys(d.indexes), ['_id']);
+            assert.deepEqual(Object.keys(d.indexes), ['_id'])
 
-            d.ensureIndex({ fieldName: 'z' });
-            d.indexes.z.fieldName.should.equal('z');
-            d.indexes.z.unique.should.equal(false);
-            d.indexes.z.sparse.should.equal(false);
-            d.indexes.z.tree.getNumberOfKeys().should.equal(3);
-            d.indexes.z.tree.search('1')[0].should.equal(d.getAllData()[0]);
-            d.indexes.z.tree.search('2')[0].should.equal(d.getAllData()[1]);
-            d.indexes.z.tree.search('3')[0].should.equal(d.getAllData()[2]);
+            d.ensureIndex({ fieldName: 'z' })
+            d.indexes.z.fieldName.should.equal('z')
+            d.indexes.z.unique.should.equal(false)
+            d.indexes.z.sparse.should.equal(false)
+            d.indexes.z.tree.getNumberOfKeys().should.equal(3)
+            d.indexes.z.tree.search('1')[0].should.equal(d.getAllData()[0])
+            d.indexes.z.tree.search('2')[0].should.equal(d.getAllData()[1])
+            d.indexes.z.tree.search('3')[0].should.equal(d.getAllData()[2])
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('ensureIndex can be called twice on the same field, the second call will ahve no effect', function (done) {
-        Object.keys(d.indexes).length.should.equal(1);
-        Object.keys(d.indexes)[0].should.equal("_id");
+        Object.keys(d.indexes).length.should.equal(1)
+        Object.keys(d.indexes)[0].should.equal('_id')
 
-        d.insert({ planet: "Earth" }, function () {
-          d.insert({ planet: "Mars" }, function () {
+        d.insert({ planet: 'Earth' }, function () {
+          d.insert({ planet: 'Mars' }, function () {
             d.find({}, function (err, docs) {
-              docs.length.should.equal(2);
+              docs.length.should.equal(2)
 
-              d.ensureIndex({ fieldName: "planet" }, function (err) {
-                assert.isNull(err);
-                Object.keys(d.indexes).length.should.equal(2);
-                Object.keys(d.indexes)[0].should.equal("_id");
-                Object.keys(d.indexes)[1].should.equal("planet");
+              d.ensureIndex({ fieldName: 'planet' }, function (err) {
+                assert.isNull(err)
+                Object.keys(d.indexes).length.should.equal(2)
+                Object.keys(d.indexes)[0].should.equal('_id')
+                Object.keys(d.indexes)[1].should.equal('planet')
 
-                d.indexes.planet.getAll().length.should.equal(2);
+                d.indexes.planet.getAll().length.should.equal(2)
 
                 // This second call has no effect, documents don't get inserted twice in the index
-                d.ensureIndex({ fieldName: "planet" }, function (err) {
-                  assert.isNull(err);
-                  Object.keys(d.indexes).length.should.equal(2);
-                  Object.keys(d.indexes)[0].should.equal("_id");
-                  Object.keys(d.indexes)[1].should.equal("planet");
+                d.ensureIndex({ fieldName: 'planet' }, function (err) {
+                  assert.isNull(err)
+                  Object.keys(d.indexes).length.should.equal(2)
+                  Object.keys(d.indexes)[0].should.equal('_id')
+                  Object.keys(d.indexes)[1].should.equal('planet')
 
-                  d.indexes.planet.getAll().length.should.equal(2);
+                  d.indexes.planet.getAll().length.should.equal(2)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('ensureIndex can be called after the data set was modified and the index still be correct', function (done) {
-        var rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-                      model.serialize({ _id: "bbb", z: "2", hello: 'world' })
-          ;
+        const rawData = model.serialize({ _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+          model.serialize({ _id: 'bbb', z: '2', hello: 'world' })
 
-        d.getAllData().length.should.equal(0);
+        d.getAllData().length.should.equal(0)
 
         fs.writeFile(testDb, rawData, 'utf8', function () {
           d.loadDatabase(function () {
-            d.getAllData().length.should.equal(2);
+            d.getAllData().length.should.equal(2)
 
-            assert.deepEqual(Object.keys(d.indexes), ['_id']);
+            assert.deepEqual(Object.keys(d.indexes), ['_id'])
 
-            d.insert({ z: "12", yes: 'yes' }, function (err, newDoc1) {
-              d.insert({ z: "14", nope: 'nope' }, function (err, newDoc2) {
-                d.remove({ z: "2" }, {}, function () {
-                  d.update({ z: "1" }, { $set: { 'yes': 'yep' } }, {}, function () {
-                    assert.deepEqual(Object.keys(d.indexes), ['_id']);
+            d.insert({ z: '12', yes: 'yes' }, function (err, newDoc1) {
+              d.insert({ z: '14', nope: 'nope' }, function (err, newDoc2) {
+                d.remove({ z: '2' }, {}, function () {
+                  d.update({ z: '1' }, { $set: { 'yes': 'yep' } }, {}, function () {
+                    assert.deepEqual(Object.keys(d.indexes), ['_id'])
 
-                    d.ensureIndex({ fieldName: 'z' });
-                    d.indexes.z.fieldName.should.equal('z');
-                    d.indexes.z.unique.should.equal(false);
-                    d.indexes.z.sparse.should.equal(false);
-                    d.indexes.z.tree.getNumberOfKeys().should.equal(3);
+                    d.ensureIndex({ fieldName: 'z' })
+                    d.indexes.z.fieldName.should.equal('z')
+                    d.indexes.z.unique.should.equal(false)
+                    d.indexes.z.sparse.should.equal(false)
+                    d.indexes.z.tree.getNumberOfKeys().should.equal(3)
 
                     // The pointers in the _id and z indexes are the same
-                    d.indexes.z.tree.search('1')[0].should.equal(d.indexes._id.getMatching('aaa')[0]);
-                    d.indexes.z.tree.search('12')[0].should.equal(d.indexes._id.getMatching(newDoc1._id)[0]);
-                    d.indexes.z.tree.search('14')[0].should.equal(d.indexes._id.getMatching(newDoc2._id)[0]);
+                    d.indexes.z.tree.search('1')[0].should.equal(d.indexes._id.getMatching('aaa')[0])
+                    d.indexes.z.tree.search('12')[0].should.equal(d.indexes._id.getMatching(newDoc1._id)[0])
+                    d.indexes.z.tree.search('14')[0].should.equal(d.indexes._id.getMatching(newDoc2._id)[0])
 
                     // The data in the z index is correct
                     d.find({}, function (err, docs) {
-                      var doc0 = _.find(docs, function (doc) { return doc._id === 'aaa'; })
-                        , doc1 = _.find(docs, function (doc) { return doc._id === newDoc1._id; })
-                        , doc2 = _.find(docs, function (doc) { return doc._id === newDoc2._id; })
-                        ;
+                      const doc0 = _.find(docs, function (doc) { return doc._id === 'aaa' })
+                      const doc1 = _.find(docs, function (doc) { return doc._id === newDoc1._id })
+                      const doc2 = _.find(docs, function (doc) { return doc._id === newDoc2._id })
 
-                      docs.length.should.equal(3);
+                      docs.length.should.equal(3)
 
-                      assert.deepEqual(doc0, { _id: "aaa", z: "1", a: 2, ages: [1, 5, 12], yes: 'yep' });
-                      assert.deepEqual(doc1, { _id: newDoc1._id, z: "12", yes: 'yes' });
-                      assert.deepEqual(doc2, { _id: newDoc2._id, z: "14", nope: 'nope' });
+                      assert.deepEqual(doc0, { _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12], yes: 'yep' })
+                      assert.deepEqual(doc1, { _id: newDoc1._id, z: '12', yes: 'yes' })
+                      assert.deepEqual(doc2, { _id: newDoc2._id, z: '14', nope: 'nope' })
 
-                      done();
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+                      done()
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('ensureIndex can be called before a loadDatabase and still be initialized and filled correctly', function (done) {
-        var now = new Date()
-          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-                      model.serialize({ _id: "bbb", z: "2", hello: 'world' }) + '\n' +
-                      model.serialize({ _id: "ccc", z: "3", nested: { today: now } })
-          ;
+        const now = new Date()
+          , rawData = model.serialize({ _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+          model.serialize({ _id: 'bbb', z: '2', hello: 'world' }) + '\n' +
+          model.serialize({ _id: 'ccc', z: '3', nested: { today: now } })
 
-        d.getAllData().length.should.equal(0);
+        d.getAllData().length.should.equal(0)
 
-        d.ensureIndex({ fieldName: 'z' });
-        d.indexes.z.fieldName.should.equal('z');
-        d.indexes.z.unique.should.equal(false);
-        d.indexes.z.sparse.should.equal(false);
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z' })
+        d.indexes.z.fieldName.should.equal('z')
+        d.indexes.z.unique.should.equal(false)
+        d.indexes.z.sparse.should.equal(false)
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         fs.writeFile(testDb, rawData, 'utf8', function () {
           d.loadDatabase(function () {
-            var doc1 = _.find(d.getAllData(), function (doc) { return doc.z === "1"; })
-              , doc2 = _.find(d.getAllData(), function (doc) { return doc.z === "2"; })
-              , doc3 = _.find(d.getAllData(), function (doc) { return doc.z === "3"; })
-              ;
+            const doc1 = _.find(d.getAllData(), function (doc) { return doc.z === '1' })
+            const doc2 = _.find(d.getAllData(), function (doc) { return doc.z === '2' })
+            const doc3 = _.find(d.getAllData(), function (doc) { return doc.z === '3' })
 
-            d.getAllData().length.should.equal(3);
+            d.getAllData().length.should.equal(3)
 
-            d.indexes.z.tree.getNumberOfKeys().should.equal(3);
-            d.indexes.z.tree.search('1')[0].should.equal(doc1);
-            d.indexes.z.tree.search('2')[0].should.equal(doc2);
-            d.indexes.z.tree.search('3')[0].should.equal(doc3);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(3)
+            d.indexes.z.tree.search('1')[0].should.equal(doc1)
+            d.indexes.z.tree.search('2')[0].should.equal(doc2)
+            d.indexes.z.tree.search('3')[0].should.equal(doc3)
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('Can initialize multiple indexes on a database load', function (done) {
-        var now = new Date()
-          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-                      model.serialize({ _id: "bbb", z: "2", a: 'world' }) + '\n' +
-                      model.serialize({ _id: "ccc", z: "3", a: { today: now } })
-          ;
+        const now = new Date()
+        const rawData = model.serialize({ _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+          model.serialize({ _id: 'bbb', z: '2', a: 'world' }) + '\n' +
+          model.serialize({ _id: 'ccc', z: '3', a: { today: now } })
 
-        d.getAllData().length.should.equal(0);
+        d.getAllData().length.should.equal(0)
         d.ensureIndex({ fieldName: 'z' }, function () {
           d.ensureIndex({ fieldName: 'a' }, function () {
-            d.indexes.a.tree.getNumberOfKeys().should.equal(0);
-            d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+            d.indexes.a.tree.getNumberOfKeys().should.equal(0)
+            d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
             fs.writeFile(testDb, rawData, 'utf8', function () {
               d.loadDatabase(function (err) {
-                var doc1 = _.find(d.getAllData(), function (doc) { return doc.z === "1"; })
-                  , doc2 = _.find(d.getAllData(), function (doc) { return doc.z === "2"; })
-                  , doc3 = _.find(d.getAllData(), function (doc) { return doc.z === "3"; })
-                  ;
+                const doc1 = _.find(d.getAllData(), function (doc) { return doc.z === '1' })
+                const doc2 = _.find(d.getAllData(), function (doc) { return doc.z === '2' })
+                const doc3 = _.find(d.getAllData(), function (doc) { return doc.z === '3' })
 
-                assert.isNull(err);
-                d.getAllData().length.should.equal(3);
+                assert.isNull(err)
+                d.getAllData().length.should.equal(3)
 
-                d.indexes.z.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.z.tree.search('1')[0].should.equal(doc1);
-                d.indexes.z.tree.search('2')[0].should.equal(doc2);
-                d.indexes.z.tree.search('3')[0].should.equal(doc3);
+                d.indexes.z.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.z.tree.search('1')[0].should.equal(doc1)
+                d.indexes.z.tree.search('2')[0].should.equal(doc2)
+                d.indexes.z.tree.search('3')[0].should.equal(doc3)
 
-                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.a.tree.search(2)[0].should.equal(doc1);
-                d.indexes.a.tree.search('world')[0].should.equal(doc2);
-                d.indexes.a.tree.search({ today: now })[0].should.equal(doc3);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.a.tree.search(2)[0].should.equal(doc1)
+                d.indexes.a.tree.search('world')[0].should.equal(doc2)
+                d.indexes.a.tree.search({ today: now })[0].should.equal(doc3)
 
-                done();
-              });
-            });
-          });
+                done()
+              })
+            })
+          })
 
-        });
-      });
+        })
+      })
 
       it('If a unique constraint is not respected, database loading will not work and no data will be inserted', function (done) {
-        var now = new Date()
-          , rawData = model.serialize({ _id: "aaa", z: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-                      model.serialize({ _id: "bbb", z: "2", a: 'world' }) + '\n' +
-                      model.serialize({ _id: "ccc", z: "1", a: { today: now } })
-          ;
+        const now = new Date()
+        const rawData = model.serialize({ _id: 'aaa', z: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+          model.serialize({ _id: 'bbb', z: '2', a: 'world' }) + '\n' +
+          model.serialize({ _id: 'ccc', z: '1', a: { today: now } })
 
-        d.getAllData().length.should.equal(0);
+        d.getAllData().length.should.equal(0)
 
-        d.ensureIndex({ fieldName: 'z', unique: true });
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z', unique: true })
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         fs.writeFile(testDb, rawData, 'utf8', function () {
           d.loadDatabase(function (err) {
-            err.errorType.should.equal('uniqueViolated');
-            err.key.should.equal("1");
-            d.getAllData().length.should.equal(0);
-            d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+            err.errorType.should.equal('uniqueViolated')
+            err.key.should.equal('1')
+            d.getAllData().length.should.equal(0)
+            d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('If a unique constraint is not respected, ensureIndex will return an error and not create an index', function (done) {
         d.insert({ a: 1, b: 4 }, function () {
           d.insert({ a: 2, b: 45 }, function () {
             d.insert({ a: 1, b: 3 }, function () {
               d.ensureIndex({ fieldName: 'b' }, function (err) {
-                assert.isNull(err);
+                assert.isNull(err)
 
                 d.ensureIndex({ fieldName: 'a', unique: true }, function (err) {
-                  err.errorType.should.equal('uniqueViolated');
-                  assert.deepEqual(Object.keys(d.indexes), ['_id', 'b']);
+                  err.errorType.should.equal('uniqueViolated')
+                  assert.deepEqual(Object.keys(d.indexes), ['_id', 'b'])
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('Can remove an index', function (done) {
         d.ensureIndex({ fieldName: 'e' }, function (err) {
-          assert.isNull(err);
+          assert.isNull(err)
 
-          Object.keys(d.indexes).length.should.equal(2);
-          assert.isNotNull(d.indexes.e);
+          Object.keys(d.indexes).length.should.equal(2)
+          assert.isNotNull(d.indexes.e)
 
-          d.removeIndex("e", function (err) {
-            assert.isNull(err);
-            Object.keys(d.indexes).length.should.equal(1);
-            assert.isUndefined(d.indexes.e);
+          d.removeIndex('e', function (err) {
+            assert.isNull(err)
+            Object.keys(d.indexes).length.should.equal(1)
+            assert.isUndefined(d.indexes.e)
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
-    });   // ==== End of 'ensureIndex and index initialization in database loading' ==== //
-
+    })   // ==== End of 'ensureIndex and index initialization in database loading' ==== //
 
     describe('Indexing newly inserted documents', function () {
 
       it('Newly inserted documents are indexed', function (done) {
-        d.ensureIndex({ fieldName: 'z' });
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z' })
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
-          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc])
 
           d.insert({ a: 5, z: 'nope' }, function (err, newDoc) {
-            d.indexes.z.tree.getNumberOfKeys().should.equal(2);
-            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc]);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(2)
+            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc])
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('If multiple indexes are defined, the document is inserted in all of them', function (done) {
-        d.ensureIndex({ fieldName: 'z' });
-        d.ensureIndex({ fieldName: 'ya' });
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z' })
+        d.ensureIndex({ fieldName: 'ya' })
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         d.insert({ a: 2, z: 'yes', ya: 'indeed' }, function (err, newDoc) {
-          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-          d.indexes.ya.tree.getNumberOfKeys().should.equal(1);
-          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
-          assert.deepEqual(d.indexes.ya.getMatching('indeed'), [newDoc]);
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+          d.indexes.ya.tree.getNumberOfKeys().should.equal(1)
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc])
+          assert.deepEqual(d.indexes.ya.getMatching('indeed'), [newDoc])
 
           d.insert({ a: 5, z: 'nope', ya: 'sure' }, function (err, newDoc2) {
-            d.indexes.z.tree.getNumberOfKeys().should.equal(2);
-            d.indexes.ya.tree.getNumberOfKeys().should.equal(2);
-            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc2]);
-            assert.deepEqual(d.indexes.ya.getMatching('sure'), [newDoc2]);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(2)
+            d.indexes.ya.tree.getNumberOfKeys().should.equal(2)
+            assert.deepEqual(d.indexes.z.getMatching('nope'), [newDoc2])
+            assert.deepEqual(d.indexes.ya.getMatching('sure'), [newDoc2])
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('Can insert two docs at the same key for a non unique index', function (done) {
-        d.ensureIndex({ fieldName: 'z' });
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z' })
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
-          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc])
 
           d.insert({ a: 5, z: 'yes' }, function (err, newDoc2) {
-            d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc, newDoc2]);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc, newDoc2])
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('If the index has a unique constraint, an error is thrown if it is violated and the data is not modified', function (done) {
-        d.ensureIndex({ fieldName: 'z', unique: true });
-        d.indexes.z.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'z', unique: true })
+        d.indexes.z.tree.getNumberOfKeys().should.equal(0)
 
         d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
-          d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+          d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+          assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc])
 
           d.insert({ a: 5, z: 'yes' }, function (err) {
-            err.errorType.should.equal('uniqueViolated');
-            err.key.should.equal('yes');
+            err.errorType.should.equal('uniqueViolated')
+            err.key.should.equal('yes')
 
             // Index didn't change
-            d.indexes.z.tree.getNumberOfKeys().should.equal(1);
-            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc]);
+            d.indexes.z.tree.getNumberOfKeys().should.equal(1)
+            assert.deepEqual(d.indexes.z.getMatching('yes'), [newDoc])
 
             // Data didn't change
-            assert.deepEqual(d.getAllData(), [newDoc]);
+            assert.deepEqual(d.getAllData(), [newDoc])
             d.loadDatabase(function () {
-              d.getAllData().length.should.equal(1);
-              assert.deepEqual(d.getAllData()[0], newDoc);
+              d.getAllData().length.should.equal(1)
+              assert.deepEqual(d.getAllData()[0], newDoc)
 
-              done();
-            });
-          });
-        });
-      });
+              done()
+            })
+          })
+        })
+      })
 
       it('If an index has a unique constraint, other indexes cannot be modified when it raises an error', function (done) {
-        d.ensureIndex({ fieldName: 'nonu1' });
-        d.ensureIndex({ fieldName: 'uni', unique: true });
-        d.ensureIndex({ fieldName: 'nonu2' });
+        d.ensureIndex({ fieldName: 'nonu1' })
+        d.ensureIndex({ fieldName: 'uni', unique: true })
+        d.ensureIndex({ fieldName: 'nonu2' })
 
         d.insert({ nonu1: 'yes', nonu2: 'yes2', uni: 'willfail' }, function (err, newDoc) {
-          assert.isNull(err);
-          d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1);
-          d.indexes.uni.tree.getNumberOfKeys().should.equal(1);
-          d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1);
+          assert.isNull(err)
+          d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1)
+          d.indexes.uni.tree.getNumberOfKeys().should.equal(1)
+          d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1)
 
           d.insert({ nonu1: 'no', nonu2: 'no2', uni: 'willfail' }, function (err) {
-            err.errorType.should.equal('uniqueViolated');
+            err.errorType.should.equal('uniqueViolated')
 
             // No index was modified
-            d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1);
-            d.indexes.uni.tree.getNumberOfKeys().should.equal(1);
-            d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1);
+            d.indexes.nonu1.tree.getNumberOfKeys().should.equal(1)
+            d.indexes.uni.tree.getNumberOfKeys().should.equal(1)
+            d.indexes.nonu2.tree.getNumberOfKeys().should.equal(1)
 
-            assert.deepEqual(d.indexes.nonu1.getMatching('yes'), [newDoc]);
-            assert.deepEqual(d.indexes.uni.getMatching('willfail'), [newDoc]);
-            assert.deepEqual(d.indexes.nonu2.getMatching('yes2'), [newDoc]);
+            assert.deepEqual(d.indexes.nonu1.getMatching('yes'), [newDoc])
+            assert.deepEqual(d.indexes.uni.getMatching('willfail'), [newDoc])
+            assert.deepEqual(d.indexes.nonu2.getMatching('yes2'), [newDoc])
 
-            done();
-          });
-        });
-      });
+            done()
+          })
+        })
+      })
 
       it('Unique indexes prevent you from inserting two docs where the field is undefined except if theyre sparse', function (done) {
-        d.ensureIndex({ fieldName: 'zzz', unique: true });
-        d.indexes.zzz.tree.getNumberOfKeys().should.equal(0);
+        d.ensureIndex({ fieldName: 'zzz', unique: true })
+        d.indexes.zzz.tree.getNumberOfKeys().should.equal(0)
 
         d.insert({ a: 2, z: 'yes' }, function (err, newDoc) {
-          d.indexes.zzz.tree.getNumberOfKeys().should.equal(1);
-          assert.deepEqual(d.indexes.zzz.getMatching(undefined), [newDoc]);
+          d.indexes.zzz.tree.getNumberOfKeys().should.equal(1)
+          assert.deepEqual(d.indexes.zzz.getMatching(undefined), [newDoc])
 
           d.insert({ a: 5, z: 'other' }, function (err) {
-            err.errorType.should.equal('uniqueViolated');
-            assert.isUndefined(err.key);
+            err.errorType.should.equal('uniqueViolated')
+            assert.isUndefined(err.key)
 
-            d.ensureIndex({ fieldName: 'yyy', unique: true, sparse: true });
+            d.ensureIndex({ fieldName: 'yyy', unique: true, sparse: true })
 
             d.insert({ a: 5, z: 'other', zzz: 'set' }, function (err) {
-              assert.isNull(err);
-              d.indexes.yyy.getAll().length.should.equal(0);   // Nothing indexed
-              d.indexes.zzz.getAll().length.should.equal(2);
+              assert.isNull(err)
+              d.indexes.yyy.getAll().length.should.equal(0)   // Nothing indexed
+              d.indexes.zzz.getAll().length.should.equal(2)
 
-              done();
-            });
-          });
-        });
-      });
+              done()
+            })
+          })
+        })
+      })
 
       it('Insertion still works as before with indexing', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
-        d.ensureIndex({ fieldName: 'b' });
+        d.ensureIndex({ fieldName: 'a' })
+        d.ensureIndex({ fieldName: 'b' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, doc2) {
             d.find({}, function (err, docs) {
-              assert.deepEqual(doc1, _.find(docs, function (d) { return d._id === doc1._id; }));
-              assert.deepEqual(doc2, _.find(docs, function (d) { return d._id === doc2._id; }));
+              assert.deepEqual(doc1, _.find(docs, function (d) { return d._id === doc1._id }))
+              assert.deepEqual(doc2, _.find(docs, function (d) { return d._id === doc2._id }))
 
-              done();
-            });
-          });
-        });
-      });
+              done()
+            })
+          })
+        })
+      })
 
       it('All indexes point to the same data as the main index on _id', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'a' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, doc2) {
             d.find({}, function (err, docs) {
-              docs.length.should.equal(2);
-              d.getAllData().length.should.equal(2);
+              docs.length.should.equal(2)
+              d.getAllData().length.should.equal(2)
 
-              d.indexes._id.getMatching(doc1._id).length.should.equal(1);
-              d.indexes.a.getMatching(1).length.should.equal(1);
-              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0]);
+              d.indexes._id.getMatching(doc1._id).length.should.equal(1)
+              d.indexes.a.getMatching(1).length.should.equal(1)
+              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0])
 
-              d.indexes._id.getMatching(doc2._id).length.should.equal(1);
-              d.indexes.a.getMatching(2).length.should.equal(1);
-              d.indexes._id.getMatching(doc2._id)[0].should.equal(d.indexes.a.getMatching(2)[0]);
+              d.indexes._id.getMatching(doc2._id).length.should.equal(1)
+              d.indexes.a.getMatching(2).length.should.equal(1)
+              d.indexes._id.getMatching(doc2._id)[0].should.equal(d.indexes.a.getMatching(2)[0])
 
-              done();
-            });
-          });
-        });
-      });
+              done()
+            })
+          })
+        })
+      })
 
       it('If a unique constraint is violated, no index is changed, including the main one', function (done) {
-        d.ensureIndex({ fieldName: 'a', unique: true });
+        d.ensureIndex({ fieldName: 'a', unique: true })
 
         d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
           d.insert({ a: 1, b: 'si' }, function (err) {
-            assert.isDefined(err);
+            assert.isDefined(err)
 
             d.find({}, function (err, docs) {
-              docs.length.should.equal(1);
-              d.getAllData().length.should.equal(1);
+              docs.length.should.equal(1)
+              d.getAllData().length.should.equal(1)
 
-              d.indexes._id.getMatching(doc1._id).length.should.equal(1);
-              d.indexes.a.getMatching(1).length.should.equal(1);
-              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0]);
+              d.indexes._id.getMatching(doc1._id).length.should.equal(1)
+              d.indexes.a.getMatching(1).length.should.equal(1)
+              d.indexes._id.getMatching(doc1._id)[0].should.equal(d.indexes.a.getMatching(1)[0])
 
-              d.indexes.a.getMatching(2).length.should.equal(0);
+              d.indexes.a.getMatching(2).length.should.equal(0)
 
-              done();
-            });
-          });
-        });
-      });
+              done()
+            })
+          })
+        })
+      })
 
-    });   // ==== End of 'Indexing newly inserted documents' ==== //
+    })   // ==== End of 'Indexing newly inserted documents' ==== //
 
     describe('Updating indexes upon document update', function () {
 
       it('Updating docs still works as before with indexing', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'a' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, _doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, _doc2) {
             d.update({ a: 1 }, { $set: { a: 456, b: 'no' } }, {}, function (err, nr) {
-              var data = d.getAllData()
-                , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
-                , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
-                ;
+              const data = d.getAllData()
+              const doc1 = _.find(data, function (doc) { return doc._id === _doc1._id })
+              const doc2 = _.find(data, function (doc) { return doc._id === _doc2._id })
 
-              assert.isNull(err);
-              nr.should.equal(1);
+              assert.isNull(err)
+              nr.should.equal(1)
 
-              data.length.should.equal(2);
-              assert.deepEqual(doc1, { a: 456, b: 'no', _id: _doc1._id });
-              assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id });
+              data.length.should.equal(2)
+              assert.deepEqual(doc1, { a: 456, b: 'no', _id: _doc1._id })
+              assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id })
 
               d.update({}, { $inc: { a: 10 }, $set: { b: 'same' } }, { multi: true }, function (err, nr) {
-                var data = d.getAllData()
-                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
-                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
-                  ;
+                const data = d.getAllData()
+                const doc1 = _.find(data, function (doc) { return doc._id === _doc1._id })
+                const doc2 = _.find(data, function (doc) { return doc._id === _doc2._id })
 
-                assert.isNull(err);
-                nr.should.equal(2);
+                assert.isNull(err)
+                nr.should.equal(2)
 
-                data.length.should.equal(2);
-                assert.deepEqual(doc1, { a: 466, b: 'same', _id: _doc1._id });
-                assert.deepEqual(doc2, { a: 12, b: 'same', _id: _doc2._id });
+                data.length.should.equal(2)
+                assert.deepEqual(doc1, { a: 466, b: 'same', _id: _doc1._id })
+                assert.deepEqual(doc2, { a: 12, b: 'same', _id: _doc2._id })
 
-                done();
-              });
-            });
-          });
-        });
-      });
+                done()
+              })
+            })
+          })
+        })
+      })
 
       it('Indexes get updated when a document (or multiple documents) is updated', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
-        d.ensureIndex({ fieldName: 'b' });
+        d.ensureIndex({ fieldName: 'a' })
+        d.ensureIndex({ fieldName: 'b' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, doc2) {
             // Simple update
             d.update({ a: 1 }, { $set: { a: 456, b: 'no' } }, {}, function (err, nr) {
-              assert.isNull(err);
-              nr.should.equal(1);
+              assert.isNull(err)
+              nr.should.equal(1)
 
-              d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-              d.indexes.a.getMatching(456)[0]._id.should.equal(doc1._id);
-              d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id);
+              d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+              d.indexes.a.getMatching(456)[0]._id.should.equal(doc1._id)
+              d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id)
 
-              d.indexes.b.tree.getNumberOfKeys().should.equal(2);
-              d.indexes.b.getMatching('no')[0]._id.should.equal(doc1._id);
-              d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id);
+              d.indexes.b.tree.getNumberOfKeys().should.equal(2)
+              d.indexes.b.getMatching('no')[0]._id.should.equal(doc1._id)
+              d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id)
 
               // The same pointers are shared between all indexes
-              d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-              d.indexes.b.tree.getNumberOfKeys().should.equal(2);
-              d.indexes._id.tree.getNumberOfKeys().should.equal(2);
-              d.indexes.a.getMatching(456)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
-              d.indexes.b.getMatching('no')[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
-              d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
-              d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+              d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+              d.indexes.b.tree.getNumberOfKeys().should.equal(2)
+              d.indexes._id.tree.getNumberOfKeys().should.equal(2)
+              d.indexes.a.getMatching(456)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0])
+              d.indexes.b.getMatching('no')[0].should.equal(d.indexes._id.getMatching(doc1._id)[0])
+              d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0])
+              d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0])
 
               // Multi update
               d.update({}, { $inc: { a: 10 }, $set: { b: 'same' } }, { multi: true }, function (err, nr) {
-                assert.isNull(err);
-                nr.should.equal(2);
+                assert.isNull(err)
+                nr.should.equal(2)
 
-                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.a.getMatching(466)[0]._id.should.equal(doc1._id);
-                d.indexes.a.getMatching(12)[0]._id.should.equal(doc2._id);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.a.getMatching(466)[0]._id.should.equal(doc1._id)
+                d.indexes.a.getMatching(12)[0]._id.should.equal(doc2._id)
 
-                d.indexes.b.tree.getNumberOfKeys().should.equal(1);
-                d.indexes.b.getMatching('same').length.should.equal(2);
-                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc1._id);
-                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc2._id);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(1)
+                d.indexes.b.getMatching('same').length.should.equal(2)
+                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc1._id)
+                _.pluck(d.indexes.b.getMatching('same'), '_id').should.contain(doc2._id)
 
                 // The same pointers are shared between all indexes
-                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.b.tree.getNumberOfKeys().should.equal(1);
-                d.indexes.b.getAll().length.should.equal(2);
-                d.indexes._id.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.a.getMatching(466)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0]);
-                d.indexes.a.getMatching(12)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.b.tree.getNumberOfKeys().should.equal(1)
+                d.indexes.b.getAll().length.should.equal(2)
+                d.indexes._id.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.a.getMatching(466)[0].should.equal(d.indexes._id.getMatching(doc1._id)[0])
+                d.indexes.a.getMatching(12)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0])
                 // Can't test the pointers in b as their order is randomized, but it is the same as with a
 
-                done();
-              });
-            });
-          });
-        });
-      });
+                done()
+              })
+            })
+          })
+        })
+      })
 
       it('If a simple update violates a contraint, all changes are rolled back and an error is thrown', function (done) {
-        d.ensureIndex({ fieldName: 'a', unique: true });
-        d.ensureIndex({ fieldName: 'b', unique: true });
-        d.ensureIndex({ fieldName: 'c', unique: true });
+        d.ensureIndex({ fieldName: 'a', unique: true })
+        d.ensureIndex({ fieldName: 'b', unique: true })
+        d.ensureIndex({ fieldName: 'c', unique: true })
 
         d.insert({ a: 1, b: 10, c: 100 }, function (err, _doc1) {
           d.insert({ a: 2, b: 20, c: 200 }, function (err, _doc2) {
             d.insert({ a: 3, b: 30, c: 300 }, function (err, _doc3) {
               // Will conflict with doc3
               d.update({ a: 2 }, { $inc: { a: 10, c: 1000 }, $set: { b: 30 } }, {}, function (err) {
-                var data = d.getAllData()
-                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
-                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
-                  , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
-                  ;
+                const data = d.getAllData()
+                const doc1 = _.find(data, function (doc) { return doc._id === _doc1._id })
+                const doc2 = _.find(data, function (doc) { return doc._id === _doc2._id })
+                const doc3 = _.find(data, function (doc) { return doc._id === _doc3._id })
 
-                err.errorType.should.equal('uniqueViolated');
+                err.errorType.should.equal('uniqueViolated')
 
                 // Data left unchanged
-                data.length.should.equal(3);
-                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id });
-                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id });
-                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id });
+                data.length.should.equal(3)
+                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id })
+                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id })
+                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id })
 
                 // All indexes left unchanged and pointing to the same docs
-                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.a.getMatching(1)[0].should.equal(doc1);
-                d.indexes.a.getMatching(2)[0].should.equal(doc2);
-                d.indexes.a.getMatching(3)[0].should.equal(doc3);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.a.getMatching(1)[0].should.equal(doc1)
+                d.indexes.a.getMatching(2)[0].should.equal(doc2)
+                d.indexes.a.getMatching(3)[0].should.equal(doc3)
 
-                d.indexes.b.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.b.getMatching(10)[0].should.equal(doc1);
-                d.indexes.b.getMatching(20)[0].should.equal(doc2);
-                d.indexes.b.getMatching(30)[0].should.equal(doc3);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.b.getMatching(10)[0].should.equal(doc1)
+                d.indexes.b.getMatching(20)[0].should.equal(doc2)
+                d.indexes.b.getMatching(30)[0].should.equal(doc3)
 
-                d.indexes.c.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.c.getMatching(100)[0].should.equal(doc1);
-                d.indexes.c.getMatching(200)[0].should.equal(doc2);
-                d.indexes.c.getMatching(300)[0].should.equal(doc3);
+                d.indexes.c.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.c.getMatching(100)[0].should.equal(doc1)
+                d.indexes.c.getMatching(200)[0].should.equal(doc2)
+                d.indexes.c.getMatching(300)[0].should.equal(doc3)
 
-                done();
-              });
-            });
-          });
-        });
-      });
+                done()
+              })
+            })
+          })
+        })
+      })
 
       it('If a multi update violates a contraint, all changes are rolled back and an error is thrown', function (done) {
-        d.ensureIndex({ fieldName: 'a', unique: true });
-        d.ensureIndex({ fieldName: 'b', unique: true });
-        d.ensureIndex({ fieldName: 'c', unique: true });
+        d.ensureIndex({ fieldName: 'a', unique: true })
+        d.ensureIndex({ fieldName: 'b', unique: true })
+        d.ensureIndex({ fieldName: 'c', unique: true })
 
         d.insert({ a: 1, b: 10, c: 100 }, function (err, _doc1) {
           d.insert({ a: 2, b: 20, c: 200 }, function (err, _doc2) {
             d.insert({ a: 3, b: 30, c: 300 }, function (err, _doc3) {
               // Will conflict with doc3
-              d.update({ a: { $in: [1, 2] } }, { $inc: { a: 10, c: 1000 }, $set: { b: 30 } }, { multi: true }, function (err) {
-                var data = d.getAllData()
-                  , doc1 = _.find(data, function (doc) { return doc._id === _doc1._id; })
-                  , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
-                  , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
-                  ;
+              d.update({ a: { $in: [1, 2] } }, {
+                $inc: { a: 10, c: 1000 },
+                $set: { b: 30 }
+              }, { multi: true }, function (err) {
+                const data = d.getAllData()
+                const doc1 = _.find(data, function (doc) { return doc._id === _doc1._id })
+                const doc2 = _.find(data, function (doc) { return doc._id === _doc2._id })
+                const doc3 = _.find(data, function (doc) { return doc._id === _doc3._id })
 
-                err.errorType.should.equal('uniqueViolated');
+                err.errorType.should.equal('uniqueViolated')
 
                 // Data left unchanged
-                data.length.should.equal(3);
-                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id });
-                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id });
-                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id });
+                data.length.should.equal(3)
+                assert.deepEqual(doc1, { a: 1, b: 10, c: 100, _id: _doc1._id })
+                assert.deepEqual(doc2, { a: 2, b: 20, c: 200, _id: _doc2._id })
+                assert.deepEqual(doc3, { a: 3, b: 30, c: 300, _id: _doc3._id })
 
                 // All indexes left unchanged and pointing to the same docs
-                d.indexes.a.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.a.getMatching(1)[0].should.equal(doc1);
-                d.indexes.a.getMatching(2)[0].should.equal(doc2);
-                d.indexes.a.getMatching(3)[0].should.equal(doc3);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.a.getMatching(1)[0].should.equal(doc1)
+                d.indexes.a.getMatching(2)[0].should.equal(doc2)
+                d.indexes.a.getMatching(3)[0].should.equal(doc3)
 
-                d.indexes.b.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.b.getMatching(10)[0].should.equal(doc1);
-                d.indexes.b.getMatching(20)[0].should.equal(doc2);
-                d.indexes.b.getMatching(30)[0].should.equal(doc3);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.b.getMatching(10)[0].should.equal(doc1)
+                d.indexes.b.getMatching(20)[0].should.equal(doc2)
+                d.indexes.b.getMatching(30)[0].should.equal(doc3)
 
-                d.indexes.c.tree.getNumberOfKeys().should.equal(3);
-                d.indexes.c.getMatching(100)[0].should.equal(doc1);
-                d.indexes.c.getMatching(200)[0].should.equal(doc2);
-                d.indexes.c.getMatching(300)[0].should.equal(doc3);
+                d.indexes.c.tree.getNumberOfKeys().should.equal(3)
+                d.indexes.c.getMatching(100)[0].should.equal(doc1)
+                d.indexes.c.getMatching(200)[0].should.equal(doc2)
+                d.indexes.c.getMatching(300)[0].should.equal(doc3)
 
-                done();
-              });
-            });
-          });
-        });
-      });
+                done()
+              })
+            })
+          })
+        })
+      })
 
-    });   // ==== End of 'Updating indexes upon document update' ==== //
+    })   // ==== End of 'Updating indexes upon document update' ==== //
 
     describe('Updating indexes upon document remove', function () {
 
       it('Removing docs still works as before with indexing', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
+        d.ensureIndex({ fieldName: 'a' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, _doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, _doc2) {
             d.insert({ a: 3, b: 'coin' }, function (err, _doc3) {
               d.remove({ a: 1 }, {}, function (err, nr) {
-                var data = d.getAllData()
-                , doc2 = _.find(data, function (doc) { return doc._id === _doc2._id; })
-                , doc3 = _.find(data, function (doc) { return doc._id === _doc3._id; })
-                ;
+                const data = d.getAllData()
+                const doc2 = _.find(data, function (doc) { return doc._id === _doc2._id })
+                const doc3 = _.find(data, function (doc) { return doc._id === _doc3._id })
 
-                assert.isNull(err);
-                nr.should.equal(1);
+                assert.isNull(err)
+                nr.should.equal(1)
 
-                data.length.should.equal(2);
-                assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id });
-                assert.deepEqual(doc3, { a: 3, b: 'coin', _id: _doc3._id });
+                data.length.should.equal(2)
+                assert.deepEqual(doc2, { a: 2, b: 'si', _id: _doc2._id })
+                assert.deepEqual(doc3, { a: 3, b: 'coin', _id: _doc3._id })
 
                 d.remove({ a: { $in: [2, 3] } }, { multi: true }, function (err, nr) {
-                  var data = d.getAllData()
-                  ;
+                  const data = d.getAllData()
 
-                  assert.isNull(err);
-                  nr.should.equal(2);
-                  data.length.should.equal(0);
+                  assert.isNull(err)
+                  nr.should.equal(2)
+                  data.length.should.equal(0)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('Indexes get updated when a document (or multiple documents) is removed', function (done) {
-        d.ensureIndex({ fieldName: 'a' });
-        d.ensureIndex({ fieldName: 'b' });
+        d.ensureIndex({ fieldName: 'a' })
+        d.ensureIndex({ fieldName: 'b' })
 
         d.insert({ a: 1, b: 'hello' }, function (err, doc1) {
           d.insert({ a: 2, b: 'si' }, function (err, doc2) {
             d.insert({ a: 3, b: 'coin' }, function (err, doc3) {
               // Simple remove
               d.remove({ a: 1 }, {}, function (err, nr) {
-                assert.isNull(err);
-                nr.should.equal(1);
+                assert.isNull(err)
+                nr.should.equal(1)
 
-                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id);
-                d.indexes.a.getMatching(3)[0]._id.should.equal(doc3._id);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.a.getMatching(2)[0]._id.should.equal(doc2._id)
+                d.indexes.a.getMatching(3)[0]._id.should.equal(doc3._id)
 
-                d.indexes.b.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id);
-                d.indexes.b.getMatching('coin')[0]._id.should.equal(doc3._id);
+                d.indexes.b.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.b.getMatching('si')[0]._id.should.equal(doc2._id)
+                d.indexes.b.getMatching('coin')[0]._id.should.equal(doc3._id)
 
                 // The same pointers are shared between all indexes
-                d.indexes.a.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.b.tree.getNumberOfKeys().should.equal(2);
-                d.indexes._id.tree.getNumberOfKeys().should.equal(2);
-                d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
-                d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0]);
-                d.indexes.a.getMatching(3)[0].should.equal(d.indexes._id.getMatching(doc3._id)[0]);
-                d.indexes.b.getMatching('coin')[0].should.equal(d.indexes._id.getMatching(doc3._id)[0]);
+                d.indexes.a.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.b.tree.getNumberOfKeys().should.equal(2)
+                d.indexes._id.tree.getNumberOfKeys().should.equal(2)
+                d.indexes.a.getMatching(2)[0].should.equal(d.indexes._id.getMatching(doc2._id)[0])
+                d.indexes.b.getMatching('si')[0].should.equal(d.indexes._id.getMatching(doc2._id)[0])
+                d.indexes.a.getMatching(3)[0].should.equal(d.indexes._id.getMatching(doc3._id)[0])
+                d.indexes.b.getMatching('coin')[0].should.equal(d.indexes._id.getMatching(doc3._id)[0])
 
                 // Multi remove
                 d.remove({}, { multi: true }, function (err, nr) {
-                  assert.isNull(err);
-                  nr.should.equal(2);
+                  assert.isNull(err)
+                  nr.should.equal(2)
 
-                  d.indexes.a.tree.getNumberOfKeys().should.equal(0);
-                  d.indexes.b.tree.getNumberOfKeys().should.equal(0);
-                  d.indexes._id.tree.getNumberOfKeys().should.equal(0);
+                  d.indexes.a.tree.getNumberOfKeys().should.equal(0)
+                  d.indexes.b.tree.getNumberOfKeys().should.equal(0)
+                  d.indexes._id.tree.getNumberOfKeys().should.equal(0)
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
-    });   // ==== End of 'Updating indexes upon document remove' ==== //
-
+    })   // ==== End of 'Updating indexes upon document remove' ==== //
 
     describe('Persisting indexes', function () {
 
       it('Indexes are persisted to a separate file and recreated upon reload', function (done) {
-        var persDb = "workspace/persistIndexes.db"
-          , db
-          ;
+        const persDb = 'workspace/persistIndexes.db'
+        let db
 
-        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
-        db = new Datastore({ filename: persDb, autoload: true });
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8') }
+        db = new Datastore({ filename: persDb, autoload: true })
 
-        Object.keys(db.indexes).length.should.equal(1);
-        Object.keys(db.indexes)[0].should.equal("_id");
+        Object.keys(db.indexes).length.should.equal(1)
+        Object.keys(db.indexes)[0].should.equal('_id')
 
-        db.insert({ planet: "Earth" }, function (err) {
-          assert.isNull(err);
-          db.insert({ planet: "Mars" }, function (err) {
-            assert.isNull(err);
+        db.insert({ planet: 'Earth' }, function (err) {
+          assert.isNull(err)
+          db.insert({ planet: 'Mars' }, function (err) {
+            assert.isNull(err)
 
-            db.ensureIndex({ fieldName: "planet" }, function (err) {
-              Object.keys(db.indexes).length.should.equal(2);
-              Object.keys(db.indexes)[0].should.equal("_id");
-              Object.keys(db.indexes)[1].should.equal("planet");
-              db.indexes._id.getAll().length.should.equal(2);
-              db.indexes.planet.getAll().length.should.equal(2);
-              db.indexes.planet.fieldName.should.equal("planet");
+            db.ensureIndex({ fieldName: 'planet' }, function (err) {
+              Object.keys(db.indexes).length.should.equal(2)
+              Object.keys(db.indexes)[0].should.equal('_id')
+              Object.keys(db.indexes)[1].should.equal('planet')
+              db.indexes._id.getAll().length.should.equal(2)
+              db.indexes.planet.getAll().length.should.equal(2)
+              db.indexes.planet.fieldName.should.equal('planet')
 
               // After a reload the indexes are recreated
-              db = new Datastore({ filename: persDb });
+              db = new Datastore({ filename: persDb })
               db.loadDatabase(function (err) {
-                assert.isNull(err);
-                Object.keys(db.indexes).length.should.equal(2);
-                Object.keys(db.indexes)[0].should.equal("_id");
-                Object.keys(db.indexes)[1].should.equal("planet");
-                db.indexes._id.getAll().length.should.equal(2);
-                db.indexes.planet.getAll().length.should.equal(2);
-                db.indexes.planet.fieldName.should.equal("planet");
+                assert.isNull(err)
+                Object.keys(db.indexes).length.should.equal(2)
+                Object.keys(db.indexes)[0].should.equal('_id')
+                Object.keys(db.indexes)[1].should.equal('planet')
+                db.indexes._id.getAll().length.should.equal(2)
+                db.indexes.planet.getAll().length.should.equal(2)
+                db.indexes.planet.fieldName.should.equal('planet')
 
                 // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
-                db = new Datastore({ filename: persDb });
+                db = new Datastore({ filename: persDb })
                 db.loadDatabase(function (err) {
-                  assert.isNull(err);
-                  Object.keys(db.indexes).length.should.equal(2);
-                  Object.keys(db.indexes)[0].should.equal("_id");
-                  Object.keys(db.indexes)[1].should.equal("planet");
-                  db.indexes._id.getAll().length.should.equal(2);
-                  db.indexes.planet.getAll().length.should.equal(2);
-                  db.indexes.planet.fieldName.should.equal("planet");
+                  assert.isNull(err)
+                  Object.keys(db.indexes).length.should.equal(2)
+                  Object.keys(db.indexes)[0].should.equal('_id')
+                  Object.keys(db.indexes)[1].should.equal('planet')
+                  db.indexes._id.getAll().length.should.equal(2)
+                  db.indexes.planet.getAll().length.should.equal(2)
+                  db.indexes.planet.fieldName.should.equal('planet')
 
-                  done();
-                });
-              });
-            });
-          });
-        });
-      });
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('Indexes are persisted with their options and recreated even if some db operation happen between loads', function (done) {
-        var persDb = "workspace/persistIndexes.db"
-          , db
-        ;
+        const persDb = 'workspace/persistIndexes.db'
+        let db
 
-        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
-        db = new Datastore({ filename: persDb, autoload: true });
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8') }
+        db = new Datastore({ filename: persDb, autoload: true })
 
-        Object.keys(db.indexes).length.should.equal(1);
-        Object.keys(db.indexes)[0].should.equal("_id");
+        Object.keys(db.indexes).length.should.equal(1)
+        Object.keys(db.indexes)[0].should.equal('_id')
 
-        db.insert({ planet: "Earth" }, function (err) {
-          assert.isNull(err);
-          db.insert({ planet: "Mars" }, function (err) {
-            assert.isNull(err);
+        db.insert({ planet: 'Earth' }, function (err) {
+          assert.isNull(err)
+          db.insert({ planet: 'Mars' }, function (err) {
+            assert.isNull(err)
 
-            db.ensureIndex({ fieldName: "planet", unique: true, sparse: false }, function (err) {
-              Object.keys(db.indexes).length.should.equal(2);
-              Object.keys(db.indexes)[0].should.equal("_id");
-              Object.keys(db.indexes)[1].should.equal("planet");
-              db.indexes._id.getAll().length.should.equal(2);
-              db.indexes.planet.getAll().length.should.equal(2);
-              db.indexes.planet.unique.should.equal(true);
-              db.indexes.planet.sparse.should.equal(false);
+            db.ensureIndex({ fieldName: 'planet', unique: true, sparse: false }, function (err) {
+              Object.keys(db.indexes).length.should.equal(2)
+              Object.keys(db.indexes)[0].should.equal('_id')
+              Object.keys(db.indexes)[1].should.equal('planet')
+              db.indexes._id.getAll().length.should.equal(2)
+              db.indexes.planet.getAll().length.should.equal(2)
+              db.indexes.planet.unique.should.equal(true)
+              db.indexes.planet.sparse.should.equal(false)
 
-              db.insert({ planet: "Jupiter" }, function (err) {
-                assert.isNull(err);
+              db.insert({ planet: 'Jupiter' }, function (err) {
+                assert.isNull(err)
 
                 // After a reload the indexes are recreated
-                db = new Datastore({ filename: persDb });
+                db = new Datastore({ filename: persDb })
                 db.loadDatabase(function (err) {
-                  assert.isNull(err);
-                  Object.keys(db.indexes).length.should.equal(2);
-                  Object.keys(db.indexes)[0].should.equal("_id");
-                  Object.keys(db.indexes)[1].should.equal("planet");
-                  db.indexes._id.getAll().length.should.equal(3);
-                  db.indexes.planet.getAll().length.should.equal(3);
-                  db.indexes.planet.unique.should.equal(true);
-                  db.indexes.planet.sparse.should.equal(false);
+                  assert.isNull(err)
+                  Object.keys(db.indexes).length.should.equal(2)
+                  Object.keys(db.indexes)[0].should.equal('_id')
+                  Object.keys(db.indexes)[1].should.equal('planet')
+                  db.indexes._id.getAll().length.should.equal(3)
+                  db.indexes.planet.getAll().length.should.equal(3)
+                  db.indexes.planet.unique.should.equal(true)
+                  db.indexes.planet.sparse.should.equal(false)
 
                   db.ensureIndex({ fieldName: 'bloup', unique: false, sparse: true }, function (err) {
-                    assert.isNull(err);
-                    Object.keys(db.indexes).length.should.equal(3);
-                    Object.keys(db.indexes)[0].should.equal("_id");
-                    Object.keys(db.indexes)[1].should.equal("planet");
-                    Object.keys(db.indexes)[2].should.equal("bloup");
-                    db.indexes._id.getAll().length.should.equal(3);
-                    db.indexes.planet.getAll().length.should.equal(3);
-                    db.indexes.bloup.getAll().length.should.equal(0);
-                    db.indexes.planet.unique.should.equal(true);
-                    db.indexes.planet.sparse.should.equal(false);
-                    db.indexes.bloup.unique.should.equal(false);
-                    db.indexes.bloup.sparse.should.equal(true);
+                    assert.isNull(err)
+                    Object.keys(db.indexes).length.should.equal(3)
+                    Object.keys(db.indexes)[0].should.equal('_id')
+                    Object.keys(db.indexes)[1].should.equal('planet')
+                    Object.keys(db.indexes)[2].should.equal('bloup')
+                    db.indexes._id.getAll().length.should.equal(3)
+                    db.indexes.planet.getAll().length.should.equal(3)
+                    db.indexes.bloup.getAll().length.should.equal(0)
+                    db.indexes.planet.unique.should.equal(true)
+                    db.indexes.planet.sparse.should.equal(false)
+                    db.indexes.bloup.unique.should.equal(false)
+                    db.indexes.bloup.sparse.should.equal(true)
 
                     // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
-                    db = new Datastore({ filename: persDb });
+                    db = new Datastore({ filename: persDb })
                     db.loadDatabase(function (err) {
-                      assert.isNull(err);
-                      Object.keys(db.indexes).length.should.equal(3);
-                      Object.keys(db.indexes)[0].should.equal("_id");
-                      Object.keys(db.indexes)[1].should.equal("planet");
-                      Object.keys(db.indexes)[2].should.equal("bloup");
-                      db.indexes._id.getAll().length.should.equal(3);
-                      db.indexes.planet.getAll().length.should.equal(3);
-                      db.indexes.bloup.getAll().length.should.equal(0);
-                      db.indexes.planet.unique.should.equal(true);
-                      db.indexes.planet.sparse.should.equal(false);
-                      db.indexes.bloup.unique.should.equal(false);
-                      db.indexes.bloup.sparse.should.equal(true);
+                      assert.isNull(err)
+                      Object.keys(db.indexes).length.should.equal(3)
+                      Object.keys(db.indexes)[0].should.equal('_id')
+                      Object.keys(db.indexes)[1].should.equal('planet')
+                      Object.keys(db.indexes)[2].should.equal('bloup')
+                      db.indexes._id.getAll().length.should.equal(3)
+                      db.indexes.planet.getAll().length.should.equal(3)
+                      db.indexes.bloup.getAll().length.should.equal(0)
+                      db.indexes.planet.unique.should.equal(true)
+                      db.indexes.planet.sparse.should.equal(false)
+                      db.indexes.bloup.unique.should.equal(false)
+                      db.indexes.bloup.sparse.should.equal(true)
 
-                      done();
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+                      done()
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
 
       it('Indexes can also be removed and the remove persisted', function (done) {
-        var persDb = "workspace/persistIndexes.db"
-          , db
-        ;
+        const persDb = 'workspace/persistIndexes.db'
+        let db
 
-        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8'); }
-        db = new Datastore({ filename: persDb, autoload: true });
+        if (fs.existsSync(persDb)) { fs.writeFileSync(persDb, '', 'utf8') }
+        db = new Datastore({ filename: persDb, autoload: true })
 
-        Object.keys(db.indexes).length.should.equal(1);
-        Object.keys(db.indexes)[0].should.equal("_id");
+        Object.keys(db.indexes).length.should.equal(1)
+        Object.keys(db.indexes)[0].should.equal('_id')
 
-        db.insert({ planet: "Earth" }, function (err) {
-          assert.isNull(err);
-          db.insert({ planet: "Mars" }, function (err) {
-            assert.isNull(err);
+        db.insert({ planet: 'Earth' }, function (err) {
+          assert.isNull(err)
+          db.insert({ planet: 'Mars' }, function (err) {
+            assert.isNull(err)
 
-            db.ensureIndex({ fieldName: "planet" }, function (err) {
-              assert.isNull(err);
-              db.ensureIndex({ fieldName: "another" }, function (err) {
-                assert.isNull(err);
-                Object.keys(db.indexes).length.should.equal(3);
-                Object.keys(db.indexes)[0].should.equal("_id");
-                Object.keys(db.indexes)[1].should.equal("planet");
-                Object.keys(db.indexes)[2].should.equal("another");
-                db.indexes._id.getAll().length.should.equal(2);
-                db.indexes.planet.getAll().length.should.equal(2);
-                db.indexes.planet.fieldName.should.equal("planet");
+            db.ensureIndex({ fieldName: 'planet' }, function (err) {
+              assert.isNull(err)
+              db.ensureIndex({ fieldName: 'another' }, function (err) {
+                assert.isNull(err)
+                Object.keys(db.indexes).length.should.equal(3)
+                Object.keys(db.indexes)[0].should.equal('_id')
+                Object.keys(db.indexes)[1].should.equal('planet')
+                Object.keys(db.indexes)[2].should.equal('another')
+                db.indexes._id.getAll().length.should.equal(2)
+                db.indexes.planet.getAll().length.should.equal(2)
+                db.indexes.planet.fieldName.should.equal('planet')
 
                 // After a reload the indexes are recreated
-                db = new Datastore({ filename: persDb });
+                db = new Datastore({ filename: persDb })
                 db.loadDatabase(function (err) {
-                  assert.isNull(err);
-                  Object.keys(db.indexes).length.should.equal(3);
-                  Object.keys(db.indexes)[0].should.equal("_id");
-                  Object.keys(db.indexes)[1].should.equal("planet");
-                  Object.keys(db.indexes)[2].should.equal("another");
-                  db.indexes._id.getAll().length.should.equal(2);
-                  db.indexes.planet.getAll().length.should.equal(2);
-                  db.indexes.planet.fieldName.should.equal("planet");
+                  assert.isNull(err)
+                  Object.keys(db.indexes).length.should.equal(3)
+                  Object.keys(db.indexes)[0].should.equal('_id')
+                  Object.keys(db.indexes)[1].should.equal('planet')
+                  Object.keys(db.indexes)[2].should.equal('another')
+                  db.indexes._id.getAll().length.should.equal(2)
+                  db.indexes.planet.getAll().length.should.equal(2)
+                  db.indexes.planet.fieldName.should.equal('planet')
 
                   // Index is removed
-                  db.removeIndex("planet", function (err) {
-                    assert.isNull(err);
-                    Object.keys(db.indexes).length.should.equal(2);
-                    Object.keys(db.indexes)[0].should.equal("_id");
-                    Object.keys(db.indexes)[1].should.equal("another");
-                    db.indexes._id.getAll().length.should.equal(2);
+                  db.removeIndex('planet', function (err) {
+                    assert.isNull(err)
+                    Object.keys(db.indexes).length.should.equal(2)
+                    Object.keys(db.indexes)[0].should.equal('_id')
+                    Object.keys(db.indexes)[1].should.equal('another')
+                    db.indexes._id.getAll().length.should.equal(2)
 
                     // After a reload indexes are preserved
-                    db = new Datastore({ filename: persDb });
+                    db = new Datastore({ filename: persDb })
                     db.loadDatabase(function (err) {
-                      assert.isNull(err);
-                      Object.keys(db.indexes).length.should.equal(2);
-                      Object.keys(db.indexes)[0].should.equal("_id");
-                      Object.keys(db.indexes)[1].should.equal("another");
-                      db.indexes._id.getAll().length.should.equal(2);
+                      assert.isNull(err)
+                      Object.keys(db.indexes).length.should.equal(2)
+                      Object.keys(db.indexes)[0].should.equal('_id')
+                      Object.keys(db.indexes)[1].should.equal('another')
+                      db.indexes._id.getAll().length.should.equal(2)
 
                       // After another reload the indexes are still there (i.e. they are preserved during autocompaction)
-                      db = new Datastore({ filename: persDb });
+                      db = new Datastore({ filename: persDb })
                       db.loadDatabase(function (err) {
-                        assert.isNull(err);
-                        Object.keys(db.indexes).length.should.equal(2);
-                        Object.keys(db.indexes)[0].should.equal("_id");
-                        Object.keys(db.indexes)[1].should.equal("another");
-                        db.indexes._id.getAll().length.should.equal(2);
+                        assert.isNull(err)
+                        Object.keys(db.indexes).length.should.equal(2)
+                        Object.keys(db.indexes)[0].should.equal('_id')
+                        Object.keys(db.indexes)[1].should.equal('another')
+                        db.indexes._id.getAll().length.should.equal(2)
 
-                        done();
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+                        done()
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
 
-    });   // ==== End of 'Persisting indexes' ====
+    })   // ==== End of 'Persisting indexes' ====
 
     it('Results of getMatching should never contain duplicates', function (done) {
-      d.ensureIndex({ fieldName: 'bad' });
+      d.ensureIndex({ fieldName: 'bad' })
       d.insert({ bad: ['a', 'b'] }, function () {
         d.getCandidates({ bad: { $in: ['a', 'b'] } }, function (err, res) {
-          res.length.should.equal(1);
-          done();
-        });
-      });
-    });
+          res.length.should.equal(1)
+          done()
+        })
+      })
+    })
 
-  });   // ==== End of 'Using indexes' ==== //
+  })   // ==== End of 'Using indexes' ==== //
 
-
-});
+})

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -1,0 +1,213 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , testDb = 'workspace/test.db'
+  , fs = require('fs')
+  , path = require('path')
+  , _ = require('underscore')
+  , async = require('async')
+  , model = require('../src/nedb/model')
+  , Datastore = require('../src/nedb/datastore')
+  , Persistence = require('../src/nedb/persistence')
+  ;
+
+
+// Test that even if a callback throws an exception, the next DB operations will still be executed
+// We prevent Mocha from catching the exception we throw on purpose by remembering all current handlers, remove them and register them back after test ends
+function testThrowInCallback (d, done) {
+  var currentUncaughtExceptionHandlers = process.listeners('uncaughtException');
+
+  process.removeAllListeners('uncaughtException');
+
+  process.on('uncaughtException', function (err) {
+    // Do nothing with the error which is only there to test we stay on track
+  });
+
+  d.find({}, function (err) {
+    process.nextTick(function () {
+      d.insert({ bar: 1 }, function (err) {
+        process.removeAllListeners('uncaughtException');
+        for (var i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
+          process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+        }
+
+        done();
+      });
+    });
+
+    throw new Error('Some error');
+  });
+}
+
+// Test that if the callback is falsy, the next DB operations will still be executed
+function testFalsyCallback (d, done) {
+  d.insert({ a: 1 }, null);
+  process.nextTick(function () {
+    d.update({ a: 1 }, { a: 2 }, {}, null);
+    process.nextTick(function () {
+      d.update({ a: 2 }, { a: 1 }, null);
+      process.nextTick(function () {
+        d.remove({ a: 2 }, {}, null);
+        process.nextTick(function () {
+          d.remove({ a: 2 }, null);
+          process.nextTick(function () {
+            d.find({}, done);
+          });
+        });
+      });
+    });
+  });
+}
+
+// Test that operations are executed in the right order
+// We prevent Mocha from catching the exception we throw on purpose by remembering all current handlers, remove them and register them back after test ends
+function testRightOrder (d, done) {
+  var currentUncaughtExceptionHandlers = process.listeners('uncaughtException');
+
+  process.removeAllListeners('uncaughtException');
+
+  process.on('uncaughtException', function (err) {
+    // Do nothing with the error which is only there to test we stay on track
+  });
+
+  d.find({}, function (err, docs) {
+    docs.length.should.equal(0);
+
+    d.insert({ a: 1 }, function () {
+      d.update({ a: 1 }, { a: 2 }, {}, function () {
+        d.find({}, function (err, docs) {
+          docs[0].a.should.equal(2);
+
+          process.nextTick(function () {
+            d.update({ a: 2 }, { a: 3 }, {}, function () {
+              d.find({}, function (err, docs) {
+                docs[0].a.should.equal(3);
+
+                process.removeAllListeners('uncaughtException');
+                for (var i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
+                  process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+                }
+
+                done();
+              });
+            });
+          });
+
+          throw new Error('Some error');
+        });
+      });
+    });
+  });
+}
+
+// Note:  The following test does not have any assertion because it
+// is meant to address the deprecation warning:
+// (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
+// see
+var testEventLoopStarvation = function(d, done){
+   var times = 1001;
+   var i = 0;
+   while ( i <times) {
+      i++;
+     d.find({"bogus": "search"}, function (err, docs) {
+     });
+   }
+   done();
+};
+
+// Test that operations are executed in the right order even with no callback
+function testExecutorWorksWithoutCallback (d, done) {
+  d.insert({ a: 1 });
+  d.insert({ a: 2 }, false);
+  d.find({}, function (err, docs) {
+    docs.length.should.equal(2);
+    done();
+  });
+}
+
+
+describe('Executor', function () {
+
+  describe('With persistent database', function () {
+    var d;
+
+    beforeEach(function (done) {
+      d = new Datastore({ filename: testDb });
+      d.filename.should.equal(testDb);
+      d.inMemoryOnly.should.equal(false);
+
+      async.waterfall([
+        function (cb) {
+          Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
+            fs.exists(testDb, function (exists) {
+              if (exists) {
+                fs.unlink(testDb, cb);
+              } else { return cb(); }
+            });
+          });
+        }
+      , function (cb) {
+          d.loadDatabase(function (err) {
+            assert.isNull(err);
+            d.getAllData().length.should.equal(0);
+            return cb();
+          });
+        }
+      ], done);
+    });
+
+    it('A throw in a callback doesnt prevent execution of next operations', function(done) {
+      testThrowInCallback(d, done);
+    });
+
+    it('A falsy callback doesnt prevent execution of next operations', function(done) {
+      testFalsyCallback(d, done);
+    });
+
+    it('Operations are executed in the right order', function(done) {
+      testRightOrder(d, done);
+    });
+
+    it('Does not starve event loop and raise warning when more than 1000 callbacks are in queue', function(done){
+      testEventLoopStarvation(d, done);
+    });
+
+    it('Works in the right order even with no supplied callback', function(done){
+      testExecutorWorksWithoutCallback(d, done);
+    });
+
+  });   // ==== End of 'With persistent database' ====
+
+
+  describe('With non persistent database', function () {
+    var d;
+
+    beforeEach(function (done) {
+      d = new Datastore({ inMemoryOnly: true });
+      d.inMemoryOnly.should.equal(true);
+
+      d.loadDatabase(function (err) {
+        assert.isNull(err);
+        d.getAllData().length.should.equal(0);
+        return done();
+      });
+    });
+
+    it('A throw in a callback doesnt prevent execution of next operations', function(done) {
+      testThrowInCallback(d, done);
+    });
+
+    it('A falsy callback doesnt prevent execution of next operations', function(done) {
+      testFalsyCallback(d, done);
+    });
+
+    it('Operations are executed in the right order', function(done) {
+      testRightOrder(d, done);
+    });
+
+    it('Works in the right order even with no supplied callback', function(done){
+      testExecutorWorksWithoutCallback(d, done);
+    });
+
+  });   // ==== End of 'With non persistent database' ====
+
+});

--- a/test/executor.test.js
+++ b/test/executor.test.js
@@ -1,213 +1,209 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , testDb = 'workspace/test.db'
-  , fs = require('fs')
-  , path = require('path')
-  , _ = require('underscore')
-  , async = require('async')
-  , model = require('../src/nedb/model')
-  , Datastore = require('../src/nedb/datastore')
-  , Persistence = require('../src/nedb/persistence')
-  ;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const testDb = 'workspace/test.db'
+const fs = require('fs')
+const path = require('path')
+const _ = require('underscore')
+const async = require('async')
+const model = require('../src/nedb/model')
+const Datastore = require('../src/nedb/datastore')
+const Persistence = require('../src/nedb/persistence')
 
 // Test that even if a callback throws an exception, the next DB operations will still be executed
 // We prevent Mocha from catching the exception we throw on purpose by remembering all current handlers, remove them and register them back after test ends
 function testThrowInCallback (d, done) {
-  var currentUncaughtExceptionHandlers = process.listeners('uncaughtException');
+  const currentUncaughtExceptionHandlers = process.listeners('uncaughtException')
 
-  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('uncaughtException')
 
   process.on('uncaughtException', function (err) {
     // Do nothing with the error which is only there to test we stay on track
-  });
+  })
 
   d.find({}, function (err) {
     process.nextTick(function () {
       d.insert({ bar: 1 }, function (err) {
-        process.removeAllListeners('uncaughtException');
-        for (var i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
-          process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+        process.removeAllListeners('uncaughtException')
+        for (let i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
+          process.on('uncaughtException', currentUncaughtExceptionHandlers[i])
         }
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-    throw new Error('Some error');
-  });
+    throw new Error('Some error')
+  })
 }
 
 // Test that if the callback is falsy, the next DB operations will still be executed
 function testFalsyCallback (d, done) {
-  d.insert({ a: 1 }, null);
+  d.insert({ a: 1 }, null)
   process.nextTick(function () {
-    d.update({ a: 1 }, { a: 2 }, {}, null);
+    d.update({ a: 1 }, { a: 2 }, {}, null)
     process.nextTick(function () {
-      d.update({ a: 2 }, { a: 1 }, null);
+      d.update({ a: 2 }, { a: 1 }, null)
       process.nextTick(function () {
-        d.remove({ a: 2 }, {}, null);
+        d.remove({ a: 2 }, {}, null)
         process.nextTick(function () {
-          d.remove({ a: 2 }, null);
+          d.remove({ a: 2 }, null)
           process.nextTick(function () {
-            d.find({}, done);
-          });
-        });
-      });
-    });
-  });
+            d.find({}, done)
+          })
+        })
+      })
+    })
+  })
 }
 
 // Test that operations are executed in the right order
 // We prevent Mocha from catching the exception we throw on purpose by remembering all current handlers, remove them and register them back after test ends
 function testRightOrder (d, done) {
-  var currentUncaughtExceptionHandlers = process.listeners('uncaughtException');
+  const currentUncaughtExceptionHandlers = process.listeners('uncaughtException')
 
-  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('uncaughtException')
 
   process.on('uncaughtException', function (err) {
     // Do nothing with the error which is only there to test we stay on track
-  });
+  })
 
   d.find({}, function (err, docs) {
-    docs.length.should.equal(0);
+    docs.length.should.equal(0)
 
     d.insert({ a: 1 }, function () {
       d.update({ a: 1 }, { a: 2 }, {}, function () {
         d.find({}, function (err, docs) {
-          docs[0].a.should.equal(2);
+          docs[0].a.should.equal(2)
 
           process.nextTick(function () {
             d.update({ a: 2 }, { a: 3 }, {}, function () {
               d.find({}, function (err, docs) {
-                docs[0].a.should.equal(3);
+                docs[0].a.should.equal(3)
 
-                process.removeAllListeners('uncaughtException');
-                for (var i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
-                  process.on('uncaughtException', currentUncaughtExceptionHandlers[i]);
+                process.removeAllListeners('uncaughtException')
+                for (let i = 0; i < currentUncaughtExceptionHandlers.length; i += 1) {
+                  process.on('uncaughtException', currentUncaughtExceptionHandlers[i])
                 }
 
-                done();
-              });
-            });
-          });
+                done()
+              })
+            })
+          })
 
-          throw new Error('Some error');
-        });
-      });
-    });
-  });
+          throw new Error('Some error')
+        })
+      })
+    })
+  })
 }
 
 // Note:  The following test does not have any assertion because it
 // is meant to address the deprecation warning:
 // (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 // see
-var testEventLoopStarvation = function(d, done){
-   var times = 1001;
-   var i = 0;
-   while ( i <times) {
-      i++;
-     d.find({"bogus": "search"}, function (err, docs) {
-     });
-   }
-   done();
-};
+const testEventLoopStarvation = function (d, done) {
+  const times = 1001
+  let i = 0
+  while (i < times) {
+    i++
+    d.find({ 'bogus': 'search' }, function (err, docs) {
+    })
+  }
+  done()
+}
 
 // Test that operations are executed in the right order even with no callback
 function testExecutorWorksWithoutCallback (d, done) {
-  d.insert({ a: 1 });
-  d.insert({ a: 2 }, false);
+  d.insert({ a: 1 })
+  d.insert({ a: 2 }, false)
   d.find({}, function (err, docs) {
-    docs.length.should.equal(2);
-    done();
-  });
+    docs.length.should.equal(2)
+    done()
+  })
 }
-
 
 describe('Executor', function () {
 
   describe('With persistent database', function () {
-    var d;
+    let d
 
     beforeEach(function (done) {
-      d = new Datastore({ filename: testDb });
-      d.filename.should.equal(testDb);
-      d.inMemoryOnly.should.equal(false);
+      d = new Datastore({ filename: testDb })
+      d.filename.should.equal(testDb)
+      d.inMemoryOnly.should.equal(false)
 
       async.waterfall([
         function (cb) {
           Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
             fs.exists(testDb, function (exists) {
               if (exists) {
-                fs.unlink(testDb, cb);
-              } else { return cb(); }
-            });
-          });
+                fs.unlink(testDb, cb)
+              } else { return cb() }
+            })
+          })
         }
-      , function (cb) {
+        , function (cb) {
           d.loadDatabase(function (err) {
-            assert.isNull(err);
-            d.getAllData().length.should.equal(0);
-            return cb();
-          });
+            assert.isNull(err)
+            d.getAllData().length.should.equal(0)
+            return cb()
+          })
         }
-      ], done);
-    });
+      ], done)
+    })
 
-    it('A throw in a callback doesnt prevent execution of next operations', function(done) {
-      testThrowInCallback(d, done);
-    });
+    it('A throw in a callback doesnt prevent execution of next operations', function (done) {
+      testThrowInCallback(d, done)
+    })
 
-    it('A falsy callback doesnt prevent execution of next operations', function(done) {
-      testFalsyCallback(d, done);
-    });
+    it('A falsy callback doesnt prevent execution of next operations', function (done) {
+      testFalsyCallback(d, done)
+    })
 
-    it('Operations are executed in the right order', function(done) {
-      testRightOrder(d, done);
-    });
+    it('Operations are executed in the right order', function (done) {
+      testRightOrder(d, done)
+    })
 
-    it('Does not starve event loop and raise warning when more than 1000 callbacks are in queue', function(done){
-      testEventLoopStarvation(d, done);
-    });
+    it('Does not starve event loop and raise warning when more than 1000 callbacks are in queue', function (done) {
+      testEventLoopStarvation(d, done)
+    })
 
-    it('Works in the right order even with no supplied callback', function(done){
-      testExecutorWorksWithoutCallback(d, done);
-    });
+    it('Works in the right order even with no supplied callback', function (done) {
+      testExecutorWorksWithoutCallback(d, done)
+    })
 
-  });   // ==== End of 'With persistent database' ====
-
+  })   // ==== End of 'With persistent database' ====
 
   describe('With non persistent database', function () {
-    var d;
+    let d
 
     beforeEach(function (done) {
-      d = new Datastore({ inMemoryOnly: true });
-      d.inMemoryOnly.should.equal(true);
+      d = new Datastore({ inMemoryOnly: true })
+      d.inMemoryOnly.should.equal(true)
 
       d.loadDatabase(function (err) {
-        assert.isNull(err);
-        d.getAllData().length.should.equal(0);
-        return done();
-      });
-    });
+        assert.isNull(err)
+        d.getAllData().length.should.equal(0)
+        return done()
+      })
+    })
 
-    it('A throw in a callback doesnt prevent execution of next operations', function(done) {
-      testThrowInCallback(d, done);
-    });
+    it('A throw in a callback doesnt prevent execution of next operations', function (done) {
+      testThrowInCallback(d, done)
+    })
 
-    it('A falsy callback doesnt prevent execution of next operations', function(done) {
-      testFalsyCallback(d, done);
-    });
+    it('A falsy callback doesnt prevent execution of next operations', function (done) {
+      testFalsyCallback(d, done)
+    })
 
-    it('Operations are executed in the right order', function(done) {
-      testRightOrder(d, done);
-    });
+    it('Operations are executed in the right order', function (done) {
+      testRightOrder(d, done)
+    })
 
-    it('Works in the right order even with no supplied callback', function(done){
-      testExecutorWorksWithoutCallback(d, done);
-    });
+    it('Works in the right order even with no supplied callback', function (done) {
+      testExecutorWorksWithoutCallback(d, done)
+    })
 
-  });   // ==== End of 'With non persistent database' ====
+  })   // ==== End of 'With non persistent database' ====
 
-});
+})

--- a/test/f.proxy.test.js
+++ b/test/f.proxy.test.js
@@ -2,7 +2,7 @@ const
     { expect } = require('chai'),
     Cursor = require('../src/Cursor'),
     Datastore = require('../src/Datastore'),
-    Persistence = require('nedb/lib/persistence')
+    Persistence = require('../src/nedb/persistence')
 
 describe('testing datastore proxy', () => {
     let datastore = Datastore.create('test.db')

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -1,773 +1,735 @@
-var Index = require('../src/nedb/indexes')
-  , customUtils = require('../src/nedb/customUtils')
-  , should = require('chai').should()
-  , assert = require('chai').assert
-  , _ = require('underscore')
-  , async = require('async')
-  , model = require('../src/nedb/model')
-  ;
+const Index = require('../src/nedb/indexes')
+const customUtils = require('../src/nedb/customUtils')
+const should = require('chai').should()
+const assert = require('chai').assert
+const _ = require('underscore')
+const async = require('async')
+const model = require('../src/nedb/model')
 
 describe('Indexes', function () {
 
   describe('Insertion', function () {
 
     it('Can insert pointers to documents in the index correctly when they have the field', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
       // The underlying BST now has 3 nodes which contain the docs where it's expected
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), [{ a: 5, tf: 'hello' }]);
-      assert.deepEqual(idx.tree.search('world'), [{ a: 8, tf: 'world' }]);
-      assert.deepEqual(idx.tree.search('bloup'), [{ a: 2, tf: 'bloup' }]);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [{ a: 5, tf: 'hello' }])
+      assert.deepEqual(idx.tree.search('world'), [{ a: 8, tf: 'world' }])
+      assert.deepEqual(idx.tree.search('bloup'), [{ a: 2, tf: 'bloup' }])
 
       // The nodes contain pointers to the actual documents
-      idx.tree.search('world')[0].should.equal(doc2);
-      idx.tree.search('bloup')[0].a = 42;
-      doc3.a.should.equal(42);
-    });
+      idx.tree.search('world')[0].should.equal(doc2)
+      idx.tree.search('bloup')[0].a = 42
+      doc3.a.should.equal(42)
+    })
 
     it('Inserting twice for the same fieldName in a unique index will result in an error thrown', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
 
-      idx.insert(doc1);
+      idx.insert(doc1)
       idx.tree.getNumberOfKeys().should.equal(1);
-      (function () { idx.insert(doc1); }).should.throw();
-    });
+      (function () { idx.insert(doc1) }).should.throw()
+    })
 
     it('Inserting twice for a fieldName the docs dont have with a unique index results in an error thrown', function () {
-      var idx = new Index({ fieldName: 'nope', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 5, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'nope', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 5, tf: 'world' }
 
-      idx.insert(doc1);
+      idx.insert(doc1)
       idx.tree.getNumberOfKeys().should.equal(1);
-      (function () { idx.insert(doc2); }).should.throw();
-    });
+      (function () { idx.insert(doc2) }).should.throw()
+    })
 
     it('Inserting twice for a fieldName the docs dont have with a unique and sparse index will not throw, since the docs will be non indexed', function () {
-      var idx = new Index({ fieldName: 'nope', unique: true, sparse: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 5, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'nope', unique: true, sparse: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 5, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.tree.getNumberOfKeys().should.equal(0);   // Docs are not indexed
-    });
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.tree.getNumberOfKeys().should.equal(0)   // Docs are not indexed
+    })
 
     it('Works with dot notation', function () {
-      var idx = new Index({ fieldName: 'tf.nested' })
-        , doc1 = { a: 5, tf: { nested: 'hello' } }
-        , doc2 = { a: 8, tf: { nested: 'world', additional: true } }
-        , doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
-        ;
+      const idx = new Index({ fieldName: 'tf.nested' })
+      const doc1 = { a: 5, tf: { nested: 'hello' } }
+      const doc2 = { a: 8, tf: { nested: 'world', additional: true } }
+      const doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
       // The underlying BST now has 3 nodes which contain the docs where it's expected
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), [doc1]);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
-      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [doc1])
+      assert.deepEqual(idx.tree.search('world'), [doc2])
+      assert.deepEqual(idx.tree.search('bloup'), [doc3])
 
       // The nodes contain pointers to the actual documents
-      idx.tree.search('bloup')[0].a = 42;
-      doc3.a.should.equal(42);
-    });
+      idx.tree.search('bloup')[0].a = 42
+      doc3.a.should.equal(42)
+    })
 
     it('Can insert an array of documents', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
-      idx.insert([doc1, doc2, doc3]);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), [doc1]);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
-      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
-    });
+      idx.insert([doc1, doc2, doc3])
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [doc1])
+      assert.deepEqual(idx.tree.search('world'), [doc2])
+      assert.deepEqual(idx.tree.search('bloup'), [doc3])
+    })
 
     it('When inserting an array of elements, if an error is thrown all inserts need to be rolled back', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc2b = { a: 84, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc2b = { a: 84, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
       try {
-        idx.insert([doc1, doc2, doc2b, doc3]);
+        idx.insert([doc1, doc2, doc2b, doc3])
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
+        e.errorType.should.equal('uniqueViolated')
       }
-      idx.tree.getNumberOfKeys().should.equal(0);
-      assert.deepEqual(idx.tree.search('hello'), []);
-      assert.deepEqual(idx.tree.search('world'), []);
-      assert.deepEqual(idx.tree.search('bloup'), []);
-    });
-
+      idx.tree.getNumberOfKeys().should.equal(0)
+      assert.deepEqual(idx.tree.search('hello'), [])
+      assert.deepEqual(idx.tree.search('world'), [])
+      assert.deepEqual(idx.tree.search('bloup'), [])
+    })
 
     describe('Array fields', function () {
 
       it('Inserts one entry per array element in the index', function () {
-        var obj = { tf: ['aa', 'bb'], really: 'yeah' }
-          , obj2 = { tf: 'normal', yes: 'indeed' }
-          , idx = new Index({ fieldName: 'tf' })
-          ;
+        const obj = { tf: ['aa', 'bb'], really: 'yeah' }
+        const obj2 = { tf: 'normal', yes: 'indeed' }
+        const idx = new Index({ fieldName: 'tf' })
 
-        idx.insert(obj);
-        idx.getAll().length.should.equal(2);
-        idx.getAll()[0].should.equal(obj);
-        idx.getAll()[1].should.equal(obj);
+        idx.insert(obj)
+        idx.getAll().length.should.equal(2)
+        idx.getAll()[0].should.equal(obj)
+        idx.getAll()[1].should.equal(obj)
 
-        idx.insert(obj2);
-        idx.getAll().length.should.equal(3);
-      });
+        idx.insert(obj2)
+        idx.getAll().length.should.equal(3)
+      })
 
       it('Inserts one entry per array element in the index, type-checked', function () {
-        var obj = { tf: ['42', 42, new Date(42), 42], really: 'yeah' }
-          , idx = new Index({ fieldName: 'tf' })
-          ;
+        const obj = { tf: ['42', 42, new Date(42), 42], really: 'yeah' }
+        const idx = new Index({ fieldName: 'tf' })
 
-        idx.insert(obj);
-        idx.getAll().length.should.equal(3);
-        idx.getAll()[0].should.equal(obj);
-        idx.getAll()[1].should.equal(obj);
-        idx.getAll()[2].should.equal(obj);
-      });
+        idx.insert(obj)
+        idx.getAll().length.should.equal(3)
+        idx.getAll()[0].should.equal(obj)
+        idx.getAll()[1].should.equal(obj)
+        idx.getAll()[2].should.equal(obj)
+      })
 
       it('Inserts one entry per unique array element in the index, the unique constraint only holds across documents', function () {
-        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
-          , obj2 = { tf: ['cc', 'yy', 'cc'], yes: 'indeed' }
-          , idx = new Index({ fieldName: 'tf', unique: true })
-          ;
+        const obj = { tf: ['aa', 'aa'], really: 'yeah' }
+        const obj2 = { tf: ['cc', 'yy', 'cc'], yes: 'indeed' }
+        const idx = new Index({ fieldName: 'tf', unique: true })
 
-        idx.insert(obj);
-        idx.getAll().length.should.equal(1);
-        idx.getAll()[0].should.equal(obj);
+        idx.insert(obj)
+        idx.getAll().length.should.equal(1)
+        idx.getAll()[0].should.equal(obj)
 
-        idx.insert(obj2);
-        idx.getAll().length.should.equal(3);
-      });
+        idx.insert(obj2)
+        idx.getAll().length.should.equal(3)
+      })
 
       it('The unique constraint holds across documents', function () {
-        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
-          , obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
-          , idx = new Index({ fieldName: 'tf', unique: true })
-          ;
+        const obj = { tf: ['aa', 'aa'], really: 'yeah' }
+        const obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
+        const idx = new Index({ fieldName: 'tf', unique: true })
 
-        idx.insert(obj);
-        idx.getAll().length.should.equal(1);
+        idx.insert(obj)
+        idx.getAll().length.should.equal(1)
         idx.getAll()[0].should.equal(obj);
 
-        (function () { idx.insert(obj2); }).should.throw();
-      });
+        (function () { idx.insert(obj2) }).should.throw()
+      })
 
       it('When removing a document, remove it from the index at all unique array elements', function () {
-        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
-          , obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
-          , idx = new Index({ fieldName: 'tf' })
-          ;
+        const obj = { tf: ['aa', 'aa'], really: 'yeah' }
+        const obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
+        const idx = new Index({ fieldName: 'tf' })
 
-        idx.insert(obj);
-        idx.insert(obj2);
-        idx.getMatching('aa').length.should.equal(2);
-        idx.getMatching('aa').indexOf(obj).should.not.equal(-1);
-        idx.getMatching('aa').indexOf(obj2).should.not.equal(-1);
-        idx.getMatching('cc').length.should.equal(1);
+        idx.insert(obj)
+        idx.insert(obj2)
+        idx.getMatching('aa').length.should.equal(2)
+        idx.getMatching('aa').indexOf(obj).should.not.equal(-1)
+        idx.getMatching('aa').indexOf(obj2).should.not.equal(-1)
+        idx.getMatching('cc').length.should.equal(1)
 
-        idx.remove(obj2);
-        idx.getMatching('aa').length.should.equal(1);
-        idx.getMatching('aa').indexOf(obj).should.not.equal(-1);
-        idx.getMatching('aa').indexOf(obj2).should.equal(-1);
-        idx.getMatching('cc').length.should.equal(0);
-      });
+        idx.remove(obj2)
+        idx.getMatching('aa').length.should.equal(1)
+        idx.getMatching('aa').indexOf(obj).should.not.equal(-1)
+        idx.getMatching('aa').indexOf(obj2).should.equal(-1)
+        idx.getMatching('cc').length.should.equal(0)
+      })
 
       it('If a unique constraint is violated when inserting an array key, roll back all inserts before the key', function () {
-        var obj = { tf: ['aa', 'bb'], really: 'yeah' }
-          , obj2 = { tf: ['cc', 'dd', 'aa', 'ee'], yes: 'indeed' }
-          , idx = new Index({ fieldName: 'tf', unique: true })
-          ;
+        const obj = { tf: ['aa', 'bb'], really: 'yeah' }
+        const obj2 = { tf: ['cc', 'dd', 'aa', 'ee'], yes: 'indeed' }
+        const idx = new Index({ fieldName: 'tf', unique: true })
 
-        idx.insert(obj);
-        idx.getAll().length.should.equal(2);
-        idx.getMatching('aa').length.should.equal(1);
-        idx.getMatching('bb').length.should.equal(1);
-        idx.getMatching('cc').length.should.equal(0);
-        idx.getMatching('dd').length.should.equal(0);
+        idx.insert(obj)
+        idx.getAll().length.should.equal(2)
+        idx.getMatching('aa').length.should.equal(1)
+        idx.getMatching('bb').length.should.equal(1)
+        idx.getMatching('cc').length.should.equal(0)
+        idx.getMatching('dd').length.should.equal(0)
         idx.getMatching('ee').length.should.equal(0);
 
-        (function () { idx.insert(obj2); }).should.throw();
-        idx.getAll().length.should.equal(2);
-        idx.getMatching('aa').length.should.equal(1);
-        idx.getMatching('bb').length.should.equal(1);
-        idx.getMatching('cc').length.should.equal(0);
-        idx.getMatching('dd').length.should.equal(0);
-        idx.getMatching('ee').length.should.equal(0);
-      });
+        (function () { idx.insert(obj2) }).should.throw()
+        idx.getAll().length.should.equal(2)
+        idx.getMatching('aa').length.should.equal(1)
+        idx.getMatching('bb').length.should.equal(1)
+        idx.getMatching('cc').length.should.equal(0)
+        idx.getMatching('dd').length.should.equal(0)
+        idx.getMatching('ee').length.should.equal(0)
+      })
 
-    });   // ==== End of 'Array fields' ==== //
+    })   // ==== End of 'Array fields' ==== //
 
-  });   // ==== End of 'Insertion' ==== //
-
+  })   // ==== End of 'Insertion' ==== //
 
   describe('Removal', function () {
 
     it('Can remove pointers from the index, even when multiple documents have the same key', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc4 = { a: 23, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc4 = { a: 23, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
-      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
+      idx.tree.getNumberOfKeys().should.equal(3)
 
-      idx.remove(doc1);
-      idx.tree.getNumberOfKeys().should.equal(2);
-      idx.tree.search('hello').length.should.equal(0);
+      idx.remove(doc1)
+      idx.tree.getNumberOfKeys().should.equal(2)
+      idx.tree.search('hello').length.should.equal(0)
 
-      idx.remove(doc2);
-      idx.tree.getNumberOfKeys().should.equal(2);
-      idx.tree.search('world').length.should.equal(1);
-      idx.tree.search('world')[0].should.equal(doc4);
-    });
+      idx.remove(doc2)
+      idx.tree.getNumberOfKeys().should.equal(2)
+      idx.tree.search('world').length.should.equal(1)
+      idx.tree.search('world')[0].should.equal(doc4)
+    })
 
     it('If we have a sparse index, removing a non indexed doc has no effect', function () {
-      var idx = new Index({ fieldName: 'nope', sparse: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 5, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'nope', sparse: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 5, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.tree.getNumberOfKeys().should.equal(0);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.tree.getNumberOfKeys().should.equal(0)
 
-      idx.remove(doc1);
-      idx.tree.getNumberOfKeys().should.equal(0);
-    });
+      idx.remove(doc1)
+      idx.tree.getNumberOfKeys().should.equal(0)
+    })
 
     it('Works with dot notation', function () {
-      var idx = new Index({ fieldName: 'tf.nested' })
-        , doc1 = { a: 5, tf: { nested: 'hello' } }
-        , doc2 = { a: 8, tf: { nested: 'world', additional: true } }
-        , doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
-        , doc4 = { a: 2, tf: { nested: 'world', fruits: ['apple', 'carrot'] } }
-        ;
+      const idx = new Index({ fieldName: 'tf.nested' })
+      const doc1 = { a: 5, tf: { nested: 'hello' } }
+      const doc2 = { a: 8, tf: { nested: 'world', additional: true } }
+      const doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
+      const doc4 = { a: 2, tf: { nested: 'world', fruits: ['apple', 'carrot'] } }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
-      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
+      idx.tree.getNumberOfKeys().should.equal(3)
 
-      idx.remove(doc1);
-      idx.tree.getNumberOfKeys().should.equal(2);
-      idx.tree.search('hello').length.should.equal(0);
+      idx.remove(doc1)
+      idx.tree.getNumberOfKeys().should.equal(2)
+      idx.tree.search('hello').length.should.equal(0)
 
-      idx.remove(doc2);
-      idx.tree.getNumberOfKeys().should.equal(2);
-      idx.tree.search('world').length.should.equal(1);
-      idx.tree.search('world')[0].should.equal(doc4);
-    });
+      idx.remove(doc2)
+      idx.tree.getNumberOfKeys().should.equal(2)
+      idx.tree.search('world').length.should.equal(1)
+      idx.tree.search('world')[0].should.equal(doc4)
+    })
 
     it('Can remove an array of documents', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
-      idx.insert([doc1, doc2, doc3]);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.remove([doc1, doc3]);
-      idx.tree.getNumberOfKeys().should.equal(1);
-      assert.deepEqual(idx.tree.search('hello'), []);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
-      assert.deepEqual(idx.tree.search('bloup'), []);
-    });
+      idx.insert([doc1, doc2, doc3])
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.remove([doc1, doc3])
+      idx.tree.getNumberOfKeys().should.equal(1)
+      assert.deepEqual(idx.tree.search('hello'), [])
+      assert.deepEqual(idx.tree.search('world'), [doc2])
+      assert.deepEqual(idx.tree.search('bloup'), [])
+    })
 
-  });   // ==== End of 'Removal' ==== //
-
+  })   // ==== End of 'Removal' ==== //
 
   describe('Update', function () {
 
     it('Can update a document whose key did or didnt change', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc4 = { a: 23, tf: 'world' }
-        , doc5 = { a: 1, tf: 'changed' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc4 = { a: 23, tf: 'world' }
+      const doc5 = { a: 1, tf: 'changed' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('world'), [doc2])
 
-      idx.update(doc2, doc4);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('world'), [doc4]);
+      idx.update(doc2, doc4)
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('world'), [doc4])
 
-      idx.update(doc1, doc5);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), []);
-      assert.deepEqual(idx.tree.search('changed'), [doc5]);
-    });
+      idx.update(doc1, doc5)
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [])
+      assert.deepEqual(idx.tree.search('changed'), [doc5])
+    })
 
     it('If a simple update violates a unique constraint, changes are rolled back and an error thrown', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , bad = { a: 23, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const bad = { a: 23, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), [doc1]);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
-      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [doc1])
+      assert.deepEqual(idx.tree.search('world'), [doc2])
+      assert.deepEqual(idx.tree.search('bloup'), [doc3])
 
       try {
-        idx.update(doc3, bad);
+        idx.update(doc3, bad)
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
+        e.errorType.should.equal('uniqueViolated')
       }
 
       // No change
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('hello'), [doc1]);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
-      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
-    });
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('hello'), [doc1])
+      assert.deepEqual(idx.tree.search('world'), [doc2])
+      assert.deepEqual(idx.tree.search('bloup'), [doc3])
+    })
 
     it('Can update an array of documents', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc1b = { a: 23, tf: 'world' }
-        , doc2b = { a: 1, tf: 'changed' }
-        , doc3b = { a: 44, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc1b = { a: 23, tf: 'world' }
+      const doc2b = { a: 1, tf: 'changed' }
+      const doc3b = { a: 44, tf: 'bloup' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.tree.getNumberOfKeys().should.equal(3)
 
-      idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
+      idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }])
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc1b);
-      idx.getMatching('changed').length.should.equal(1);
-      idx.getMatching('changed')[0].should.equal(doc2b);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3b);
-    });
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc1b)
+      idx.getMatching('changed').length.should.equal(1)
+      idx.getMatching('changed')[0].should.equal(doc2b)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3b)
+    })
 
     it('If a unique constraint is violated during an array-update, all changes are rolled back and an error thrown', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc0 = { a: 432, tf: 'notthistoo' }
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc1b = { a: 23, tf: 'changed' }
-        , doc2b = { a: 1, tf: 'changed' }   // Will violate the constraint (first try)
-        , doc2c = { a: 1, tf: 'notthistoo' }   // Will violate the constraint (second try)
-        , doc3b = { a: 44, tf: 'alsochanged' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc0 = { a: 432, tf: 'notthistoo' }
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc1b = { a: 23, tf: 'changed' }
+      const doc2b = { a: 1, tf: 'changed' }
+      const doc2c = { a: 1, tf: 'notthistoo' }
+      const doc3b = { a: 44, tf: 'alsochanged' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.tree.getNumberOfKeys().should.equal(3);
-
-      try {
-        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
-      } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
-      }
-
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('hello')[0].should.equal(doc1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc2);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.tree.getNumberOfKeys().should.equal(3)
 
       try {
-        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
+        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }])
       } catch (e) {
-        e.errorType.should.equal('uniqueViolated');
+        e.errorType.should.equal('uniqueViolated')
       }
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('hello')[0].should.equal(doc1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc2);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3);
-    });
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('hello')[0].should.equal(doc1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc2)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3)
+
+      try {
+        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }])
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated')
+      }
+
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('hello')[0].should.equal(doc1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc2)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3)
+    })
 
     it('If an update doesnt change a document, the unique constraint is not violated', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , noChange = { a: 8, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const noChange = { a: 8, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('world'), [doc2])
 
-      idx.update(doc2, noChange);   // No error thrown
-      idx.tree.getNumberOfKeys().should.equal(3);
-      assert.deepEqual(idx.tree.search('world'), [noChange]);
-    });
+      idx.update(doc2, noChange)   // No error thrown
+      idx.tree.getNumberOfKeys().should.equal(3)
+      assert.deepEqual(idx.tree.search('world'), [noChange])
+    })
 
     it('Can revert simple and batch updates', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc1b = { a: 23, tf: 'world' }
-        , doc2b = { a: 1, tf: 'changed' }
-        , doc3b = { a: 44, tf: 'bloup' }
-        , batchUpdate = [{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc1b = { a: 23, tf: 'world' }
+      const doc2b = { a: 1, tf: 'changed' }
+      const doc3b = { a: 44, tf: 'bloup' }
+      const batchUpdate = [{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, {
+        oldDoc: doc3,
+        newDoc: doc3b
+      }]
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.tree.getNumberOfKeys().should.equal(3)
 
-      idx.update(batchUpdate);
+      idx.update(batchUpdate)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc1b);
-      idx.getMatching('changed').length.should.equal(1);
-      idx.getMatching('changed')[0].should.equal(doc2b);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3b);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc1b)
+      idx.getMatching('changed').length.should.equal(1)
+      idx.getMatching('changed')[0].should.equal(doc2b)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3b)
 
-      idx.revertUpdate(batchUpdate);
+      idx.revertUpdate(batchUpdate)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('hello')[0].should.equal(doc1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc2);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('hello')[0].should.equal(doc1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc2)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3)
 
       // Now a simple update
-      idx.update(doc2, doc2b);
+      idx.update(doc2, doc2b)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('hello')[0].should.equal(doc1);
-      idx.getMatching('changed').length.should.equal(1);
-      idx.getMatching('changed')[0].should.equal(doc2b);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('hello')[0].should.equal(doc1)
+      idx.getMatching('changed').length.should.equal(1)
+      idx.getMatching('changed')[0].should.equal(doc2b)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3)
 
-      idx.revertUpdate(doc2, doc2b);
+      idx.revertUpdate(doc2, doc2b)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('hello')[0].should.equal(doc1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('world')[0].should.equal(doc2);
-      idx.getMatching('bloup').length.should.equal(1);
-      idx.getMatching('bloup')[0].should.equal(doc3);
-    });
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('hello')[0].should.equal(doc1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('world')[0].should.equal(doc2)
+      idx.getMatching('bloup').length.should.equal(1)
+      idx.getMatching('bloup')[0].should.equal(doc3)
+    })
 
-  });   // ==== End of 'Update' ==== //
-
+  })   // ==== End of 'Update' ==== //
 
   describe('Get matching documents', function () {
 
     it('Get all documents where fieldName is equal to the given value, or an empty array if no match', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , doc4 = { a: 23, tf: 'world' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const doc4 = { a: 23, tf: 'world' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
 
-      assert.deepEqual(idx.getMatching('bloup'), [doc3]);
-      assert.deepEqual(idx.getMatching('world'), [doc2, doc4]);
-      assert.deepEqual(idx.getMatching('nope'), []);
-    });
+      assert.deepEqual(idx.getMatching('bloup'), [doc3])
+      assert.deepEqual(idx.getMatching('world'), [doc2, doc4])
+      assert.deepEqual(idx.getMatching('nope'), [])
+    })
 
     it('Can get all documents for a given key in a unique index', function () {
-      var idx = new Index({ fieldName: 'tf', unique: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf', unique: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      assert.deepEqual(idx.getMatching('bloup'), [doc3]);
-      assert.deepEqual(idx.getMatching('world'), [doc2]);
-      assert.deepEqual(idx.getMatching('nope'), []);
-    });
+      assert.deepEqual(idx.getMatching('bloup'), [doc3])
+      assert.deepEqual(idx.getMatching('world'), [doc2])
+      assert.deepEqual(idx.getMatching('nope'), [])
+    })
 
     it('Can get all documents for which a field is undefined', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 2, nottf: 'bloup' }
-        , doc3 = { a: 8, tf: 'world' }
-        , doc4 = { a: 7, nottf: 'yes' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 2, nottf: 'bloup' }
+      const doc3 = { a: 8, tf: 'world' }
+      const doc4 = { a: 7, nottf: 'yes' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      assert.deepEqual(idx.getMatching('bloup'), []);
-      assert.deepEqual(idx.getMatching('hello'), [doc1]);
-      assert.deepEqual(idx.getMatching('world'), [doc3]);
-      assert.deepEqual(idx.getMatching('yes'), []);
-      assert.deepEqual(idx.getMatching(undefined), [doc2]);
+      assert.deepEqual(idx.getMatching('bloup'), [])
+      assert.deepEqual(idx.getMatching('hello'), [doc1])
+      assert.deepEqual(idx.getMatching('world'), [doc3])
+      assert.deepEqual(idx.getMatching('yes'), [])
+      assert.deepEqual(idx.getMatching(undefined), [doc2])
 
-      idx.insert(doc4);
+      idx.insert(doc4)
 
-      assert.deepEqual(idx.getMatching('bloup'), []);
-      assert.deepEqual(idx.getMatching('hello'), [doc1]);
-      assert.deepEqual(idx.getMatching('world'), [doc3]);
-      assert.deepEqual(idx.getMatching('yes'), []);
-      assert.deepEqual(idx.getMatching(undefined), [doc2, doc4]);
-    });
+      assert.deepEqual(idx.getMatching('bloup'), [])
+      assert.deepEqual(idx.getMatching('hello'), [doc1])
+      assert.deepEqual(idx.getMatching('world'), [doc3])
+      assert.deepEqual(idx.getMatching('yes'), [])
+      assert.deepEqual(idx.getMatching(undefined), [doc2, doc4])
+    })
 
     it('Can get all documents for which a field is null', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 2, tf: null }
-        , doc3 = { a: 8, tf: 'world' }
-        , doc4 = { a: 7, tf: null }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 2, tf: null }
+      const doc3 = { a: 8, tf: 'world' }
+      const doc4 = { a: 7, tf: null }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      assert.deepEqual(idx.getMatching('bloup'), []);
-      assert.deepEqual(idx.getMatching('hello'), [doc1]);
-      assert.deepEqual(idx.getMatching('world'), [doc3]);
-      assert.deepEqual(idx.getMatching('yes'), []);
-      assert.deepEqual(idx.getMatching(null), [doc2]);
+      assert.deepEqual(idx.getMatching('bloup'), [])
+      assert.deepEqual(idx.getMatching('hello'), [doc1])
+      assert.deepEqual(idx.getMatching('world'), [doc3])
+      assert.deepEqual(idx.getMatching('yes'), [])
+      assert.deepEqual(idx.getMatching(null), [doc2])
 
-      idx.insert(doc4);
+      idx.insert(doc4)
 
-      assert.deepEqual(idx.getMatching('bloup'), []);
-      assert.deepEqual(idx.getMatching('hello'), [doc1]);
-      assert.deepEqual(idx.getMatching('world'), [doc3]);
-      assert.deepEqual(idx.getMatching('yes'), []);
-      assert.deepEqual(idx.getMatching(null), [doc2, doc4]);
-    });
+      assert.deepEqual(idx.getMatching('bloup'), [])
+      assert.deepEqual(idx.getMatching('hello'), [doc1])
+      assert.deepEqual(idx.getMatching('world'), [doc3])
+      assert.deepEqual(idx.getMatching('yes'), [])
+      assert.deepEqual(idx.getMatching(null), [doc2, doc4])
+    })
 
     it('Can get all documents for a given key in a sparse index, but not unindexed docs (= field undefined)', function () {
-      var idx = new Index({ fieldName: 'tf', sparse: true })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 2, nottf: 'bloup' }
-        , doc3 = { a: 8, tf: 'world' }
-        , doc4 = { a: 7, nottf: 'yes' }
-        ;
+      const idx = new Index({ fieldName: 'tf', sparse: true })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 2, nottf: 'bloup' }
+      const doc3 = { a: 8, tf: 'world' }
+      const doc4 = { a: 7, nottf: 'yes' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
 
-      assert.deepEqual(idx.getMatching('bloup'), []);
-      assert.deepEqual(idx.getMatching('hello'), [doc1]);
-      assert.deepEqual(idx.getMatching('world'), [doc3]);
-      assert.deepEqual(idx.getMatching('yes'), []);
-      assert.deepEqual(idx.getMatching(undefined), []);
-    });
+      assert.deepEqual(idx.getMatching('bloup'), [])
+      assert.deepEqual(idx.getMatching('hello'), [doc1])
+      assert.deepEqual(idx.getMatching('world'), [doc3])
+      assert.deepEqual(idx.getMatching('yes'), [])
+      assert.deepEqual(idx.getMatching(undefined), [])
+    })
 
     it('Can get all documents whose key is in an array of keys', function () {
       // For this test only we have to use objects with _ids as the array version of getMatching
       // relies on the _id property being set, otherwise we have to use a quadratic algorithm
       // or a fingerprinting algorithm, both solutions too complicated and slow given that live nedb
       // indexes documents with _id always set
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello', _id: '1' }
-        , doc2 = { a: 2, tf: 'bloup', _id: '2' }
-        , doc3 = { a: 8, tf: 'world', _id: '3' }
-        , doc4 = { a: 7, tf: 'yes', _id: '4' }
-        , doc5 = { a: 7, tf: 'yes', _id: '5' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello', _id: '1' }
+      const doc2 = { a: 2, tf: 'bloup', _id: '2' }
+      const doc3 = { a: 8, tf: 'world', _id: '3' }
+      const doc4 = { a: 7, tf: 'yes', _id: '4' }
+      const doc5 = { a: 7, tf: 'yes', _id: '5' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
-      idx.insert(doc5);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
+      idx.insert(doc5)
 
-      assert.deepEqual(idx.getMatching([]), []);
-      assert.deepEqual(idx.getMatching(['bloup']), [doc2]);
-      assert.deepEqual(idx.getMatching(['bloup', 'yes']), [doc2, doc4, doc5]);
-      assert.deepEqual(idx.getMatching(['hello', 'no']), [doc1]);
-      assert.deepEqual(idx.getMatching(['nope', 'no']), []);
-    });
+      assert.deepEqual(idx.getMatching([]), [])
+      assert.deepEqual(idx.getMatching(['bloup']), [doc2])
+      assert.deepEqual(idx.getMatching(['bloup', 'yes']), [doc2, doc4, doc5])
+      assert.deepEqual(idx.getMatching(['hello', 'no']), [doc1])
+      assert.deepEqual(idx.getMatching(['nope', 'no']), [])
+    })
 
     it('Can get all documents whose key is between certain bounds', function () {
-      var idx = new Index({ fieldName: 'a' })
+      const idx = new Index({ fieldName: 'a' })
         , doc1 = { a: 5, tf: 'hello' }
         , doc2 = { a: 2, tf: 'bloup' }
         , doc3 = { a: 8, tf: 'world' }
         , doc4 = { a: 7, tf: 'yes' }
         , doc5 = { a: 10, tf: 'yes' }
-        ;
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
-      idx.insert(doc4);
-      idx.insert(doc5);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
+      idx.insert(doc4)
+      idx.insert(doc5)
 
-      assert.deepEqual(idx.getBetweenBounds({ $lt: 10, $gte: 5 }), [ doc1, doc4, doc3 ]);
-      assert.deepEqual(idx.getBetweenBounds({ $lte: 8 }), [ doc2, doc1, doc4, doc3 ]);
-      assert.deepEqual(idx.getBetweenBounds({ $gt: 7 }), [ doc3, doc5 ]);
-    });
+      assert.deepEqual(idx.getBetweenBounds({ $lt: 10, $gte: 5 }), [doc1, doc4, doc3])
+      assert.deepEqual(idx.getBetweenBounds({ $lte: 8 }), [doc2, doc1, doc4, doc3])
+      assert.deepEqual(idx.getBetweenBounds({ $gt: 7 }), [doc3, doc5])
+    })
 
-  });   // ==== End of 'Get matching documents' ==== //
-
+  })   // ==== End of 'Get matching documents' ==== //
 
   describe('Resetting', function () {
 
     it('Can reset an index without any new data, the index will be empty afterwards', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('bloup').length.should.equal(1);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('bloup').length.should.equal(1)
 
-      idx.reset();
-      idx.tree.getNumberOfKeys().should.equal(0);
-      idx.getMatching('hello').length.should.equal(0);
-      idx.getMatching('world').length.should.equal(0);
-      idx.getMatching('bloup').length.should.equal(0);
-    });
+      idx.reset()
+      idx.tree.getNumberOfKeys().should.equal(0)
+      idx.getMatching('hello').length.should.equal(0)
+      idx.getMatching('world').length.should.equal(0)
+      idx.getMatching('bloup').length.should.equal(0)
+    })
 
     it('Can reset an index and initialize it with one document', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , newDoc = { a: 555, tf: 'new' }
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const newDoc = { a: 555, tf: 'new' }
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('bloup').length.should.equal(1);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('bloup').length.should.equal(1)
 
-      idx.reset(newDoc);
-      idx.tree.getNumberOfKeys().should.equal(1);
-      idx.getMatching('hello').length.should.equal(0);
-      idx.getMatching('world').length.should.equal(0);
-      idx.getMatching('bloup').length.should.equal(0);
-      idx.getMatching('new')[0].a.should.equal(555);
-    });
+      idx.reset(newDoc)
+      idx.tree.getNumberOfKeys().should.equal(1)
+      idx.getMatching('hello').length.should.equal(0)
+      idx.getMatching('world').length.should.equal(0)
+      idx.getMatching('bloup').length.should.equal(0)
+      idx.getMatching('new')[0].a.should.equal(555)
+    })
 
     it('Can reset an index and initialize it with an array of documents', function () {
-      var idx = new Index({ fieldName: 'tf' })
-        , doc1 = { a: 5, tf: 'hello' }
-        , doc2 = { a: 8, tf: 'world' }
-        , doc3 = { a: 2, tf: 'bloup' }
-        , newDocs = [{ a: 555, tf: 'new' }, { a: 666, tf: 'again' }]
-        ;
+      const idx = new Index({ fieldName: 'tf' })
+      const doc1 = { a: 5, tf: 'hello' }
+      const doc2 = { a: 8, tf: 'world' }
+      const doc3 = { a: 2, tf: 'bloup' }
+      const newDocs = [{ a: 555, tf: 'new' }, { a: 666, tf: 'again' }]
 
-      idx.insert(doc1);
-      idx.insert(doc2);
-      idx.insert(doc3);
+      idx.insert(doc1)
+      idx.insert(doc2)
+      idx.insert(doc3)
 
-      idx.tree.getNumberOfKeys().should.equal(3);
-      idx.getMatching('hello').length.should.equal(1);
-      idx.getMatching('world').length.should.equal(1);
-      idx.getMatching('bloup').length.should.equal(1);
+      idx.tree.getNumberOfKeys().should.equal(3)
+      idx.getMatching('hello').length.should.equal(1)
+      idx.getMatching('world').length.should.equal(1)
+      idx.getMatching('bloup').length.should.equal(1)
 
-      idx.reset(newDocs);
-      idx.tree.getNumberOfKeys().should.equal(2);
-      idx.getMatching('hello').length.should.equal(0);
-      idx.getMatching('world').length.should.equal(0);
-      idx.getMatching('bloup').length.should.equal(0);
-      idx.getMatching('new')[0].a.should.equal(555);
-      idx.getMatching('again')[0].a.should.equal(666);
-    });
+      idx.reset(newDocs)
+      idx.tree.getNumberOfKeys().should.equal(2)
+      idx.getMatching('hello').length.should.equal(0)
+      idx.getMatching('world').length.should.equal(0)
+      idx.getMatching('bloup').length.should.equal(0)
+      idx.getMatching('new')[0].a.should.equal(555)
+      idx.getMatching('again')[0].a.should.equal(666)
+    })
 
-  });   // ==== End of 'Resetting' ==== //
+  })   // ==== End of 'Resetting' ==== //
 
   it('Get all elements in the index', function () {
-    var idx = new Index({ fieldName: 'a' })
-      , doc1 = { a: 5, tf: 'hello' }
-      , doc2 = { a: 8, tf: 'world' }
-      , doc3 = { a: 2, tf: 'bloup' }
-      ;
+    const idx = new Index({ fieldName: 'a' })
+    const doc1 = { a: 5, tf: 'hello' }
+    const doc2 = { a: 8, tf: 'world' }
+    const doc3 = { a: 2, tf: 'bloup' }
 
-    idx.insert(doc1);
-    idx.insert(doc2);
-    idx.insert(doc3);
+    idx.insert(doc1)
+    idx.insert(doc2)
+    idx.insert(doc3)
 
-    assert.deepEqual(idx.getAll(), [{ a: 2, tf: 'bloup' }, { a: 5, tf: 'hello' }, { a: 8, tf: 'world' }]);
-  });
+    assert.deepEqual(idx.getAll(), [{ a: 2, tf: 'bloup' }, { a: 5, tf: 'hello' }, { a: 8, tf: 'world' }])
+  })
 
-
-});
+})

--- a/test/indexes.test.js
+++ b/test/indexes.test.js
@@ -1,0 +1,773 @@
+var Index = require('../src/nedb/indexes')
+  , customUtils = require('../src/nedb/customUtils')
+  , should = require('chai').should()
+  , assert = require('chai').assert
+  , _ = require('underscore')
+  , async = require('async')
+  , model = require('../src/nedb/model')
+  ;
+
+describe('Indexes', function () {
+
+  describe('Insertion', function () {
+
+    it('Can insert pointers to documents in the index correctly when they have the field', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      // The underlying BST now has 3 nodes which contain the docs where it's expected
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), [{ a: 5, tf: 'hello' }]);
+      assert.deepEqual(idx.tree.search('world'), [{ a: 8, tf: 'world' }]);
+      assert.deepEqual(idx.tree.search('bloup'), [{ a: 2, tf: 'bloup' }]);
+
+      // The nodes contain pointers to the actual documents
+      idx.tree.search('world')[0].should.equal(doc2);
+      idx.tree.search('bloup')[0].a = 42;
+      doc3.a.should.equal(42);
+    });
+
+    it('Inserting twice for the same fieldName in a unique index will result in an error thrown', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        ;
+
+      idx.insert(doc1);
+      idx.tree.getNumberOfKeys().should.equal(1);
+      (function () { idx.insert(doc1); }).should.throw();
+    });
+
+    it('Inserting twice for a fieldName the docs dont have with a unique index results in an error thrown', function () {
+      var idx = new Index({ fieldName: 'nope', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 5, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.tree.getNumberOfKeys().should.equal(1);
+      (function () { idx.insert(doc2); }).should.throw();
+    });
+
+    it('Inserting twice for a fieldName the docs dont have with a unique and sparse index will not throw, since the docs will be non indexed', function () {
+      var idx = new Index({ fieldName: 'nope', unique: true, sparse: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 5, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.tree.getNumberOfKeys().should.equal(0);   // Docs are not indexed
+    });
+
+    it('Works with dot notation', function () {
+      var idx = new Index({ fieldName: 'tf.nested' })
+        , doc1 = { a: 5, tf: { nested: 'hello' } }
+        , doc2 = { a: 8, tf: { nested: 'world', additional: true } }
+        , doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      // The underlying BST now has 3 nodes which contain the docs where it's expected
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), [doc1]);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+
+      // The nodes contain pointers to the actual documents
+      idx.tree.search('bloup')[0].a = 42;
+      doc3.a.should.equal(42);
+    });
+
+    it('Can insert an array of documents', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      idx.insert([doc1, doc2, doc3]);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), [doc1]);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+    });
+
+    it('When inserting an array of elements, if an error is thrown all inserts need to be rolled back', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc2b = { a: 84, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      try {
+        idx.insert([doc1, doc2, doc2b, doc3]);
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+      }
+      idx.tree.getNumberOfKeys().should.equal(0);
+      assert.deepEqual(idx.tree.search('hello'), []);
+      assert.deepEqual(idx.tree.search('world'), []);
+      assert.deepEqual(idx.tree.search('bloup'), []);
+    });
+
+
+    describe('Array fields', function () {
+
+      it('Inserts one entry per array element in the index', function () {
+        var obj = { tf: ['aa', 'bb'], really: 'yeah' }
+          , obj2 = { tf: 'normal', yes: 'indeed' }
+          , idx = new Index({ fieldName: 'tf' })
+          ;
+
+        idx.insert(obj);
+        idx.getAll().length.should.equal(2);
+        idx.getAll()[0].should.equal(obj);
+        idx.getAll()[1].should.equal(obj);
+
+        idx.insert(obj2);
+        idx.getAll().length.should.equal(3);
+      });
+
+      it('Inserts one entry per array element in the index, type-checked', function () {
+        var obj = { tf: ['42', 42, new Date(42), 42], really: 'yeah' }
+          , idx = new Index({ fieldName: 'tf' })
+          ;
+
+        idx.insert(obj);
+        idx.getAll().length.should.equal(3);
+        idx.getAll()[0].should.equal(obj);
+        idx.getAll()[1].should.equal(obj);
+        idx.getAll()[2].should.equal(obj);
+      });
+
+      it('Inserts one entry per unique array element in the index, the unique constraint only holds across documents', function () {
+        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
+          , obj2 = { tf: ['cc', 'yy', 'cc'], yes: 'indeed' }
+          , idx = new Index({ fieldName: 'tf', unique: true })
+          ;
+
+        idx.insert(obj);
+        idx.getAll().length.should.equal(1);
+        idx.getAll()[0].should.equal(obj);
+
+        idx.insert(obj2);
+        idx.getAll().length.should.equal(3);
+      });
+
+      it('The unique constraint holds across documents', function () {
+        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
+          , obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
+          , idx = new Index({ fieldName: 'tf', unique: true })
+          ;
+
+        idx.insert(obj);
+        idx.getAll().length.should.equal(1);
+        idx.getAll()[0].should.equal(obj);
+
+        (function () { idx.insert(obj2); }).should.throw();
+      });
+
+      it('When removing a document, remove it from the index at all unique array elements', function () {
+        var obj = { tf: ['aa', 'aa'], really: 'yeah' }
+          , obj2 = { tf: ['cc', 'aa', 'cc'], yes: 'indeed' }
+          , idx = new Index({ fieldName: 'tf' })
+          ;
+
+        idx.insert(obj);
+        idx.insert(obj2);
+        idx.getMatching('aa').length.should.equal(2);
+        idx.getMatching('aa').indexOf(obj).should.not.equal(-1);
+        idx.getMatching('aa').indexOf(obj2).should.not.equal(-1);
+        idx.getMatching('cc').length.should.equal(1);
+
+        idx.remove(obj2);
+        idx.getMatching('aa').length.should.equal(1);
+        idx.getMatching('aa').indexOf(obj).should.not.equal(-1);
+        idx.getMatching('aa').indexOf(obj2).should.equal(-1);
+        idx.getMatching('cc').length.should.equal(0);
+      });
+
+      it('If a unique constraint is violated when inserting an array key, roll back all inserts before the key', function () {
+        var obj = { tf: ['aa', 'bb'], really: 'yeah' }
+          , obj2 = { tf: ['cc', 'dd', 'aa', 'ee'], yes: 'indeed' }
+          , idx = new Index({ fieldName: 'tf', unique: true })
+          ;
+
+        idx.insert(obj);
+        idx.getAll().length.should.equal(2);
+        idx.getMatching('aa').length.should.equal(1);
+        idx.getMatching('bb').length.should.equal(1);
+        idx.getMatching('cc').length.should.equal(0);
+        idx.getMatching('dd').length.should.equal(0);
+        idx.getMatching('ee').length.should.equal(0);
+
+        (function () { idx.insert(obj2); }).should.throw();
+        idx.getAll().length.should.equal(2);
+        idx.getMatching('aa').length.should.equal(1);
+        idx.getMatching('bb').length.should.equal(1);
+        idx.getMatching('cc').length.should.equal(0);
+        idx.getMatching('dd').length.should.equal(0);
+        idx.getMatching('ee').length.should.equal(0);
+      });
+
+    });   // ==== End of 'Array fields' ==== //
+
+  });   // ==== End of 'Insertion' ==== //
+
+
+  describe('Removal', function () {
+
+    it('Can remove pointers from the index, even when multiple documents have the same key', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc4 = { a: 23, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.tree.getNumberOfKeys().should.equal(3);
+
+      idx.remove(doc1);
+      idx.tree.getNumberOfKeys().should.equal(2);
+      idx.tree.search('hello').length.should.equal(0);
+
+      idx.remove(doc2);
+      idx.tree.getNumberOfKeys().should.equal(2);
+      idx.tree.search('world').length.should.equal(1);
+      idx.tree.search('world')[0].should.equal(doc4);
+    });
+
+    it('If we have a sparse index, removing a non indexed doc has no effect', function () {
+      var idx = new Index({ fieldName: 'nope', sparse: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 5, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.tree.getNumberOfKeys().should.equal(0);
+
+      idx.remove(doc1);
+      idx.tree.getNumberOfKeys().should.equal(0);
+    });
+
+    it('Works with dot notation', function () {
+      var idx = new Index({ fieldName: 'tf.nested' })
+        , doc1 = { a: 5, tf: { nested: 'hello' } }
+        , doc2 = { a: 8, tf: { nested: 'world', additional: true } }
+        , doc3 = { a: 2, tf: { nested: 'bloup', age: 42 } }
+        , doc4 = { a: 2, tf: { nested: 'world', fruits: ['apple', 'carrot'] } }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.tree.getNumberOfKeys().should.equal(3);
+
+      idx.remove(doc1);
+      idx.tree.getNumberOfKeys().should.equal(2);
+      idx.tree.search('hello').length.should.equal(0);
+
+      idx.remove(doc2);
+      idx.tree.getNumberOfKeys().should.equal(2);
+      idx.tree.search('world').length.should.equal(1);
+      idx.tree.search('world')[0].should.equal(doc4);
+    });
+
+    it('Can remove an array of documents', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      idx.insert([doc1, doc2, doc3]);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.remove([doc1, doc3]);
+      idx.tree.getNumberOfKeys().should.equal(1);
+      assert.deepEqual(idx.tree.search('hello'), []);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      assert.deepEqual(idx.tree.search('bloup'), []);
+    });
+
+  });   // ==== End of 'Removal' ==== //
+
+
+  describe('Update', function () {
+
+    it('Can update a document whose key did or didnt change', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc4 = { a: 23, tf: 'world' }
+        , doc5 = { a: 1, tf: 'changed' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+
+      idx.update(doc2, doc4);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('world'), [doc4]);
+
+      idx.update(doc1, doc5);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), []);
+      assert.deepEqual(idx.tree.search('changed'), [doc5]);
+    });
+
+    it('If a simple update violates a unique constraint, changes are rolled back and an error thrown', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , bad = { a: 23, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), [doc1]);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+
+      try {
+        idx.update(doc3, bad);
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+      }
+
+      // No change
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('hello'), [doc1]);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+      assert.deepEqual(idx.tree.search('bloup'), [doc3]);
+    });
+
+    it('Can update an array of documents', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc1b = { a: 23, tf: 'world' }
+        , doc2b = { a: 1, tf: 'changed' }
+        , doc3b = { a: 44, tf: 'bloup' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3);
+
+      idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc1b);
+      idx.getMatching('changed').length.should.equal(1);
+      idx.getMatching('changed')[0].should.equal(doc2b);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3b);
+    });
+
+    it('If a unique constraint is violated during an array-update, all changes are rolled back and an error thrown', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc0 = { a: 432, tf: 'notthistoo' }
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc1b = { a: 23, tf: 'changed' }
+        , doc2b = { a: 1, tf: 'changed' }   // Will violate the constraint (first try)
+        , doc2c = { a: 1, tf: 'notthistoo' }   // Will violate the constraint (second try)
+        , doc3b = { a: 44, tf: 'alsochanged' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3);
+
+      try {
+        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+      }
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('hello')[0].should.equal(doc1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc2);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3);
+
+      try {
+        idx.update([{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]);
+      } catch (e) {
+        e.errorType.should.equal('uniqueViolated');
+      }
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('hello')[0].should.equal(doc1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc2);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3);
+    });
+
+    it('If an update doesnt change a document, the unique constraint is not violated', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , noChange = { a: 8, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('world'), [doc2]);
+
+      idx.update(doc2, noChange);   // No error thrown
+      idx.tree.getNumberOfKeys().should.equal(3);
+      assert.deepEqual(idx.tree.search('world'), [noChange]);
+    });
+
+    it('Can revert simple and batch updates', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc1b = { a: 23, tf: 'world' }
+        , doc2b = { a: 1, tf: 'changed' }
+        , doc3b = { a: 44, tf: 'bloup' }
+        , batchUpdate = [{ oldDoc: doc1, newDoc: doc1b }, { oldDoc: doc2, newDoc: doc2b }, { oldDoc: doc3, newDoc: doc3b }]
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.tree.getNumberOfKeys().should.equal(3);
+
+      idx.update(batchUpdate);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc1b);
+      idx.getMatching('changed').length.should.equal(1);
+      idx.getMatching('changed')[0].should.equal(doc2b);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3b);
+
+      idx.revertUpdate(batchUpdate);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('hello')[0].should.equal(doc1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc2);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3);
+
+      // Now a simple update
+      idx.update(doc2, doc2b);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('hello')[0].should.equal(doc1);
+      idx.getMatching('changed').length.should.equal(1);
+      idx.getMatching('changed')[0].should.equal(doc2b);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3);
+
+      idx.revertUpdate(doc2, doc2b);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('hello')[0].should.equal(doc1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('world')[0].should.equal(doc2);
+      idx.getMatching('bloup').length.should.equal(1);
+      idx.getMatching('bloup')[0].should.equal(doc3);
+    });
+
+  });   // ==== End of 'Update' ==== //
+
+
+  describe('Get matching documents', function () {
+
+    it('Get all documents where fieldName is equal to the given value, or an empty array if no match', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , doc4 = { a: 23, tf: 'world' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+
+      assert.deepEqual(idx.getMatching('bloup'), [doc3]);
+      assert.deepEqual(idx.getMatching('world'), [doc2, doc4]);
+      assert.deepEqual(idx.getMatching('nope'), []);
+    });
+
+    it('Can get all documents for a given key in a unique index', function () {
+      var idx = new Index({ fieldName: 'tf', unique: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      assert.deepEqual(idx.getMatching('bloup'), [doc3]);
+      assert.deepEqual(idx.getMatching('world'), [doc2]);
+      assert.deepEqual(idx.getMatching('nope'), []);
+    });
+
+    it('Can get all documents for which a field is undefined', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, nottf: 'bloup' }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, nottf: 'yes' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      assert.deepEqual(idx.getMatching('bloup'), []);
+      assert.deepEqual(idx.getMatching('hello'), [doc1]);
+      assert.deepEqual(idx.getMatching('world'), [doc3]);
+      assert.deepEqual(idx.getMatching('yes'), []);
+      assert.deepEqual(idx.getMatching(undefined), [doc2]);
+
+      idx.insert(doc4);
+
+      assert.deepEqual(idx.getMatching('bloup'), []);
+      assert.deepEqual(idx.getMatching('hello'), [doc1]);
+      assert.deepEqual(idx.getMatching('world'), [doc3]);
+      assert.deepEqual(idx.getMatching('yes'), []);
+      assert.deepEqual(idx.getMatching(undefined), [doc2, doc4]);
+    });
+
+    it('Can get all documents for which a field is null', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, tf: null }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, tf: null }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      assert.deepEqual(idx.getMatching('bloup'), []);
+      assert.deepEqual(idx.getMatching('hello'), [doc1]);
+      assert.deepEqual(idx.getMatching('world'), [doc3]);
+      assert.deepEqual(idx.getMatching('yes'), []);
+      assert.deepEqual(idx.getMatching(null), [doc2]);
+
+      idx.insert(doc4);
+
+      assert.deepEqual(idx.getMatching('bloup'), []);
+      assert.deepEqual(idx.getMatching('hello'), [doc1]);
+      assert.deepEqual(idx.getMatching('world'), [doc3]);
+      assert.deepEqual(idx.getMatching('yes'), []);
+      assert.deepEqual(idx.getMatching(null), [doc2, doc4]);
+    });
+
+    it('Can get all documents for a given key in a sparse index, but not unindexed docs (= field undefined)', function () {
+      var idx = new Index({ fieldName: 'tf', sparse: true })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, nottf: 'bloup' }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, nottf: 'yes' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+
+      assert.deepEqual(idx.getMatching('bloup'), []);
+      assert.deepEqual(idx.getMatching('hello'), [doc1]);
+      assert.deepEqual(idx.getMatching('world'), [doc3]);
+      assert.deepEqual(idx.getMatching('yes'), []);
+      assert.deepEqual(idx.getMatching(undefined), []);
+    });
+
+    it('Can get all documents whose key is in an array of keys', function () {
+      // For this test only we have to use objects with _ids as the array version of getMatching
+      // relies on the _id property being set, otherwise we have to use a quadratic algorithm
+      // or a fingerprinting algorithm, both solutions too complicated and slow given that live nedb
+      // indexes documents with _id always set
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello', _id: '1' }
+        , doc2 = { a: 2, tf: 'bloup', _id: '2' }
+        , doc3 = { a: 8, tf: 'world', _id: '3' }
+        , doc4 = { a: 7, tf: 'yes', _id: '4' }
+        , doc5 = { a: 7, tf: 'yes', _id: '5' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.insert(doc5);
+
+      assert.deepEqual(idx.getMatching([]), []);
+      assert.deepEqual(idx.getMatching(['bloup']), [doc2]);
+      assert.deepEqual(idx.getMatching(['bloup', 'yes']), [doc2, doc4, doc5]);
+      assert.deepEqual(idx.getMatching(['hello', 'no']), [doc1]);
+      assert.deepEqual(idx.getMatching(['nope', 'no']), []);
+    });
+
+    it('Can get all documents whose key is between certain bounds', function () {
+      var idx = new Index({ fieldName: 'a' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 2, tf: 'bloup' }
+        , doc3 = { a: 8, tf: 'world' }
+        , doc4 = { a: 7, tf: 'yes' }
+        , doc5 = { a: 10, tf: 'yes' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+      idx.insert(doc4);
+      idx.insert(doc5);
+
+      assert.deepEqual(idx.getBetweenBounds({ $lt: 10, $gte: 5 }), [ doc1, doc4, doc3 ]);
+      assert.deepEqual(idx.getBetweenBounds({ $lte: 8 }), [ doc2, doc1, doc4, doc3 ]);
+      assert.deepEqual(idx.getBetweenBounds({ $gt: 7 }), [ doc3, doc5 ]);
+    });
+
+  });   // ==== End of 'Get matching documents' ==== //
+
+
+  describe('Resetting', function () {
+
+    it('Can reset an index without any new data, the index will be empty afterwards', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('bloup').length.should.equal(1);
+
+      idx.reset();
+      idx.tree.getNumberOfKeys().should.equal(0);
+      idx.getMatching('hello').length.should.equal(0);
+      idx.getMatching('world').length.should.equal(0);
+      idx.getMatching('bloup').length.should.equal(0);
+    });
+
+    it('Can reset an index and initialize it with one document', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , newDoc = { a: 555, tf: 'new' }
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('bloup').length.should.equal(1);
+
+      idx.reset(newDoc);
+      idx.tree.getNumberOfKeys().should.equal(1);
+      idx.getMatching('hello').length.should.equal(0);
+      idx.getMatching('world').length.should.equal(0);
+      idx.getMatching('bloup').length.should.equal(0);
+      idx.getMatching('new')[0].a.should.equal(555);
+    });
+
+    it('Can reset an index and initialize it with an array of documents', function () {
+      var idx = new Index({ fieldName: 'tf' })
+        , doc1 = { a: 5, tf: 'hello' }
+        , doc2 = { a: 8, tf: 'world' }
+        , doc3 = { a: 2, tf: 'bloup' }
+        , newDocs = [{ a: 555, tf: 'new' }, { a: 666, tf: 'again' }]
+        ;
+
+      idx.insert(doc1);
+      idx.insert(doc2);
+      idx.insert(doc3);
+
+      idx.tree.getNumberOfKeys().should.equal(3);
+      idx.getMatching('hello').length.should.equal(1);
+      idx.getMatching('world').length.should.equal(1);
+      idx.getMatching('bloup').length.should.equal(1);
+
+      idx.reset(newDocs);
+      idx.tree.getNumberOfKeys().should.equal(2);
+      idx.getMatching('hello').length.should.equal(0);
+      idx.getMatching('world').length.should.equal(0);
+      idx.getMatching('bloup').length.should.equal(0);
+      idx.getMatching('new')[0].a.should.equal(555);
+      idx.getMatching('again')[0].a.should.equal(666);
+    });
+
+  });   // ==== End of 'Resetting' ==== //
+
+  it('Get all elements in the index', function () {
+    var idx = new Index({ fieldName: 'a' })
+      , doc1 = { a: 5, tf: 'hello' }
+      , doc2 = { a: 8, tf: 'world' }
+      , doc3 = { a: 2, tf: 'bloup' }
+      ;
+
+    idx.insert(doc1);
+    idx.insert(doc2);
+    idx.insert(doc3);
+
+    assert.deepEqual(idx.getAll(), [{ a: 2, tf: 'bloup' }, { a: 5, tf: 'hello' }, { a: 8, tf: 'world' }]);
+  });
+
+
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,176 +1,184 @@
-var model = require('../src/nedb/model')
-  , should = require('chai').should()
-  , assert = require('chai').assert
-  , expect = require('chai').expect
-  , _ = require('underscore')
-  , async = require('async')
-  , util = require('util')
-  , Datastore = require('../src/nedb/datastore')
-  , fs = require('fs')
-  ;
-
+const model = require('../src/nedb/model')
+const should = require('chai').should()
+const assert = require('chai').assert
+const expect = require('chai').expect
+const _ = require('underscore')
+const async = require('async')
+const util = require('util')
+const Datastore = require('../src/nedb/datastore')
+const fs = require('fs')
 
 describe('Model', function () {
 
   describe('Serialization, deserialization', function () {
 
     it('Can serialize and deserialize strings', function () {
-      var a, b, c;
+      let a
+      let b
+      let c
 
-      a = { test: "Some string" };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      c.test.should.equal("Some string");
+      a = { test: 'Some string' }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      c.test.should.equal('Some string')
 
       // Even if a property is a string containing a new line, the serialized
       // version doesn't. The new line must still be there upon deserialization
-      a = { test: "With a new\nline" };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      c.test.should.equal("With a new\nline");
-      a.test.indexOf('\n').should.not.equal(-1);
-      b.indexOf('\n').should.equal(-1);
-      c.test.indexOf('\n').should.not.equal(-1);
-    });
+      a = { test: 'With a new\nline' }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      c.test.should.equal('With a new\nline')
+      a.test.indexOf('\n').should.not.equal(-1)
+      b.indexOf('\n').should.equal(-1)
+      c.test.indexOf('\n').should.not.equal(-1)
+    })
 
     it('Can serialize and deserialize booleans', function () {
-      var a, b, c;
+      let a
+      let b
+      let c
 
-      a = { test: true };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      c.test.should.equal(true);
-    });
+      a = { test: true }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      c.test.should.equal(true)
+    })
 
     it('Can serialize and deserialize numbers', function () {
-      var a, b, c;
+      let a
+      let b
+      let c
 
-      a = { test: 5 };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      c.test.should.equal(5);
-    });
+      a = { test: 5 }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      c.test.should.equal(5)
+    })
 
     it('Can serialize and deserialize null', function () {
-      var a, b, c;
+      let a
+      let b
+      let c
 
-      a = { test: null };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      assert.isNull(a.test);
-    });
+      a = { test: null }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      assert.isNull(a.test)
+    })
 
-    it('undefined fields are removed when serialized', function() {
-      var a = { bloup: undefined, hello: 'world' }
-        , b = model.serialize(a)
-        , c = model.deserialize(b)
-        ;
+    it('undefined fields are removed when serialized', function () {
+      const a = { bloup: undefined, hello: 'world' }
+      const b = model.serialize(a)
+      const c = model.deserialize(b)
 
-      Object.keys(c).length.should.equal(1);
-      c.hello.should.equal('world');
-      assert.isUndefined(c.bloup);
-    });
+      Object.keys(c).length.should.equal(1)
+      c.hello.should.equal('world')
+      assert.isUndefined(c.bloup)
+    })
 
     it('Can serialize and deserialize a date', function () {
-      var a, b, c
-        , d = new Date();
+      let a
+      let b
+      let c
+      const d = new Date()
 
-      a = { test: d };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      b.should.equal('{"test":{"$$date":' + d.getTime() + '}}');
-      util.isDate(c.test).should.equal(true);
-      c.test.getTime().should.equal(d.getTime());
-    });
+      a = { test: d }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      b.should.equal('{"test":{"$$date":' + d.getTime() + '}}')
+      util.isDate(c.test).should.equal(true)
+      c.test.getTime().should.equal(d.getTime())
+    })
 
     it('Can serialize and deserialize sub objects', function () {
-      var a, b, c
-        , d = new Date();
+      let a, b, c
+      const d = new Date()
 
-      a = { test: { something: 39, also: d, yes: { again: 'yes' } } };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      c.test.something.should.equal(39);
-      c.test.also.getTime().should.equal(d.getTime());
-      c.test.yes.again.should.equal('yes');
-    });
+      a = { test: { something: 39, also: d, yes: { again: 'yes' } } }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      c.test.something.should.equal(39)
+      c.test.also.getTime().should.equal(d.getTime())
+      c.test.yes.again.should.equal('yes')
+    })
 
     it('Can serialize and deserialize sub arrays', function () {
-      var a, b, c
-        , d = new Date();
+      let a
+      let b
+      let c
+      const d = new Date()
 
-      a = { test: [ 39, d, { again: 'yes' } ] };
-      b = model.serialize(a);
-      c = model.deserialize(b);
-      b.indexOf('\n').should.equal(-1);
-      c.test[0].should.equal(39);
-      c.test[1].getTime().should.equal(d.getTime());
-      c.test[2].again.should.equal('yes');
-    });
+      a = { test: [39, d, { again: 'yes' }] }
+      b = model.serialize(a)
+      c = model.deserialize(b)
+      b.indexOf('\n').should.equal(-1)
+      c.test[0].should.equal(39)
+      c.test[1].getTime().should.equal(d.getTime())
+      c.test[2].again.should.equal('yes')
+    })
 
     it('Reject field names beginning with a $ sign or containing a dot, except the four edge cases', function () {
-      var a1 = { $something: 'totest' }
-        , a2 = { "with.dot": 'totest' }
-        , e1 = { $$date: 4321 }
-        , e2 = { $$deleted: true }
-        , e3 = { $$indexCreated: "indexName" }
-        , e4 = { $$indexRemoved: "indexName" }
-        , b;
+      const a1 = { $something: 'totest' }
+      const a2 = { 'with.dot': 'totest' }
+      const e1 = { $$date: 4321 }
+      const e2 = { $$deleted: true }
+      const e3 = { $$indexCreated: 'indexName' }
+      const e4 = { $$indexRemoved: 'indexName' }
+      let b
 
       // Normal cases
-      (function () { b = model.serialize(a1); }).should.throw();
-      (function () { b = model.serialize(a2); }).should.throw();
+      (function () { b = model.serialize(a1) }).should.throw();
+      (function () { b = model.serialize(a2) }).should.throw()
 
       // Edge cases
-      b = model.serialize(e1);
-      b = model.serialize(e2);
-      b = model.serialize(e3);
-      b = model.serialize(e4);
-    });
+      b = model.serialize(e1)
+      b = model.serialize(e2)
+      b = model.serialize(e3)
+      b = model.serialize(e4)
+    })
 
     it('Can serialize string fields with a new line without breaking the DB', function (done) {
-      var db1, db2
-        , badString = "world\r\nearth\nother\rline"
-      ;
+      let db1
+      let db2
+      const badString = 'world\r\nearth\nother\rline'
 
-      if (fs.existsSync('workspace/test1.db')) { fs.unlinkSync('workspace/test1.db'); }
-      fs.existsSync('workspace/test1.db').should.equal(false);
-      db1 = new Datastore({ filename: 'workspace/test1.db' });
+      if (fs.existsSync('workspace/test1.db')) { fs.unlinkSync('workspace/test1.db') }
+      fs.existsSync('workspace/test1.db').should.equal(false)
+      db1 = new Datastore({ filename: 'workspace/test1.db' })
 
       db1.loadDatabase(function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
         db1.insert({ hello: badString }, function (err) {
-          assert.isNull(err);
+          assert.isNull(err)
 
-          db2 = new Datastore({ filename: 'workspace/test1.db' });
+          db2 = new Datastore({ filename: 'workspace/test1.db' })
           db2.loadDatabase(function (err) {
-            assert.isNull(err);
+            assert.isNull(err)
             db2.find({}, function (err, docs) {
-              assert.isNull(err);
-              docs.length.should.equal(1);
-              docs[0].hello.should.equal(badString);
+              assert.isNull(err)
+              docs.length.should.equal(1)
+              docs[0].hello.should.equal(badString)
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
     it('Can accept objects whose keys are numbers', function () {
-      var o = { 42: true };
+      const o = { 42: true }
 
-      var s = model.serialize(o);
-    });
+      const s = model.serialize(o)
+    })
 
-  });   // ==== End of 'Serialization, deserialization' ==== //
-
+  })   // ==== End of 'Serialization, deserialization' ==== //
 
   describe('Object checking', function () {
 
@@ -178,945 +186,988 @@ describe('Model', function () {
       assert.isDefined(model.checkObject);
 
       (function () {
-        model.checkObject({ $bad: true });
+        model.checkObject({ $bad: true })
       }).should.throw();
 
       (function () {
-        model.checkObject({ some: 42, nested: { again: "no", $worse: true } });
-      }).should.throw();
+        model.checkObject({ some: 42, nested: { again: 'no', $worse: true } })
+      }).should.throw()
 
       // This shouldn't throw since "$actuallyok" is not a field name
-      model.checkObject({ some: 42, nested: [ 5, "no", "$actuallyok", true ] });
+      model.checkObject({ some: 42, nested: [5, 'no', '$actuallyok', true] });
 
       (function () {
-        model.checkObject({ some: 42, nested: [ 5, "no", "$actuallyok", true, { $hidden: "useless" } ] });
-      }).should.throw();
-    });
+        model.checkObject({ some: 42, nested: [5, 'no', '$actuallyok', true, { $hidden: 'useless' }] })
+      }).should.throw()
+    })
 
     it('Field names cannot contain a .', function () {
       assert.isDefined(model.checkObject);
 
       (function () {
-        model.checkObject({ "so.bad": true });
-      }).should.throw();
+        model.checkObject({ 'so.bad': true })
+      }).should.throw()
 
       // Recursive behaviour testing done in the above test on $ signs
-    });
+    })
 
     it('Properties with a null value dont trigger an error', function () {
-      var obj = { prop: null };
+      const obj = { prop: null }
 
-      model.checkObject(obj);
-    });
+      model.checkObject(obj)
+    })
 
     it('Can check if an object is a primitive or not', function () {
-      model.isPrimitiveType(5).should.equal(true);
-      model.isPrimitiveType('sdsfdfs').should.equal(true);
-      model.isPrimitiveType(0).should.equal(true);
-      model.isPrimitiveType(true).should.equal(true);
-      model.isPrimitiveType(false).should.equal(true);
-      model.isPrimitiveType(new Date()).should.equal(true);
-      model.isPrimitiveType([]).should.equal(true);
-      model.isPrimitiveType([3, 'try']).should.equal(true);
-      model.isPrimitiveType(null).should.equal(true);
+      model.isPrimitiveType(5).should.equal(true)
+      model.isPrimitiveType('sdsfdfs').should.equal(true)
+      model.isPrimitiveType(0).should.equal(true)
+      model.isPrimitiveType(true).should.equal(true)
+      model.isPrimitiveType(false).should.equal(true)
+      model.isPrimitiveType(new Date()).should.equal(true)
+      model.isPrimitiveType([]).should.equal(true)
+      model.isPrimitiveType([3, 'try']).should.equal(true)
+      model.isPrimitiveType(null).should.equal(true)
 
-      model.isPrimitiveType({}).should.equal(false);
-      model.isPrimitiveType({ a: 42 }).should.equal(false);
-    });
+      model.isPrimitiveType({}).should.equal(false)
+      model.isPrimitiveType({ a: 42 }).should.equal(false)
+    })
 
-  });   // ==== End of 'Object checking' ==== //
-
+  })   // ==== End of 'Object checking' ==== //
 
   describe('Deep copying', function () {
 
     it('Should be able to deep copy any serializable model', function () {
-      var d = new Date()
-        , obj = { a: ['ee', 'ff', 42], date: d, subobj: { a: 'b', b: 'c' } }
-        , res = model.deepCopy(obj);
-        ;
+      const d = new Date()
+      const obj = { a: ['ee', 'ff', 42], date: d, subobj: { a: 'b', b: 'c' } }
+      const res = model.deepCopy(obj)
 
-      res.a.length.should.equal(3);
-      res.a[0].should.equal('ee');
-      res.a[1].should.equal('ff');
-      res.a[2].should.equal(42);
-      res.date.getTime().should.equal(d.getTime());
-      res.subobj.a.should.equal('b');
-      res.subobj.b.should.equal('c');
+      res.a.length.should.equal(3)
+      res.a[0].should.equal('ee')
+      res.a[1].should.equal('ff')
+      res.a[2].should.equal(42)
+      res.date.getTime().should.equal(d.getTime())
+      res.subobj.a.should.equal('b')
+      res.subobj.b.should.equal('c')
 
-      obj.a.push('ggg');
-      obj.date = 'notadate';
-      obj.subobj = [];
+      obj.a.push('ggg')
+      obj.date = 'notadate'
+      obj.subobj = []
 
       // Even if the original object is modified, the copied one isn't
-      res.a.length.should.equal(3);
-      res.a[0].should.equal('ee');
-      res.a[1].should.equal('ff');
-      res.a[2].should.equal(42);
-      res.date.getTime().should.equal(d.getTime());
-      res.subobj.a.should.equal('b');
-      res.subobj.b.should.equal('c');
-    });
+      res.a.length.should.equal(3)
+      res.a[0].should.equal('ee')
+      res.a[1].should.equal('ff')
+      res.a[2].should.equal(42)
+      res.date.getTime().should.equal(d.getTime())
+      res.subobj.a.should.equal('b')
+      res.subobj.b.should.equal('c')
+    })
 
     it('Should deep copy the contents of an array', function () {
-      var a = [{ hello: 'world' }]
-        , b = model.deepCopy(a)
-      ;
+      const a = [{ hello: 'world' }]
+      const b = model.deepCopy(a)
 
-      b[0].hello.should.equal('world');
-      b[0].hello = 'another';
-      b[0].hello.should.equal('another');
-      a[0].hello.should.equal('world');
-    });
+      b[0].hello.should.equal('world')
+      b[0].hello = 'another'
+      b[0].hello.should.equal('another')
+      a[0].hello.should.equal('world')
+    })
 
     it('Without the strictKeys option, everything gets deep copied', function () {
-      var a = { a: 4, $e: 'rrr', 'eee.rt': 42, nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 }, array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }] }
-        , b = model.deepCopy(a)
-      ;
+      const a = {
+        a: 4,
+        $e: 'rrr',
+        'eee.rt': 42,
+        nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 },
+        array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }]
+      }
+      const b = model.deepCopy(a)
 
-      assert.deepEqual(a, b);
-    });
+      assert.deepEqual(a, b)
+    })
 
     it('With the strictKeys option, only valid keys gets deep copied', function () {
-      var a = { a: 4, $e: 'rrr', 'eee.rt': 42, nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 }, array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }] }
-        , b = model.deepCopy(a, true)
-      ;
+      const a = {
+        a: 4,
+        $e: 'rrr',
+        'eee.rt': 42,
+        nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 },
+        array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }]
+      }
+      const b = model.deepCopy(a, true)
 
-      assert.deepEqual(b, { a: 4, nested: { yes: 1 }, array: [{}, { yes: true }, {}] });
-    });
+      assert.deepEqual(b, { a: 4, nested: { yes: 1 }, array: [{}, { yes: true }, {}] })
+    })
 
-  });   // ==== End of 'Deep copying' ==== //
-
+  })   // ==== End of 'Deep copying' ==== //
 
   describe('Modifying documents', function () {
 
     it('Queries not containing any modifier just replace the document by the contents of the query but keep its _id', function () {
-      var obj = { some: 'thing', _id: 'keepit' }
-        , updateQuery = { replace: 'done', bloup: [ 1, 8] }
-        , t
-        ;
+      const obj = { some: 'thing', _id: 'keepit' }
+      const updateQuery = { replace: 'done', bloup: [1, 8] }
+      let t
 
-      t = model.modify(obj, updateQuery);
-      t.replace.should.equal('done');
-      t.bloup.length.should.equal(2);
-      t.bloup[0].should.equal(1);
-      t.bloup[1].should.equal(8);
+      t = model.modify(obj, updateQuery)
+      t.replace.should.equal('done')
+      t.bloup.length.should.equal(2)
+      t.bloup[0].should.equal(1)
+      t.bloup[1].should.equal(8)
 
-      assert.isUndefined(t.some);
-      t._id.should.equal('keepit');
-    });
+      assert.isUndefined(t.some)
+      t._id.should.equal('keepit')
+    })
 
     it('Throw an error if trying to change the _id field in a copy-type modification', function () {
-      var obj = { some: 'thing', _id: 'keepit' }
-        , updateQuery = { replace: 'done', bloup: [ 1, 8], _id: 'donttryit' }
-        ;
+      const obj = { some: 'thing', _id: 'keepit' }
+      const updateQuery = { replace: 'done', bloup: [1, 8], _id: 'donttryit' }
 
       expect(function () {
-        model.modify(obj, updateQuery);
-      }).to.throw("You cannot change a document's _id");
+        model.modify(obj, updateQuery)
+      }).to.throw('You cannot change a document\'s _id')
 
-      updateQuery._id = 'keepit';
-      model.modify(obj, updateQuery);   // No error thrown
-    });
+      updateQuery._id = 'keepit'
+      model.modify(obj, updateQuery)   // No error thrown
+    })
 
     it('Throw an error if trying to use modify in a mixed copy+modify way', function () {
-      var obj = { some: 'thing' }
-        , updateQuery = { replace: 'me', $modify: 'metoo' };
+      const obj = { some: 'thing' }
+      const updateQuery = { replace: 'me', $modify: 'metoo' }
 
       expect(function () {
-        model.modify(obj, updateQuery);
-      }).to.throw("You cannot mix modifiers and normal fields");
-    });
+        model.modify(obj, updateQuery)
+      }).to.throw('You cannot mix modifiers and normal fields')
+    })
 
     it('Throw an error if trying to use an inexistent modifier', function () {
-      var obj = { some: 'thing' }
-        , updateQuery = { $set: { it: 'exists' }, $modify: 'not this one' };
+      const obj = { some: 'thing' }
+      const updateQuery = { $set: { it: 'exists' }, $modify: 'not this one' }
 
       expect(function () {
-        model.modify(obj, updateQuery);
-      }).to.throw(/^Unknown modifier .modify/);
-    });
+        model.modify(obj, updateQuery)
+      }).to.throw(/^Unknown modifier .modify/)
+    })
 
     it('Throw an error if a modifier is used with a non-object argument', function () {
-      var obj = { some: 'thing' }
-        , updateQuery = { $set: 'this exists' };
+      const obj = { some: 'thing' }
+      const updateQuery = { $set: 'this exists' }
 
       expect(function () {
-        model.modify(obj, updateQuery);
-      }).to.throw(/Modifier .set's argument must be an object/);
-    });
+        model.modify(obj, updateQuery)
+      }).to.throw(/Modifier .set's argument must be an object/)
+    })
 
     describe('$set modifier', function () {
       it('Can change already set fields without modfifying the underlying object', function () {
-        var obj = { some: 'thing', yup: 'yes', nay: 'noes' }
-          , updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
-          , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', yup: 'yes', nay: 'noes' }
+        const updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
+        const modified = model.modify(obj, updateQuery)
 
-        Object.keys(modified).length.should.equal(3);
-        modified.some.should.equal('changed');
-        modified.yup.should.equal('yes');
-        modified.nay.should.equal('yes indeed');
+        Object.keys(modified).length.should.equal(3)
+        modified.some.should.equal('changed')
+        modified.yup.should.equal('yes')
+        modified.nay.should.equal('yes indeed')
 
-        Object.keys(obj).length.should.equal(3);
-        obj.some.should.equal('thing');
-        obj.yup.should.equal('yes');
-        obj.nay.should.equal('noes');
-      });
+        Object.keys(obj).length.should.equal(3)
+        obj.some.should.equal('thing')
+        obj.yup.should.equal('yes')
+        obj.nay.should.equal('noes')
+      })
 
       it('Creates fields to set if they dont exist yet', function () {
-        var obj = { yup: 'yes' }
-          , updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
-          , modified = model.modify(obj, updateQuery);
+        const obj = { yup: 'yes' }
+        const updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
+        const modified = model.modify(obj, updateQuery)
 
-        Object.keys(modified).length.should.equal(3);
-        modified.some.should.equal('changed');
-        modified.yup.should.equal('yes');
-        modified.nay.should.equal('yes indeed');
-      });
+        Object.keys(modified).length.should.equal(3)
+        modified.some.should.equal('changed')
+        modified.yup.should.equal('yes')
+        modified.nay.should.equal('yes indeed')
+      })
 
       it('Can set sub-fields and create them if necessary', function () {
-        var obj = { yup: { subfield: 'bloup' } }
-          , updateQuery = { $set: { "yup.subfield": 'changed', "yup.yop": 'yes indeed', "totally.doesnt.exist": 'now it does' } }
-          , modified = model.modify(obj, updateQuery);
+        const obj = { yup: { subfield: 'bloup' } }
+        const updateQuery = {
+          $set: {
+            'yup.subfield': 'changed',
+            'yup.yop': 'yes indeed',
+            'totally.doesnt.exist': 'now it does'
+          }
+        }
+        const modified = model.modify(obj, updateQuery)
 
-        _.isEqual(modified, { yup: { subfield: 'changed', yop: 'yes indeed' }, totally: { doesnt: { exist: 'now it does' } } }).should.equal(true);
-      });
+        _.isEqual(modified, {
+          yup: { subfield: 'changed', yop: 'yes indeed' },
+          totally: { doesnt: { exist: 'now it does' } }
+        }).should.equal(true)
+      })
 
-      it("Doesn't replace a falsy field by an object when recursively following dot notation", function () {
-        var obj = { nested: false }
-          , updateQuery = { $set: { "nested.now": 'it is' } }
-          , modified = model.modify(obj, updateQuery);
+      it('Doesn\'t replace a falsy field by an object when recursively following dot notation', function () {
+        const obj = { nested: false }
+        const updateQuery = { $set: { 'nested.now': 'it is' } }
+        const modified = model.modify(obj, updateQuery)
 
-        assert.deepEqual(modified, { nested: false });   // Object not modified as the nested field doesn't exist
-      });
-    });   // End of '$set modifier'
+        assert.deepEqual(modified, { nested: false })   // Object not modified as the nested field doesn't exist
+      })
+    })   // End of '$set modifier'
 
     describe('$unset modifier', function () {
 
       it('Can delete a field, not throwing an error if the field doesnt exist', function () {
-        var obj, updateQuery, modified;
+        let obj
+        let updateQuery
+        let modified
 
         obj = { yup: 'yes', other: 'also' }
         updateQuery = { $unset: { yup: true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, { other: 'also' });
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, { other: 'also' })
 
         obj = { yup: 'yes', other: 'also' }
         updateQuery = { $unset: { nope: true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, obj);
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, obj)
 
         obj = { yup: 'yes', other: 'also' }
         updateQuery = { $unset: { nope: true, other: true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, { yup: 'yes' });
-      });
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, { yup: 'yes' })
+      })
 
       it('Can unset sub-fields and entire nested documents', function () {
-        var obj, updateQuery, modified;
+        let obj
+        let updateQuery
+        let modified
 
         obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
         updateQuery = { $unset: { nested: true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, { yup: 'yes' });
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, { yup: 'yes' })
 
         obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
         updateQuery = { $unset: { 'nested.a': true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, { yup: 'yes', nested: { b: 'yeah' } });
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, { yup: 'yes', nested: { b: 'yeah' } })
 
         obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
         updateQuery = { $unset: { 'nested.a': true, 'nested.b': true } }
-        modified = model.modify(obj, updateQuery);
-        assert.deepEqual(modified, { yup: 'yes', nested: {} });
-      });
+        modified = model.modify(obj, updateQuery)
+        assert.deepEqual(modified, { yup: 'yes', nested: {} })
+      })
 
-      it("When unsetting nested fields, should not create an empty parent to nested field", function () {
-        var obj = model.modify({ argh: true }, { $unset: { 'bad.worse': true } });
-        assert.deepEqual(obj, { argh: true });
+      it('When unsetting nested fields, should not create an empty parent to nested field', function () {
+        let obj = model.modify({ argh: true }, { $unset: { 'bad.worse': true } })
+        assert.deepEqual(obj, { argh: true })
 
-        obj = model.modify({ argh: true, bad: { worse: 'oh' } }, { $unset: { 'bad.worse': true } });
-        assert.deepEqual(obj, { argh: true, bad: {} });
+        obj = model.modify({ argh: true, bad: { worse: 'oh' } }, { $unset: { 'bad.worse': true } })
+        assert.deepEqual(obj, { argh: true, bad: {} })
 
-        obj = model.modify({ argh: true, bad: {} }, { $unset: { 'bad.worse': true } });
-        assert.deepEqual(obj, { argh: true, bad: {} });
-      });
+        obj = model.modify({ argh: true, bad: {} }, { $unset: { 'bad.worse': true } })
+        assert.deepEqual(obj, { argh: true, bad: {} })
+      })
 
-    });   // End of '$unset modifier'
+    })   // End of '$unset modifier'
 
     describe('$inc modifier', function () {
       it('Throw an error if you try to use it with a non-number or on a non number field', function () {
         (function () {
-          var obj = { some: 'thing', yup: 'yes', nay: 2 }
-            , updateQuery = { $inc: { nay: 'notanumber' } }
-            , modified = model.modify(obj, updateQuery);
+          const obj = { some: 'thing', yup: 'yes', nay: 2 }
+          const updateQuery = { $inc: { nay: 'notanumber' } }
+          const modified = model.modify(obj, updateQuery)
         }).should.throw();
 
         (function () {
-          var obj = { some: 'thing', yup: 'yes', nay: 'nope' }
-            , updateQuery = { $inc: { nay: 1 } }
-            , modified = model.modify(obj, updateQuery);
-        }).should.throw();
-      });
+          const obj = { some: 'thing', yup: 'yes', nay: 'nope' }
+          const updateQuery = { $inc: { nay: 1 } }
+          const modified = model.modify(obj, updateQuery)
+        }).should.throw()
+      })
 
       it('Can increment number fields or create and initialize them if needed', function () {
-        var obj = { some: 'thing', nay: 40 }
-          , modified;
+        const obj = { some: 'thing', nay: 40 }
+        let modified
 
-        modified = model.modify(obj, { $inc: { nay: 2 } });
-        _.isEqual(modified, { some: 'thing', nay: 42 }).should.equal(true);
+        modified = model.modify(obj, { $inc: { nay: 2 } })
+        _.isEqual(modified, { some: 'thing', nay: 42 }).should.equal(true)
 
         // Incidentally, this tests that obj was not modified
-        modified = model.modify(obj, { $inc: { inexistent: -6 } });
-        _.isEqual(modified, { some: 'thing', nay: 40, inexistent: -6 }).should.equal(true);
-      });
+        modified = model.modify(obj, { $inc: { inexistent: -6 } })
+        _.isEqual(modified, { some: 'thing', nay: 40, inexistent: -6 }).should.equal(true)
+      })
 
       it('Works recursively', function () {
-        var obj = { some: 'thing', nay: { nope: 40 } }
-          , modified;
+        const obj = { some: 'thing', nay: { nope: 40 } }
+        let modified
 
-        modified = model.modify(obj, { $inc: { "nay.nope": -2, "blip.blop": 123 } });
-        _.isEqual(modified, { some: 'thing', nay: { nope: 38 }, blip: { blop: 123 } }).should.equal(true);
-      });
-    });   // End of '$inc modifier'
+        modified = model.modify(obj, { $inc: { 'nay.nope': -2, 'blip.blop': 123 } })
+        _.isEqual(modified, { some: 'thing', nay: { nope: 38 }, blip: { blop: 123 } }).should.equal(true)
+      })
+    })   // End of '$inc modifier'
 
     describe('$push modifier', function () {
 
       it('Can push an element to the end of an array', function () {
-        var obj = { arr: ['hello'] }
-          , modified;
+        const obj = { arr: ['hello'] }
+        let modified
 
-        modified = model.modify(obj, { $push: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['hello', 'world'] });
-      });
+        modified = model.modify(obj, { $push: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['hello', 'world'] })
+      })
 
       it('Can push an element to a non-existent field and will create the array', function () {
-        var obj = {}
-          , modified;
+        const obj = {}
+        let modified
 
-        modified = model.modify(obj, { $push: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['world'] });
-      });
+        modified = model.modify(obj, { $push: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['world'] })
+      })
 
       it('Can push on nested fields', function () {
-        var obj = { arr: { nested: ['hello'] } }
-          , modified;
+        let obj = { arr: { nested: ['hello'] } }
+        let modified
 
-        modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
-        assert.deepEqual(modified, { arr: { nested: ['hello', 'world'] } });
+        modified = model.modify(obj, { $push: { 'arr.nested': 'world' } })
+        assert.deepEqual(modified, { arr: { nested: ['hello', 'world'] } })
 
-        obj = { arr: { a: 2 }};
-        modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
-        assert.deepEqual(modified, { arr: { a: 2, nested: ['world'] } });
-      });
+        obj = { arr: { a: 2 } }
+        modified = model.modify(obj, { $push: { 'arr.nested': 'world' } })
+        assert.deepEqual(modified, { arr: { a: 2, nested: ['world'] } })
+      })
 
       it('Throw if we try to push to a non-array', function () {
-        var obj = { arr: 'hello' }
-          , modified;
+        let obj = { arr: 'hello' }
+        let modified
 
         (function () {
-          modified = model.modify(obj, { $push: { arr: 'world' } });
-        }).should.throw();
+          modified = model.modify(obj, { $push: { arr: 'world' } })
+        }).should.throw()
 
         obj = { arr: { nested: 45 } };
         (function () {
-          modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $push: { 'arr.nested': 'world' } })
+        }).should.throw()
+      })
 
       it('Can use the $each modifier to add multiple values to an array at once', function () {
-        var obj = { arr: ['hello'] }
-          , modified;
+        const obj = { arr: ['hello'] }
+        let modified
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'] } } });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'] } } })
         assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
 
         (function () {
-          modified = model.modify(obj, { $push: { arr: { $each: 45 } } });
+          modified = model.modify(obj, { $push: { arr: { $each: 45 } } })
         }).should.throw();
 
         (function () {
-          modified = model.modify(obj, { $push: { arr: { $each: ['world'], unauthorized: true } } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $push: { arr: { $each: ['world'], unauthorized: true } } })
+        }).should.throw()
+      })
 
       it('Can use the $slice modifier to limit the number of array elements', function () {
-        var obj = { arr: ['hello'] }
-          , modified;
+        const obj = { arr: ['hello'] }
+        let modified
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 1 } } });
-        assert.deepEqual(modified, { arr: ['hello'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 1 } } })
+        assert.deepEqual(modified, { arr: ['hello'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -1 } } });
-        assert.deepEqual(modified, { arr: ['everything'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -1 } } })
+        assert.deepEqual(modified, { arr: ['everything'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 0 } } });
-        assert.deepEqual(modified, { arr: [] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 0 } } })
+        assert.deepEqual(modified, { arr: [] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 2 } } });
-        assert.deepEqual(modified, { arr: ['hello', 'world'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 2 } } })
+        assert.deepEqual(modified, { arr: ['hello', 'world'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -2 } } });
-        assert.deepEqual(modified, { arr: ['earth', 'everything'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -2 } } })
+        assert.deepEqual(modified, { arr: ['earth', 'everything'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -20 } } });
-        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -20 } } })
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 20 } } });
-        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 20 } } })
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] })
 
-        modified = model.modify(obj, { $push: { arr: { $each: [], $slice: 1 } } });
-        assert.deepEqual(modified, { arr: ['hello'] });
+        modified = model.modify(obj, { $push: { arr: { $each: [], $slice: 1 } } })
+        assert.deepEqual(modified, { arr: ['hello'] })
 
         // $each not specified, but $slice is
-        modified = model.modify(obj, { $push: { arr: { $slice: 1 } } });
+        modified = model.modify(obj, { $push: { arr: { $slice: 1 } } })
         assert.deepEqual(modified, { arr: ['hello'] });
 
         (function () {
-          modified = model.modify(obj, { $push: { arr: { $slice: 1, unauthorized: true } } });
+          modified = model.modify(obj, { $push: { arr: { $slice: 1, unauthorized: true } } })
         }).should.throw();
 
         (function () {
-          modified = model.modify(obj, { $push: { arr: { $each: [], unauthorized: true } } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $push: { arr: { $each: [], unauthorized: true } } })
+        }).should.throw()
+      })
 
-    });   // End of '$push modifier'
+    })   // End of '$push modifier'
 
     describe('$addToSet modifier', function () {
 
       it('Can add an element to a set', function () {
-        var obj = { arr: ['hello'] }
-          , modified;
+        let obj = { arr: ['hello'] }
+        let modified
 
-        modified = model.modify(obj, { $addToSet: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['hello', 'world'] });
+        modified = model.modify(obj, { $addToSet: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['hello', 'world'] })
 
-        obj = { arr: ['hello'] };
-        modified = model.modify(obj, { $addToSet: { arr: 'hello' } });
-        assert.deepEqual(modified, { arr: ['hello'] });
-      });
+        obj = { arr: ['hello'] }
+        modified = model.modify(obj, { $addToSet: { arr: 'hello' } })
+        assert.deepEqual(modified, { arr: ['hello'] })
+      })
 
       it('Can add an element to a non-existent set and will create the array', function () {
-        var obj = { arr: [] }
-          , modified;
+        const obj = { arr: [] }
+        let modified
 
-        modified = model.modify(obj, { $addToSet: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['world'] });
-      });
+        modified = model.modify(obj, { $addToSet: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['world'] })
+      })
 
       it('Throw if we try to addToSet to a non-array', function () {
-        var obj = { arr: 'hello' }
-          , modified;
+        const obj = { arr: 'hello' }
+        let modified
 
         (function () {
-          modified = model.modify(obj, { $addToSet: { arr: 'world' } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $addToSet: { arr: 'world' } })
+        }).should.throw()
+      })
 
       it('Use deep-equality to check whether we can add a value to a set', function () {
-        var obj = { arr: [ { b: 2 } ] }
-          , modified;
+        let obj = { arr: [{ b: 2 }] }
+        let modified
 
-        modified = model.modify(obj, { $addToSet: { arr: { b: 3 } } });
-        assert.deepEqual(modified, { arr: [{ b: 2 }, { b: 3 }] });
+        modified = model.modify(obj, { $addToSet: { arr: { b: 3 } } })
+        assert.deepEqual(modified, { arr: [{ b: 2 }, { b: 3 }] })
 
-        obj = { arr: [ { b: 2 } ] }
-        modified = model.modify(obj, { $addToSet: { arr: { b: 2 } } });
-        assert.deepEqual(modified, { arr: [{ b: 2 }] });
-      });
+        obj = { arr: [{ b: 2 }] }
+        modified = model.modify(obj, { $addToSet: { arr: { b: 2 } } })
+        assert.deepEqual(modified, { arr: [{ b: 2 }] })
+      })
 
       it('Can use the $each modifier to add multiple values to a set at once', function () {
-        var obj = { arr: ['hello'] }
-          , modified;
+        const obj = { arr: ['hello'] }
+        let modified
 
-        modified = model.modify(obj, { $addToSet: { arr: { $each: ['world', 'earth', 'hello', 'earth'] } } });
+        modified = model.modify(obj, { $addToSet: { arr: { $each: ['world', 'earth', 'hello', 'earth'] } } })
         assert.deepEqual(modified, { arr: ['hello', 'world', 'earth'] });
 
         (function () {
-          modified = model.modify(obj, { $addToSet: { arr: { $each: 45 } } });
+          modified = model.modify(obj, { $addToSet: { arr: { $each: 45 } } })
         }).should.throw();
 
         (function () {
-          modified = model.modify(obj, { $addToSet: { arr: { $each: ['world'], unauthorized: true } } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $addToSet: { arr: { $each: ['world'], unauthorized: true } } })
+        }).should.throw()
+      })
 
-    });   // End of '$addToSet modifier'
+    })   // End of '$addToSet modifier'
 
     describe('$pop modifier', function () {
 
       it('Throw if called on a non array, a non defined field or a non integer', function () {
-        var obj = { arr: 'hello' }
-          , modified;
+        let obj = { arr: 'hello' }
+        let modified
 
         (function () {
-          modified = model.modify(obj, { $pop: { arr: 1 } });
-        }).should.throw();
+          modified = model.modify(obj, { $pop: { arr: 1 } })
+        }).should.throw()
 
         obj = { bloup: 'nope' };
         (function () {
-          modified = model.modify(obj, { $pop: { arr: 1 } });
-        }).should.throw();
+          modified = model.modify(obj, { $pop: { arr: 1 } })
+        }).should.throw()
 
         obj = { arr: [1, 4, 8] };
         (function () {
-          modified = model.modify(obj, { $pop: { arr: true } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $pop: { arr: true } })
+        }).should.throw()
+      })
 
       it('Can remove the first and last element of an array', function () {
-        var obj
-          , modified;
+        let obj
+        let modified
 
-        obj = { arr: [1, 4, 8] };
-        modified = model.modify(obj, { $pop: { arr: 1 } });
-        assert.deepEqual(modified, { arr: [1, 4] });
+        obj = { arr: [1, 4, 8] }
+        modified = model.modify(obj, { $pop: { arr: 1 } })
+        assert.deepEqual(modified, { arr: [1, 4] })
 
-        obj = { arr: [1, 4, 8] };
-        modified = model.modify(obj, { $pop: { arr: -1 } });
-        assert.deepEqual(modified, { arr: [4, 8] });
+        obj = { arr: [1, 4, 8] }
+        modified = model.modify(obj, { $pop: { arr: -1 } })
+        assert.deepEqual(modified, { arr: [4, 8] })
 
         // Empty arrays are not changed
-        obj = { arr: [] };
-        modified = model.modify(obj, { $pop: { arr: 1 } });
-        assert.deepEqual(modified, { arr: [] });
-        modified = model.modify(obj, { $pop: { arr: -1 } });
-        assert.deepEqual(modified, { arr: [] });
-      });
+        obj = { arr: [] }
+        modified = model.modify(obj, { $pop: { arr: 1 } })
+        assert.deepEqual(modified, { arr: [] })
+        modified = model.modify(obj, { $pop: { arr: -1 } })
+        assert.deepEqual(modified, { arr: [] })
+      })
 
-    });   // End of '$pop modifier'
+    })   // End of '$pop modifier'
 
     describe('$pull modifier', function () {
 
       it('Can remove an element from a set', function () {
-        var obj = { arr: ['hello', 'world'] }
-          , modified;
+        let obj = { arr: ['hello', 'world'] }
+        let modified
 
-        modified = model.modify(obj, { $pull: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['hello'] });
+        modified = model.modify(obj, { $pull: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['hello'] })
 
-        obj = { arr: ['hello'] };
-        modified = model.modify(obj, { $pull: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['hello'] });
-      });
+        obj = { arr: ['hello'] }
+        modified = model.modify(obj, { $pull: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['hello'] })
+      })
 
       it('Can remove multiple matching elements', function () {
-        var obj = { arr: ['hello', 'world', 'hello', 'world'] }
-          , modified;
+        const obj = { arr: ['hello', 'world', 'hello', 'world'] }
+        let modified
 
-        modified = model.modify(obj, { $pull: { arr: 'world' } });
-        assert.deepEqual(modified, { arr: ['hello', 'hello'] });
-      });
+        modified = model.modify(obj, { $pull: { arr: 'world' } })
+        assert.deepEqual(modified, { arr: ['hello', 'hello'] })
+      })
 
       it('Throw if we try to pull from a non-array', function () {
-        var obj = { arr: 'hello' }
-          , modified;
+        const obj = { arr: 'hello' }
+        let modified
 
         (function () {
-          modified = model.modify(obj, { $pull: { arr: 'world' } });
-        }).should.throw();
-      });
+          modified = model.modify(obj, { $pull: { arr: 'world' } })
+        }).should.throw()
+      })
 
       it('Use deep-equality to check whether we can remove a value from a set', function () {
-        var obj = { arr: [{ b: 2 }, { b: 3 }] }
-          , modified;
+        let obj = { arr: [{ b: 2 }, { b: 3 }] }
+        let modified
 
-        modified = model.modify(obj, { $pull: { arr: { b: 3 } } });
-        assert.deepEqual(modified, { arr: [ { b: 2 } ] });
+        modified = model.modify(obj, { $pull: { arr: { b: 3 } } })
+        assert.deepEqual(modified, { arr: [{ b: 2 }] })
 
-        obj = { arr: [ { b: 2 } ] }
-        modified = model.modify(obj, { $pull: { arr: { b: 3 } } });
-        assert.deepEqual(modified, { arr: [{ b: 2 }] });
-      });
+        obj = { arr: [{ b: 2 }] }
+        modified = model.modify(obj, { $pull: { arr: { b: 3 } } })
+        assert.deepEqual(modified, { arr: [{ b: 2 }] })
+      })
 
       it('Can use any kind of nedb query with $pull', function () {
-        var obj = { arr: [4, 7, 12, 2], other: 'yup' }
-          , modified
-        ;
+        let obj = { arr: [4, 7, 12, 2], other: 'yup' }
+        let modified
 
-        modified = model.modify(obj, { $pull: { arr: { $gte: 5 } } });
-        assert.deepEqual(modified, { arr: [4, 2], other: 'yup' });
+        modified = model.modify(obj, { $pull: { arr: { $gte: 5 } } })
+        assert.deepEqual(modified, { arr: [4, 2], other: 'yup' })
 
-        obj = { arr: [{ b: 4 }, { b: 7 }, { b: 1 }], other: 'yeah' };
-        modified = model.modify(obj, { $pull: { arr: { b: { $gte: 5} } } });
-        assert.deepEqual(modified, { arr: [{ b: 4 }, { b: 1 }], other: 'yeah' });
-      });
+        obj = { arr: [{ b: 4 }, { b: 7 }, { b: 1 }], other: 'yeah' }
+        modified = model.modify(obj, { $pull: { arr: { b: { $gte: 5 } } } })
+        assert.deepEqual(modified, { arr: [{ b: 4 }, { b: 1 }], other: 'yeah' })
+      })
 
-    });   // End of '$pull modifier'
+    })   // End of '$pull modifier'
 
     describe('$max modifier', function () {
       it('Will set the field to the updated value if value is greater than current one, without modifying the original object', function () {
-        var obj = { some:'thing', number: 10 }
-            , updateQuery = { $max: { number:12 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', number: 10 }
+        const updateQuery = { $max: { number: 12 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', number: 12 });
-        obj.should.deep.equal({ some: 'thing', number: 10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 12 })
+        obj.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Will not update the field if new value is smaller than current one', function () {
-        var obj = { some:'thing', number: 10 }
-            , updateQuery = { $max: { number: 9 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', number: 10 }
+        const updateQuery = { $max: { number: 9 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some:'thing', number:10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Will create the field if it does not exist', function () {
-        var obj = { some: 'thing' }
-            , updateQuery = { $max: { number: 10 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing' }
+        const updateQuery = { $max: { number: 10 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', number: 10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Works on embedded documents', function () {
-        var obj = { some: 'thing', somethingElse: { number:10 } }
-            , updateQuery = { $max: { 'somethingElse.number': 12 } }
-            , modified = model.modify(obj,updateQuery);
+        const obj = { some: 'thing', somethingElse: { number: 10 } }
+        const updateQuery = { $max: { 'somethingElse.number': 12 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', somethingElse: { number:12 } });
-      });
-    });// End of '$max modifier'
+        modified.should.deep.equal({ some: 'thing', somethingElse: { number: 12 } })
+      })
+    })// End of '$max modifier'
 
     describe('$min modifier', function () {
       it('Will set the field to the updated value if value is smaller than current one, without modifying the original object', function () {
-        var obj = { some:'thing', number: 10 }
-            , updateQuery = { $min: { number: 8 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', number: 10 }
+        const updateQuery = { $min: { number: 8 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', number: 8 });
-        obj.should.deep.equal({ some: 'thing', number: 10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 8 })
+        obj.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Will not update the field if new value is greater than current one', function () {
-        var obj = { some: 'thing', number: 10 }
-            , updateQuery = { $min: { number: 12 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', number: 10 }
+        const updateQuery = { $min: { number: 12 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', number: 10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Will create the field if it does not exist', function () {
-        var obj = { some: 'thing' }
-            , updateQuery = { $min: { number: 10 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing' }
+        const updateQuery = { $min: { number: 10 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', number: 10 });
-      });
+        modified.should.deep.equal({ some: 'thing', number: 10 })
+      })
 
       it('Works on embedded documents', function () {
-        var obj = { some: 'thing', somethingElse: { number: 10 } }
-            , updateQuery = { $min: { 'somethingElse.number': 8 } }
-            , modified = model.modify(obj, updateQuery);
+        const obj = { some: 'thing', somethingElse: { number: 10 } }
+        const updateQuery = { $min: { 'somethingElse.number': 8 } }
+        const modified = model.modify(obj, updateQuery)
 
-        modified.should.deep.equal({ some: 'thing', somethingElse: { number: 8 } } );
-      });
-    });// End of '$min modifier'
+        modified.should.deep.equal({ some: 'thing', somethingElse: { number: 8 } })
+      })
+    })// End of '$min modifier'
 
-  });   // ==== End of 'Modifying documents' ==== //
-
+  })   // ==== End of 'Modifying documents' ==== //
 
   describe('Comparing things', function () {
 
     it('undefined is the smallest', function () {
-      var otherStuff = [null, "string", "", -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]];
+      const otherStuff = [null, 'string', '', -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]]
 
-      model.compareThings(undefined, undefined).should.equal(0);
+      model.compareThings(undefined, undefined).should.equal(0)
 
       otherStuff.forEach(function (stuff) {
-        model.compareThings(undefined, stuff).should.equal(-1);
-        model.compareThings(stuff, undefined).should.equal(1);
-      });
-    });
+        model.compareThings(undefined, stuff).should.equal(-1)
+        model.compareThings(stuff, undefined).should.equal(1)
+      })
+    })
 
     it('Then null', function () {
-      var otherStuff = ["string", "", -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]];
+      const otherStuff = ['string', '', -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]]
 
-      model.compareThings(null, null).should.equal(0);
+      model.compareThings(null, null).should.equal(0)
 
       otherStuff.forEach(function (stuff) {
-        model.compareThings(null, stuff).should.equal(-1);
-        model.compareThings(stuff, null).should.equal(1);
-      });
-    });
+        model.compareThings(null, stuff).should.equal(-1)
+        model.compareThings(stuff, null).should.equal(1)
+      })
+    })
 
     it('Then numbers', function () {
-      var otherStuff = ["string", "", true, false, new Date(4312), {}, { hello: 'world' }, [], ['quite', 5]]
-        , numbers = [-12, 0, 12, 5.7];
+      const otherStuff = ['string', '', true, false, new Date(4312), {}, { hello: 'world' }, [], ['quite', 5]]
+      const numbers = [-12, 0, 12, 5.7]
 
-      model.compareThings(-12, 0).should.equal(-1);
-      model.compareThings(0, -3).should.equal(1);
-      model.compareThings(5.7, 2).should.equal(1);
-      model.compareThings(5.7, 12.3).should.equal(-1);
-      model.compareThings(0, 0).should.equal(0);
-      model.compareThings(-2.6, -2.6).should.equal(0);
-      model.compareThings(5, 5).should.equal(0);
+      model.compareThings(-12, 0).should.equal(-1)
+      model.compareThings(0, -3).should.equal(1)
+      model.compareThings(5.7, 2).should.equal(1)
+      model.compareThings(5.7, 12.3).should.equal(-1)
+      model.compareThings(0, 0).should.equal(0)
+      model.compareThings(-2.6, -2.6).should.equal(0)
+      model.compareThings(5, 5).should.equal(0)
 
       otherStuff.forEach(function (stuff) {
         numbers.forEach(function (number) {
-          model.compareThings(number, stuff).should.equal(-1);
-          model.compareThings(stuff, number).should.equal(1);
-        });
-      });
-    });
+          model.compareThings(number, stuff).should.equal(-1)
+          model.compareThings(stuff, number).should.equal(1)
+        })
+      })
+    })
 
     it('Then strings', function () {
-      var otherStuff = [true, false, new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
-        , strings = ['', 'string', 'hello world'];
+      const otherStuff = [true, false, new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
+      const strings = ['', 'string', 'hello world']
 
-      model.compareThings('', 'hey').should.equal(-1);
-      model.compareThings('hey', '').should.equal(1);
-      model.compareThings('hey', 'hew').should.equal(1);
-      model.compareThings('hey', 'hey').should.equal(0);
+      model.compareThings('', 'hey').should.equal(-1)
+      model.compareThings('hey', '').should.equal(1)
+      model.compareThings('hey', 'hew').should.equal(1)
+      model.compareThings('hey', 'hey').should.equal(0)
 
       otherStuff.forEach(function (stuff) {
         strings.forEach(function (string) {
-          model.compareThings(string, stuff).should.equal(-1);
-          model.compareThings(stuff, string).should.equal(1);
-        });
-      });
-    });
+          model.compareThings(string, stuff).should.equal(-1)
+          model.compareThings(stuff, string).should.equal(1)
+        })
+      })
+    })
 
     it('Then booleans', function () {
-      var otherStuff = [new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
-        , bools = [true, false];
+      const otherStuff = [new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
+      const bools = [true, false]
 
-      model.compareThings(true, true).should.equal(0);
-      model.compareThings(false, false).should.equal(0);
-      model.compareThings(true, false).should.equal(1);
-      model.compareThings(false, true).should.equal(-1);
+      model.compareThings(true, true).should.equal(0)
+      model.compareThings(false, false).should.equal(0)
+      model.compareThings(true, false).should.equal(1)
+      model.compareThings(false, true).should.equal(-1)
 
       otherStuff.forEach(function (stuff) {
         bools.forEach(function (bool) {
-          model.compareThings(bool, stuff).should.equal(-1);
-          model.compareThings(stuff, bool).should.equal(1);
-        });
-      });
-    });
+          model.compareThings(bool, stuff).should.equal(-1)
+          model.compareThings(stuff, bool).should.equal(1)
+        })
+      })
+    })
 
     it('Then dates', function () {
-      var otherStuff = [{}, { hello: 'world' }, [], ['quite', 5]]
-        , dates = [new Date(-123), new Date(), new Date(5555), new Date(0)]
-        , now = new Date();
+      const otherStuff = [{}, { hello: 'world' }, [], ['quite', 5]]
+      const dates = [new Date(-123), new Date(), new Date(5555), new Date(0)]
+      const now = new Date()
 
-      model.compareThings(now, now).should.equal(0);
-      model.compareThings(new Date(54341), now).should.equal(-1);
-      model.compareThings(now, new Date(54341)).should.equal(1);
-      model.compareThings(new Date(0), new Date(-54341)).should.equal(1);
-      model.compareThings(new Date(123), new Date(4341)).should.equal(-1);
+      model.compareThings(now, now).should.equal(0)
+      model.compareThings(new Date(54341), now).should.equal(-1)
+      model.compareThings(now, new Date(54341)).should.equal(1)
+      model.compareThings(new Date(0), new Date(-54341)).should.equal(1)
+      model.compareThings(new Date(123), new Date(4341)).should.equal(-1)
 
       otherStuff.forEach(function (stuff) {
         dates.forEach(function (date) {
-          model.compareThings(date, stuff).should.equal(-1);
-          model.compareThings(stuff, date).should.equal(1);
-        });
-      });
-    });
+          model.compareThings(date, stuff).should.equal(-1)
+          model.compareThings(stuff, date).should.equal(1)
+        })
+      })
+    })
 
     it('Then arrays', function () {
-      var otherStuff = [{}, { hello: 'world' }]
-        , arrays = [[], ['yes'], ['hello', 5]]
-        ;
+      const otherStuff = [{}, { hello: 'world' }]
+      const arrays = [[], ['yes'], ['hello', 5]]
 
-      model.compareThings([], []).should.equal(0);
-      model.compareThings(['hello'], []).should.equal(1);
-      model.compareThings([], ['hello']).should.equal(-1);
-      model.compareThings(['hello'], ['hello', 'world']).should.equal(-1);
-      model.compareThings(['hello', 'earth'], ['hello', 'world']).should.equal(-1);
-      model.compareThings(['hello', 'zzz'], ['hello', 'world']).should.equal(1);
-      model.compareThings(['hello', 'world'], ['hello', 'world']).should.equal(0);
+      model.compareThings([], []).should.equal(0)
+      model.compareThings(['hello'], []).should.equal(1)
+      model.compareThings([], ['hello']).should.equal(-1)
+      model.compareThings(['hello'], ['hello', 'world']).should.equal(-1)
+      model.compareThings(['hello', 'earth'], ['hello', 'world']).should.equal(-1)
+      model.compareThings(['hello', 'zzz'], ['hello', 'world']).should.equal(1)
+      model.compareThings(['hello', 'world'], ['hello', 'world']).should.equal(0)
 
       otherStuff.forEach(function (stuff) {
         arrays.forEach(function (array) {
-          model.compareThings(array, stuff).should.equal(-1);
-          model.compareThings(stuff, array).should.equal(1);
-        });
-      });
-    });
+          model.compareThings(array, stuff).should.equal(-1)
+          model.compareThings(stuff, array).should.equal(1)
+        })
+      })
+    })
 
     it('And finally objects', function () {
-      model.compareThings({}, {}).should.equal(0);
-      model.compareThings({ a: 42 }, { a: 312}).should.equal(-1);
-      model.compareThings({ a: '42' }, { a: '312'}).should.equal(1);
-      model.compareThings({ a: 42, b: 312 }, { b: 312, a: 42 }).should.equal(0);
-      model.compareThings({ a: 42, b: 312, c: 54 }, { b: 313, a: 42 }).should.equal(-1);
-    });
+      model.compareThings({}, {}).should.equal(0)
+      model.compareThings({ a: 42 }, { a: 312 }).should.equal(-1)
+      model.compareThings({ a: '42' }, { a: '312' }).should.equal(1)
+      model.compareThings({ a: 42, b: 312 }, { b: 312, a: 42 }).should.equal(0)
+      model.compareThings({ a: 42, b: 312, c: 54 }, { b: 313, a: 42 }).should.equal(-1)
+    })
 
     it('Can specify custom string comparison function', function () {
-      model.compareThings('hello', 'bloup', function (a, b) { return a < b ? -1 : 1; }).should.equal(1);
-      model.compareThings('hello', 'bloup', function (a, b) { return a > b ? -1 : 1; }).should.equal(-1);
-    });
+      model.compareThings('hello', 'bloup', function (a, b) { return a < b ? -1 : 1 }).should.equal(1)
+      model.compareThings('hello', 'bloup', function (a, b) { return a > b ? -1 : 1 }).should.equal(-1)
+    })
 
-  });   // ==== End of 'Comparing things' ==== //
-
+  })   // ==== End of 'Comparing things' ==== //
 
   describe('Querying', function () {
 
     describe('Comparing things', function () {
 
       it('Two things of different types cannot be equal, two identical native things are equal', function () {
-        var toTest = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
-          , toTestAgainst = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]   // Use another array so that we don't test pointer equality
-          , i, j
-          ;
+        const toTest = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+        const toTestAgainst = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+        let i
+        let j
 
         for (i = 0; i < toTest.length; i += 1) {
           for (j = 0; j < toTestAgainst.length; j += 1) {
-            model.areThingsEqual(toTest[i], toTestAgainst[j]).should.equal(i === j);
+            model.areThingsEqual(toTest[i], toTestAgainst[j]).should.equal(i === j)
           }
         }
-      });
+      })
 
       it('Can test native types null undefined string number boolean date equality', function () {
-        var toTest = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
-          , toTestAgainst = [undefined, null, 'someotherstring', 5, false, new Date(111111), { hello: 'mars' }]
-          , i
-          ;
+        const toTest = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+        const toTestAgainst = [undefined, null, 'someotherstring', 5, false, new Date(111111), { hello: 'mars' }]
+        let i
 
         for (i = 0; i < toTest.length; i += 1) {
-          model.areThingsEqual(toTest[i], toTestAgainst[i]).should.equal(false);
+          model.areThingsEqual(toTest[i], toTestAgainst[i]).should.equal(false)
         }
-      });
+      })
 
       it('If one side is an array or undefined, comparison fails', function () {
-        var toTestAgainst = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
-          , i
-          ;
+        const toTestAgainst = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+        let i
 
         for (i = 0; i < toTestAgainst.length; i += 1) {
-          model.areThingsEqual([1, 2, 3], toTestAgainst[i]).should.equal(false);
-          model.areThingsEqual(toTestAgainst[i], []).should.equal(false);
+          model.areThingsEqual([1, 2, 3], toTestAgainst[i]).should.equal(false)
+          model.areThingsEqual(toTestAgainst[i], []).should.equal(false)
 
-          model.areThingsEqual(undefined, toTestAgainst[i]).should.equal(false);
-          model.areThingsEqual(toTestAgainst[i], undefined).should.equal(false);
+          model.areThingsEqual(undefined, toTestAgainst[i]).should.equal(false)
+          model.areThingsEqual(toTestAgainst[i], undefined).should.equal(false)
         }
-      });
+      })
 
       it('Can test objects equality', function () {
-        model.areThingsEqual({ hello: 'world' }, {}).should.equal(false);
-        model.areThingsEqual({ hello: 'world' }, { hello: 'mars' }).should.equal(false);
-        model.areThingsEqual({ hello: 'world' }, { hello: 'world', temperature: 42 }).should.equal(false);
-        model.areThingsEqual({ hello: 'world', other: { temperature: 42 }}, { hello: 'world', other: { temperature: 42 }}).should.equal(true);
-      });
+        model.areThingsEqual({ hello: 'world' }, {}).should.equal(false)
+        model.areThingsEqual({ hello: 'world' }, { hello: 'mars' }).should.equal(false)
+        model.areThingsEqual({ hello: 'world' }, { hello: 'world', temperature: 42 }).should.equal(false)
+        model.areThingsEqual({ hello: 'world', other: { temperature: 42 } }, {
+          hello: 'world',
+          other: { temperature: 42 }
+        }).should.equal(true)
+      })
 
-    });
-
+    })
 
     describe('Getting a fields value in dot notation', function () {
 
       it('Return first-level and nested values', function () {
-        model.getDotValue({ hello: 'world' }, 'hello').should.equal('world');
-        model.getDotValue({ hello: 'world', type: { planet: true, blue: true } }, 'type.planet').should.equal(true);
-      });
+        model.getDotValue({ hello: 'world' }, 'hello').should.equal('world')
+        model.getDotValue({ hello: 'world', type: { planet: true, blue: true } }, 'type.planet').should.equal(true)
+      })
 
       it('Return undefined if the field cannot be found in the object', function () {
-        assert.isUndefined(model.getDotValue({ hello: 'world' }, 'helloo'));
-        assert.isUndefined(model.getDotValue({ hello: 'world', type: { planet: true } }, 'type.plane'));
-      });
+        assert.isUndefined(model.getDotValue({ hello: 'world' }, 'helloo'))
+        assert.isUndefined(model.getDotValue({ hello: 'world', type: { planet: true } }, 'type.plane'))
+      })
 
-      it("Can navigate inside arrays with dot notation, and return the array of values in that case", function () {
-        var dv;
+      it('Can navigate inside arrays with dot notation, and return the array of values in that case', function () {
+        let dv
 
         // Simple array of subdocuments
-        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.name');
-        assert.deepEqual(dv, ['Earth', 'Mars', 'Pluton']);
+        dv = model.getDotValue({
+          planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, {
+            name: 'Pluton',
+            number: 9
+          }]
+        }, 'planets.name')
+        assert.deepEqual(dv, ['Earth', 'Mars', 'Pluton'])
 
         // Nested array of subdocuments
-        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.number');
-        assert.deepEqual(dv, [3, 2, 9]);
+        dv = model.getDotValue({
+          nedb: true,
+          data: { planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 }] }
+        }, 'data.planets.number')
+        assert.deepEqual(dv, [3, 2, 9])
 
         // Nested array in a subdocument of an array (yay, inception!)
         // TODO: make sure MongoDB doesn't flatten the array (it wouldn't make sense)
-        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', numbers: [ 1, 3 ] }, { name: 'Mars', numbers: [ 7 ] }, { name: 'Pluton', numbers: [ 9, 5, 1 ] } ] } }, 'data.planets.numbers');
-        assert.deepEqual(dv, [[ 1, 3 ], [ 7 ], [ 9, 5, 1 ]]);
-      });
+        dv = model.getDotValue({
+          nedb: true,
+          data: {
+            planets: [{ name: 'Earth', numbers: [1, 3] }, { name: 'Mars', numbers: [7] }, {
+              name: 'Pluton',
+              numbers: [9, 5, 1]
+            }]
+          }
+        }, 'data.planets.numbers')
+        assert.deepEqual(dv, [[1, 3], [7], [9, 5, 1]])
+      })
 
-      it("Can get a single value out of an array using its index", function () {
-        var dv;
+      it('Can get a single value out of an array using its index', function () {
+        let dv
 
         // Simple index in dot notation
-        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.1');
-        assert.deepEqual(dv, { name: 'Mars', number: 2 });
+        dv = model.getDotValue({
+          planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, {
+            name: 'Pluton',
+            number: 9
+          }]
+        }, 'planets.1')
+        assert.deepEqual(dv, { name: 'Mars', number: 2 })
 
         // Out of bounds index
-        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.3');
-        assert.isUndefined(dv);
+        dv = model.getDotValue({
+          planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, {
+            name: 'Pluton',
+            number: 9
+          }]
+        }, 'planets.3')
+        assert.isUndefined(dv)
 
         // Index in nested array
-        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.2');
-        assert.deepEqual(dv, { name: 'Pluton', number: 9 });
+        dv = model.getDotValue({
+          nedb: true,
+          data: { planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 }] }
+        }, 'data.planets.2')
+        assert.deepEqual(dv, { name: 'Pluton', number: 9 })
 
         // Dot notation with index in the middle
-        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.0.name');
-        dv.should.equal('Earth');
-      });
+        dv = model.getDotValue({
+          nedb: true,
+          data: { planets: [{ name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 }] }
+        }, 'data.planets.0.name')
+        dv.should.equal('Earth')
+      })
 
-    });
-
+    })
 
     describe('Field equality', function () {
 
       it('Can find documents with simple fields', function () {
-        model.match({ test: 'yeah' }, { test: 'yea' }).should.equal(false);
-        model.match({ test: 'yeah' }, { test: 'yeahh' }).should.equal(false);
-        model.match({ test: 'yeah' }, { test: 'yeah' }).should.equal(true);
-      });
-
-      it('Can find documents with the dot-notation', function () {
-        model.match({ test: { ooo: 'yeah' } }, { "test.ooo": 'yea' }).should.equal(false);
-        model.match({ test: { ooo: 'yeah' } }, { "test.oo": 'yeah' }).should.equal(false);
-        model.match({ test: { ooo: 'yeah' } }, { "tst.ooo": 'yeah' }).should.equal(false);
-        model.match({ test: { ooo: 'yeah' } }, { "test.ooo": 'yeah' }).should.equal(true);
-      });
-
-      it('Cannot find undefined', function () {
-        model.match({ test: undefined }, { test: undefined }).should.equal(false);
-        model.match({ test: { pp: undefined } }, { "test.pp": undefined }).should.equal(false);
-      });
-
-      it('Nested objects are deep-equality matched and not treated as sub-queries', function () {
-        model.match({ a: { b: 5 } }, { a: { b: 5 } }).should.equal(true);
-        model.match({ a: { b: 5, c: 3 } }, { a: { b: 5 } }).should.equal(false);
-
-        model.match({ a: { b: 5 } }, { a: { b: { $lt: 10 } } }).should.equal(false);
-        (function () { model.match({ a: { b: 5 } }, { a: { $or: [ { b: 10 }, { b: 5 } ] } }) }).should.throw();
-      });
-
-      it("Can match for field equality inside an array with the dot notation", function () {
-        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'node' }).should.equal(false);
-        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'embedded' }).should.equal(true);
-        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'database' }).should.equal(false);
+        model.match({ test: 'yeah' }, { test: 'yea' }).should.equal(false)
+        model.match({ test: 'yeah' }, { test: 'yeahh' }).should.equal(false)
+        model.match({ test: 'yeah' }, { test: 'yeah' }).should.equal(true)
       })
 
-    });
+      it('Can find documents with the dot-notation', function () {
+        model.match({ test: { ooo: 'yeah' } }, { 'test.ooo': 'yea' }).should.equal(false)
+        model.match({ test: { ooo: 'yeah' } }, { 'test.oo': 'yeah' }).should.equal(false)
+        model.match({ test: { ooo: 'yeah' } }, { 'tst.ooo': 'yeah' }).should.equal(false)
+        model.match({ test: { ooo: 'yeah' } }, { 'test.ooo': 'yeah' }).should.equal(true)
+      })
 
+      it('Cannot find undefined', function () {
+        model.match({ test: undefined }, { test: undefined }).should.equal(false)
+        model.match({ test: { pp: undefined } }, { 'test.pp': undefined }).should.equal(false)
+      })
+
+      it('Nested objects are deep-equality matched and not treated as sub-queries', function () {
+        model.match({ a: { b: 5 } }, { a: { b: 5 } }).should.equal(true)
+        model.match({ a: { b: 5, c: 3 } }, { a: { b: 5 } }).should.equal(false)
+
+        model.match({ a: { b: 5 } }, { a: { b: { $lt: 10 } } }).should.equal(false);
+        (function () { model.match({ a: { b: 5 } }, { a: { $or: [{ b: 10 }, { b: 5 }] } }) }).should.throw()
+      })
+
+      it('Can match for field equality inside an array with the dot notation', function () {
+        model.match({ a: true, b: ['node', 'embedded', 'database'] }, { 'b.1': 'node' }).should.equal(false)
+        model.match({ a: true, b: ['node', 'embedded', 'database'] }, { 'b.1': 'embedded' }).should.equal(true)
+        model.match({ a: true, b: ['node', 'embedded', 'database'] }, { 'b.1': 'database' }).should.equal(false)
+      })
+
+    })
 
     describe('Regular expression matching', function () {
 
       it('Matching a non-string to a regular expression always yields false', function () {
-        var d = new Date()
-          , r = new RegExp(d.getTime());
+        const d = new Date()
+        const r = new RegExp(d.getTime())
 
-        model.match({ test: true }, { test: /true/ }).should.equal(false);
-        model.match({ test: null }, { test: /null/ }).should.equal(false);
-        model.match({ test: 42 }, { test: /42/ }).should.equal(false);
-        model.match({ test: d }, { test: r }).should.equal(false);
-      });
+        model.match({ test: true }, { test: /true/ }).should.equal(false)
+        model.match({ test: null }, { test: /null/ }).should.equal(false)
+        model.match({ test: 42 }, { test: /42/ }).should.equal(false)
+        model.match({ test: d }, { test: r }).should.equal(false)
+      })
 
       it('Can match strings using basic querying', function () {
-        model.match({ test: 'true' }, { test: /true/ }).should.equal(true);
-        model.match({ test: 'babaaaar' }, { test: /aba+r/ }).should.equal(true);
-        model.match({ test: 'babaaaar' }, { test: /^aba+r/ }).should.equal(false);
-        model.match({ test: 'true' }, { test: /t[ru]e/ }).should.equal(false);
-      });
+        model.match({ test: 'true' }, { test: /true/ }).should.equal(true)
+        model.match({ test: 'babaaaar' }, { test: /aba+r/ }).should.equal(true)
+        model.match({ test: 'babaaaar' }, { test: /^aba+r/ }).should.equal(false)
+        model.match({ test: 'true' }, { test: /t[ru]e/ }).should.equal(false)
+      })
 
       it('Can match strings using the $regex operator', function () {
-        model.match({ test: 'true' }, { test: { $regex: /true/ } }).should.equal(true);
-        model.match({ test: 'babaaaar' }, { test: { $regex: /aba+r/ } }).should.equal(true);
-        model.match({ test: 'babaaaar' }, { test: { $regex: /^aba+r/ } }).should.equal(false);
-        model.match({ test: 'true' }, { test: { $regex: /t[ru]e/ } }).should.equal(false);
-      });
+        model.match({ test: 'true' }, { test: { $regex: /true/ } }).should.equal(true)
+        model.match({ test: 'babaaaar' }, { test: { $regex: /aba+r/ } }).should.equal(true)
+        model.match({ test: 'babaaaar' }, { test: { $regex: /^aba+r/ } }).should.equal(false)
+        model.match({ test: 'true' }, { test: { $regex: /t[ru]e/ } }).should.equal(false)
+      })
 
       it('Will throw if $regex operator is used with a non regex value', function () {
         (function () {
@@ -1125,351 +1176,593 @@ describe('Model', function () {
 
         (function () {
           model.match({ test: 'true' }, { test: { $regex: 'true' } })
-        }).should.throw();
-      });
+        }).should.throw()
+      })
 
       it('Can use the $regex operator in cunjunction with other operators', function () {
-        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helL', 'helLop'] } }).should.equal(true);
-        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helLo', 'helLop'] } }).should.equal(false);
-      });
+        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helL', 'helLop'] } }).should.equal(true)
+        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helLo', 'helLop'] } }).should.equal(false)
+      })
 
       it('Can use dot-notation', function () {
-        model.match({ test: { nested: 'true' } }, { 'test.nested': /true/ }).should.equal(true);
-        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': /^aba+r/ }).should.equal(false);
+        model.match({ test: { nested: 'true' } }, { 'test.nested': /true/ }).should.equal(true)
+        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': /^aba+r/ }).should.equal(false)
 
-        model.match({ test: { nested: 'true' } }, { 'test.nested': { $regex: /true/ } }).should.equal(true);
-        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': { $regex: /^aba+r/ } }).should.equal(false);
-      });
+        model.match({ test: { nested: 'true' } }, { 'test.nested': { $regex: /true/ } }).should.equal(true)
+        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': { $regex: /^aba+r/ } }).should.equal(false)
+      })
 
-    });
-
+    })
 
     describe('$lt', function () {
 
       it('Cannot compare a field to an object, an array, null or a boolean, it will return false', function () {
-        model.match({ a: 5 }, { a: { $lt: { a: 6 } } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $lt: [6, 7] } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $lt: null } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $lt: true } }).should.equal(false);
-      });
+        model.match({ a: 5 }, { a: { $lt: { a: 6 } } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $lt: [6, 7] } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $lt: null } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $lt: true } }).should.equal(false)
+      })
 
       it('Can compare numbers, with or without dot notation', function () {
-        model.match({ a: 5 }, { a: { $lt: 6 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $lt: 5 } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $lt: 4 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $lt: 6 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $lt: 5 } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $lt: 4 } }).should.equal(false)
 
-        model.match({ a: { b: 5 } }, { "a.b": { $lt: 6 } }).should.equal(true);
-        model.match({ a: { b: 5 } }, { "a.b": { $lt: 3 } }).should.equal(false);
-      });
+        model.match({ a: { b: 5 } }, { 'a.b': { $lt: 6 } }).should.equal(true)
+        model.match({ a: { b: 5 } }, { 'a.b': { $lt: 3 } }).should.equal(false)
+      })
 
       it('Can compare strings, with or without dot notation', function () {
-        model.match({ a: "nedb" }, { a: { $lt: "nedc" } }).should.equal(true);
-        model.match({ a: "nedb" }, { a: { $lt: "neda" } }).should.equal(false);
+        model.match({ a: 'nedb' }, { a: { $lt: 'nedc' } }).should.equal(true)
+        model.match({ a: 'nedb' }, { a: { $lt: 'neda' } }).should.equal(false)
 
-        model.match({ a: { b: "nedb" } }, { "a.b": { $lt: "nedc" } }).should.equal(true);
-        model.match({ a: { b: "nedb" } }, { "a.b": { $lt: "neda" } }).should.equal(false);
-      });
+        model.match({ a: { b: 'nedb' } }, { 'a.b': { $lt: 'nedc' } }).should.equal(true)
+        model.match({ a: { b: 'nedb' } }, { 'a.b': { $lt: 'neda' } }).should.equal(false)
+      })
 
       it('If field is an array field, a match means a match on at least one element', function () {
-        model.match({ a: [5, 10] }, { a: { $lt: 4 } }).should.equal(false);
-        model.match({ a: [5, 10] }, { a: { $lt: 6 } }).should.equal(true);
-        model.match({ a: [5, 10] }, { a: { $lt: 11 } }).should.equal(true);
-      });
+        model.match({ a: [5, 10] }, { a: { $lt: 4 } }).should.equal(false)
+        model.match({ a: [5, 10] }, { a: { $lt: 6 } }).should.equal(true)
+        model.match({ a: [5, 10] }, { a: { $lt: 11 } }).should.equal(true)
+      })
 
       it('Works with dates too', function () {
-        model.match({ a: new Date(1000) }, { a: { $gte: new Date(1001) } }).should.equal(false);
-        model.match({ a: new Date(1000) }, { a: { $lt: new Date(1001) } }).should.equal(true);
-      });
+        model.match({ a: new Date(1000) }, { a: { $gte: new Date(1001) } }).should.equal(false)
+        model.match({ a: new Date(1000) }, { a: { $lt: new Date(1001) } }).should.equal(true)
+      })
 
-    });
-
+    })
 
     // General behaviour is tested in the block about $lt. Here we just test operators work
     describe('Other comparison operators: $lte, $gt, $gte, $ne, $in, $exists', function () {
 
       it('$lte', function () {
-        model.match({ a: 5 }, { a: { $lte: 6 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $lte: 5 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $lte: 4 } }).should.equal(false);
-      });
+        model.match({ a: 5 }, { a: { $lte: 6 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $lte: 5 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $lte: 4 } }).should.equal(false)
+      })
 
       it('$gt', function () {
-        model.match({ a: 5 }, { a: { $gt: 6 } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $gt: 5 } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $gt: 4 } }).should.equal(true);
-      });
+        model.match({ a: 5 }, { a: { $gt: 6 } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $gt: 5 } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $gt: 4 } }).should.equal(true)
+      })
 
       it('$gte', function () {
-        model.match({ a: 5 }, { a: { $gte: 6 } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $gte: 5 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $gte: 4 } }).should.equal(true);
-      });
+        model.match({ a: 5 }, { a: { $gte: 6 } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $gte: 5 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $gte: 4 } }).should.equal(true)
+      })
 
       it('$ne', function () {
-        model.match({ a: 5 }, { a: { $ne: 4 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $ne: 5 } }).should.equal(false);
-        model.match({ a: 5 }, { b: { $ne: 5 } }).should.equal(true);
-        model.match({ a: false }, { a: { $ne: false } }).should.equal(false);
-      });
+        model.match({ a: 5 }, { a: { $ne: 4 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $ne: 5 } }).should.equal(false)
+        model.match({ a: 5 }, { b: { $ne: 5 } }).should.equal(true)
+        model.match({ a: false }, { a: { $ne: false } }).should.equal(false)
+      })
 
       it('$in', function () {
-        model.match({ a: 5 }, { a: { $in: [6, 8, 9] } }).should.equal(false);
-        model.match({ a: 6 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
-        model.match({ a: 7 }, { a: { $in: [6, 8, 9] } }).should.equal(false);
-        model.match({ a: 8 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $in: [6, 8, 9] } }).should.equal(false)
+        model.match({ a: 6 }, { a: { $in: [6, 8, 9] } }).should.equal(true)
+        model.match({ a: 7 }, { a: { $in: [6, 8, 9] } }).should.equal(false)
+        model.match({ a: 8 }, { a: { $in: [6, 8, 9] } }).should.equal(true)
         model.match({ a: 9 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
 
-        (function () { model.match({ a: 5 }, { a: { $in: 5 } }); }).should.throw();
-      });
+        (function () { model.match({ a: 5 }, { a: { $in: 5 } }) }).should.throw()
+      })
 
       it('$nin', function () {
-        model.match({ a: 5 }, { a: { $nin: [6, 8, 9] } }).should.equal(true);
-        model.match({ a: 6 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
-        model.match({ a: 7 }, { a: { $nin: [6, 8, 9] } }).should.equal(true);
-        model.match({ a: 8 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
-        model.match({ a: 9 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $nin: [6, 8, 9] } }).should.equal(true)
+        model.match({ a: 6 }, { a: { $nin: [6, 8, 9] } }).should.equal(false)
+        model.match({ a: 7 }, { a: { $nin: [6, 8, 9] } }).should.equal(true)
+        model.match({ a: 8 }, { a: { $nin: [6, 8, 9] } }).should.equal(false)
+        model.match({ a: 9 }, { a: { $nin: [6, 8, 9] } }).should.equal(false)
 
         // Matches if field doesn't exist
         model.match({ a: 9 }, { b: { $nin: [6, 8, 9] } }).should.equal(true);
 
-        (function () { model.match({ a: 5 }, { a: { $in: 5 } }); }).should.throw();
-      });
+        (function () { model.match({ a: 5 }, { a: { $in: 5 } }) }).should.throw()
+      })
 
       it('$exists', function () {
-        model.match({ a: 5 }, { a: { $exists: 1 } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $exists: true } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $exists: new Date() } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $exists: '' } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $exists: [] } }).should.equal(true);
-        model.match({ a: 5 }, { a: { $exists: {} } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: 1 } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $exists: true } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $exists: new Date() } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $exists: '' } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $exists: [] } }).should.equal(true)
+        model.match({ a: 5 }, { a: { $exists: {} } }).should.equal(true)
 
-        model.match({ a: 5 }, { a: { $exists: 0 } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $exists: false } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $exists: null } }).should.equal(false);
-        model.match({ a: 5 }, { a: { $exists: undefined } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $exists: 0 } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $exists: false } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $exists: null } }).should.equal(false)
+        model.match({ a: 5 }, { a: { $exists: undefined } }).should.equal(false)
 
-        model.match({ a: 5 }, { b: { $exists: true } }).should.equal(false);
+        model.match({ a: 5 }, { b: { $exists: true } }).should.equal(false)
 
-        model.match({ a: 5 }, { b: { $exists: false } }).should.equal(true);
-      });
+        model.match({ a: 5 }, { b: { $exists: false } }).should.equal(true)
+      })
 
-    });
-
+    })
 
     describe('Comparing on arrays', function () {
 
-      it("Can perform a direct array match", function () {
-        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Mars'] }).should.equal(false);
-        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Mars', 'Pluto'] }).should.equal(true);
-        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Pluto', 'Mars'] }).should.equal(false);
-      });
+      it('Can perform a direct array match', function () {
+        model.match({
+          planets: ['Earth', 'Mars', 'Pluto'],
+          something: 'else'
+        }, { planets: ['Earth', 'Mars'] }).should.equal(false)
+        model.match({
+          planets: ['Earth', 'Mars', 'Pluto'],
+          something: 'else'
+        }, { planets: ['Earth', 'Mars', 'Pluto'] }).should.equal(true)
+        model.match({
+          planets: ['Earth', 'Mars', 'Pluto'],
+          something: 'else'
+        }, { planets: ['Earth', 'Pluto', 'Mars'] }).should.equal(false)
+      })
 
       it('Can query on the size of an array field', function () {
         // Non nested documents
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 0 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 1 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 2 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 3 } }).should.equal(true);
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $size: 0 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $size: 1 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $size: 2 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $size: 3 } }).should.equal(true)
 
         // Nested documents
-        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 0 } }).should.equal(false);
-        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 1 } }).should.equal(false);
-        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 2 } }).should.equal(true);
-        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 3 } }).should.equal(false);
+        model.match({
+          hello: 'world',
+          description: { satellites: ['Moon', 'Hubble'], diameter: 6300 }
+        }, { 'description.satellites': { $size: 0 } }).should.equal(false)
+        model.match({
+          hello: 'world',
+          description: { satellites: ['Moon', 'Hubble'], diameter: 6300 }
+        }, { 'description.satellites': { $size: 1 } }).should.equal(false)
+        model.match({
+          hello: 'world',
+          description: { satellites: ['Moon', 'Hubble'], diameter: 6300 }
+        }, { 'description.satellites': { $size: 2 } }).should.equal(true)
+        model.match({
+          hello: 'world',
+          description: { satellites: ['Moon', 'Hubble'], diameter: 6300 }
+        }, { 'description.satellites': { $size: 3 } }).should.equal(false)
 
         // Using a projected array
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 0 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 1 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 2 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 3 } }).should.equal(true);
-      });
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.names': { $size: 0 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.names': { $size: 1 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.names': { $size: 2 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.names': { $size: 3 } }).should.equal(true)
+      })
 
       it('$size operator works with empty arrays', function () {
-        model.match({ childrens: [] }, { "childrens": { $size: 0 } }).should.equal(true);
-        model.match({ childrens: [] }, { "childrens": { $size: 2 } }).should.equal(false);
-        model.match({ childrens: [] }, { "childrens": { $size: 3 } }).should.equal(false);
-      });
+        model.match({ childrens: [] }, { 'childrens': { $size: 0 } }).should.equal(true)
+        model.match({ childrens: [] }, { 'childrens': { $size: 2 } }).should.equal(false)
+        model.match({ childrens: [] }, { 'childrens': { $size: 3 } }).should.equal(false)
+      })
 
       it('Should throw an error if a query operator is used without comparing to an integer', function () {
-        (function () { model.match({ a: [1, 5] }, { a: { $size: 1.4 } }); }).should.throw();
-        (function () { model.match({ a: [1, 5] }, { a: { $size: 'fdf' } }); }).should.throw();
-        (function () { model.match({ a: [1, 5] }, { a: { $size: { $lt: 5 } } }); }).should.throw();
-      });
+        (function () { model.match({ a: [1, 5] }, { a: { $size: 1.4 } }) }).should.throw();
+        (function () { model.match({ a: [1, 5] }, { a: { $size: 'fdf' } }) }).should.throw();
+        (function () { model.match({ a: [1, 5] }, { a: { $size: { $lt: 5 } } }) }).should.throw()
+      })
 
       it('Using $size operator on a non-array field should prevent match but not throw', function () {
-        model.match({ a: 5 }, { a: { $size: 1 } }).should.equal(false);
-      });
+        model.match({ a: 5 }, { a: { $size: 1 } }).should.equal(false)
+      })
 
       it('Can use $size several times in the same matcher', function () {
-        model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { $size: 3, $size: 3 } }).should.equal(true);
-        model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { $size: 3, $size: 4 } }).should.equal(false);   // Of course this can never be true
-      });
+        model.match({ childrens: ['Riri', 'Fifi', 'Loulou'] }, {
+          'childrens': {
+            $size: 3,
+            $size: 3
+          }
+        }).should.equal(true)
+        model.match({ childrens: ['Riri', 'Fifi', 'Loulou'] }, {
+          'childrens': {
+            $size: 3,
+            $size: 4
+          }
+        }).should.equal(false)   // Of course this can never be true
+      })
 
       it('Can query array documents with multiple simultaneous conditions', function () {
         // Non nested documents
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: 7 } } }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: 12 } } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Louie", age: 3 } } }).should.equal(false);
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Dewey', age: 7 } } }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Dewey', age: 12 } } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Louie', age: 3 } } }).should.equal(false)
 
         // Nested documents
-        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Dewey", age: 7 } } }).should.equal(true);
-        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Dewey", age: 12 } } }).should.equal(false);
-        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Louie", age: 3 } } }).should.equal(false);
+        model.match({
+          outer: {
+            childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+              name: 'Louie',
+              age: 12
+            }]
+          }
+        }, { 'outer.childrens': { $elemMatch: { name: 'Dewey', age: 7 } } }).should.equal(true)
+        model.match({
+          outer: {
+            childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+              name: 'Louie',
+              age: 12
+            }]
+          }
+        }, { 'outer.childrens': { $elemMatch: { name: 'Dewey', age: 12 } } }).should.equal(false)
+        model.match({
+          outer: {
+            childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+              name: 'Louie',
+              age: 12
+            }]
+          }
+        }, { 'outer.childrens': { $elemMatch: { name: 'Louie', age: 3 } } }).should.equal(false)
 
-      });
+      })
 
       it('$elemMatch operator works with empty arrays', function () {
-        model.match({ childrens: [] }, { "childrens": { $elemMatch: { name: "Mitsos" } } }).should.equal(false);
-        model.match({ childrens: [] }, { "childrens": { $elemMatch: {} } }).should.equal(false);
-      });
+        model.match({ childrens: [] }, { 'childrens': { $elemMatch: { name: 'Mitsos' } } }).should.equal(false)
+        model.match({ childrens: [] }, { 'childrens': { $elemMatch: {} } }).should.equal(false)
+      })
 
       it('Can use more complex comparisons inside nested query documents', function () {
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $gt: 6, $lt: 8 } } } }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $in: [ 6, 7, 8 ] } } } } ).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $gt: 6, $lt: 7 } } } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Louie", age: { $gt: 6, $lte: 7 } } } }).should.equal(false);
-      });
-    });
-
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Dewey', age: { $gt: 6, $lt: 8 } } } }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Dewey', age: { $in: [6, 7, 8] } } } }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Dewey', age: { $gt: 6, $lt: 7 } } } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens': { $elemMatch: { name: 'Louie', age: { $gt: 6, $lte: 7 } } } }).should.equal(false)
+      })
+    })
 
     describe('Logical operators $or, $and, $not', function () {
 
       it('Any of the subqueries should match for an $or to match', function () {
-        model.match({ hello: 'world' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(true);
-        model.match({ hello: 'pluton' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(true);
-        model.match({ hello: 'nope' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(false);
-        model.match({ hello: 'world', age: 15 }, { $or: [ { hello: 'pluton' }, { age: { $lt: 20 } } ] }).should.equal(true);
-        model.match({ hello: 'world', age: 15 }, { $or: [ { hello: 'pluton' }, { age: { $lt: 10 } } ] }).should.equal(false);
-      });
+        model.match({ hello: 'world' }, { $or: [{ hello: 'pluton' }, { hello: 'world' }] }).should.equal(true)
+        model.match({ hello: 'pluton' }, { $or: [{ hello: 'pluton' }, { hello: 'world' }] }).should.equal(true)
+        model.match({ hello: 'nope' }, { $or: [{ hello: 'pluton' }, { hello: 'world' }] }).should.equal(false)
+        model.match({
+          hello: 'world',
+          age: 15
+        }, { $or: [{ hello: 'pluton' }, { age: { $lt: 20 } }] }).should.equal(true)
+        model.match({
+          hello: 'world',
+          age: 15
+        }, { $or: [{ hello: 'pluton' }, { age: { $lt: 10 } }] }).should.equal(false)
+      })
 
       it('All of the subqueries should match for an $and to match', function () {
-        model.match({ hello: 'world', age: 15 }, { $and: [ { age: 15 }, { hello: 'world' } ] }).should.equal(true);
-        model.match({ hello: 'world', age: 15 }, { $and: [ { age: 16 }, { hello: 'world' } ] }).should.equal(false);
-        model.match({ hello: 'world', age: 15 }, { $and: [ { hello: 'world' }, { age: { $lt: 20 } } ] }).should.equal(true);
-        model.match({ hello: 'world', age: 15 }, { $and: [ { hello: 'pluton' }, { age: { $lt: 20 } } ] }).should.equal(false);
-      });
+        model.match({ hello: 'world', age: 15 }, { $and: [{ age: 15 }, { hello: 'world' }] }).should.equal(true)
+        model.match({ hello: 'world', age: 15 }, { $and: [{ age: 16 }, { hello: 'world' }] }).should.equal(false)
+        model.match({
+          hello: 'world',
+          age: 15
+        }, { $and: [{ hello: 'world' }, { age: { $lt: 20 } }] }).should.equal(true)
+        model.match({
+          hello: 'world',
+          age: 15
+        }, { $and: [{ hello: 'pluton' }, { age: { $lt: 20 } }] }).should.equal(false)
+      })
 
       it('Subquery should not match for a $not to match', function () {
-        model.match({ a: 5, b: 10 }, { a: 5 }).should.equal(true);
-        model.match({ a: 5, b: 10 }, { $not: { a: 5 } }).should.equal(false);
-      });
+        model.match({ a: 5, b: 10 }, { a: 5 }).should.equal(true)
+        model.match({ a: 5, b: 10 }, { $not: { a: 5 } }).should.equal(false)
+      })
 
       it('Logical operators are all top-level, only other logical operators can be above', function () {
-        (function () { model.match({ a: { b: 7 } }, { a: { $or: [ { b: 5 }, { b: 7 } ] } })}).should.throw();
-        model.match({ a: { b: 7 } }, { $or: [ { "a.b": 5 }, { "a.b": 7 } ] }).should.equal(true);
-      });
+        (function () { model.match({ a: { b: 7 } }, { a: { $or: [{ b: 5 }, { b: 7 }] } })}).should.throw()
+        model.match({ a: { b: 7 } }, { $or: [{ 'a.b': 5 }, { 'a.b': 7 }] }).should.equal(true)
+      })
 
       it('Logical operators can be combined as long as they are on top of the decision tree', function () {
-        model.match({ a: 5, b: 7, c: 12 }, { $or: [ { $and: [ { a: 5 }, { b: 8 } ] }, { $and: [{ a: 5 }, { c : { $lt: 40 } }] } ] }).should.equal(true);
-        model.match({ a: 5, b: 7, c: 12 }, { $or: [ { $and: [ { a: 5 }, { b: 8 } ] }, { $and: [{ a: 5 }, { c : { $lt: 10 } }] } ] }).should.equal(false);
-      });
+        model.match({
+          a: 5,
+          b: 7,
+          c: 12
+        }, { $or: [{ $and: [{ a: 5 }, { b: 8 }] }, { $and: [{ a: 5 }, { c: { $lt: 40 } }] }] }).should.equal(true)
+        model.match({
+          a: 5,
+          b: 7,
+          c: 12
+        }, { $or: [{ $and: [{ a: 5 }, { b: 8 }] }, { $and: [{ a: 5 }, { c: { $lt: 10 } }] }] }).should.equal(false)
+      })
 
       it('Should throw an error if a logical operator is used without an array or if an unknown logical operator is used', function () {
-        (function () { model.match({ a: 5 }, { $or: { a: 5, a: 6 } }); }).should.throw();
-        (function () { model.match({ a: 5 }, { $and: { a: 5, a: 6 } }); }).should.throw();
-        (function () { model.match({ a: 5 }, { $unknown: [ { a: 5 } ] }); }).should.throw();
-      });
+        (function () { model.match({ a: 5 }, { $or: { a: 5, a: 6 } }) }).should.throw();
+        (function () { model.match({ a: 5 }, { $and: { a: 5, a: 6 } }) }).should.throw();
+        (function () { model.match({ a: 5 }, { $unknown: [{ a: 5 }] }) }).should.throw()
+      })
 
-    });
-
+    })
 
     describe('Comparison operator $where', function () {
 
       it('Function should match and not match correctly', function () {
-        model.match({ a: 4}, { $where: function () { return this.a === 4; } }).should.equal(true);
-        model.match({ a: 4}, { $where: function () { return this.a === 5; } }).should.equal(false);
-      });
+        model.match({ a: 4 }, { $where: function () { return this.a === 4 } }).should.equal(true)
+        model.match({ a: 4 }, { $where: function () { return this.a === 5 } }).should.equal(false)
+      })
 
       it('Should throw an error if the $where function is not, in fact, a function', function () {
-        (function () { model.match({ a: 4 }, { $where: 'not a function' }); }).should.throw();
-      });
+        (function () { model.match({ a: 4 }, { $where: 'not a function' }) }).should.throw()
+      })
 
       it('Should throw an error if the $where function returns a non-boolean', function () {
-        (function () { model.match({ a: 4 }, { $where: function () { return 'not a boolean'; } }); }).should.throw();
-      });
+        (function () { model.match({ a: 4 }, { $where: function () { return 'not a boolean' } }) }).should.throw()
+      })
 
       it('Should be able to do the complex matching it must be used for', function () {
-        var checkEmail = function() {
-          if (!this.firstName || !this.lastName) { return false; }
-          return this.firstName.toLowerCase() + "." + this.lastName.toLowerCase() + "@gmail.com" === this.email;
-        };
-        model.match({ firstName: "John", lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(true);
-        model.match({ firstName: "john", lastName: "doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(true);
-        model.match({ firstName: "Jane", lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
-        model.match({ firstName: "John", lastName: "Deere", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
-        model.match({ lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
-      });
+        const checkEmail = function () {
+          if (!this.firstName || !this.lastName) { return false }
+          return this.firstName.toLowerCase() + '.' + this.lastName.toLowerCase() + '@gmail.com' === this.email
+        }
+        model.match({
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john.doe@gmail.com'
+        }, { $where: checkEmail }).should.equal(true)
+        model.match({
+          firstName: 'john',
+          lastName: 'doe',
+          email: 'john.doe@gmail.com'
+        }, { $where: checkEmail }).should.equal(true)
+        model.match({
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: 'john.doe@gmail.com'
+        }, { $where: checkEmail }).should.equal(false)
+        model.match({
+          firstName: 'John',
+          lastName: 'Deere',
+          email: 'john.doe@gmail.com'
+        }, { $where: checkEmail }).should.equal(false)
+        model.match({ lastName: 'Doe', email: 'john.doe@gmail.com' }, { $where: checkEmail }).should.equal(false)
+      })
 
-    });
-
+    })
 
     describe('Array fields', function () {
 
       it('Field equality', function () {
-        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'python' }).should.equal(false);
-        model.match({ tags: ['node', 'js', 'db'] }, { tagss: 'js' }).should.equal(false);
-        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js' }).should.equal(true);
-        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js', tags: 'node' }).should.equal(true);
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'python' }).should.equal(false)
+        model.match({ tags: ['node', 'js', 'db'] }, { tagss: 'js' }).should.equal(false)
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js' }).should.equal(true)
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js', tags: 'node' }).should.equal(true)
 
         // Mixed matching with array and non array
-        model.match({ tags: ['node', 'js', 'db'], nedb: true }, { tags: 'js', nedb: true }).should.equal(true);
+        model.match({ tags: ['node', 'js', 'db'], nedb: true }, { tags: 'js', nedb: true }).should.equal(true)
 
         // Nested matching
-        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { "data.tags": 'js' }).should.equal(true);
-        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { "data.tags": 'j' }).should.equal(false);
-      });
+        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { 'data.tags': 'js' }).should.equal(true)
+        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { 'data.tags': 'j' }).should.equal(false)
+      })
 
       it('With one comparison operator', function () {
-        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 2 } }).should.equal(false);
-        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 3 } }).should.equal(false);
-        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 4 } }).should.equal(true);
-        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 8 } }).should.equal(true);
-        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 13 } }).should.equal(true);
-      });
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 2 } }).should.equal(false)
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 3 } }).should.equal(false)
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 4 } }).should.equal(true)
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 8 } }).should.equal(true)
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 13 } }).should.equal(true)
+      })
 
       it('Works with arrays that are in subdocuments', function () {
-        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 2 } }).should.equal(false);
-        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 3 } }).should.equal(false);
-        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 4 } }).should.equal(true);
-        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 8 } }).should.equal(true);
-        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 13 } }).should.equal(true);
-      });
+        model.match({ children: { ages: [3, 7, 12] } }, { 'children.ages': { $lt: 2 } }).should.equal(false)
+        model.match({ children: { ages: [3, 7, 12] } }, { 'children.ages': { $lt: 3 } }).should.equal(false)
+        model.match({ children: { ages: [3, 7, 12] } }, { 'children.ages': { $lt: 4 } }).should.equal(true)
+        model.match({ children: { ages: [3, 7, 12] } }, { 'children.ages': { $lt: 8 } }).should.equal(true)
+        model.match({ children: { ages: [3, 7, 12] } }, { 'children.ages': { $lt: 13 } }).should.equal(true)
+      })
 
       it('Can query inside arrays thanks to dot notation', function () {
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 2 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 3 } }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 4 } }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 8 } }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 13 } }).should.equal(true);
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.age': { $lt: 2 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.age': { $lt: 3 } }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.age': { $lt: 4 } }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.age': { $lt: 8 } }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.age': { $lt: 13 } }).should.equal(true)
 
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Louis' }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Louie' }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Lewi' }).should.equal(false);
-      });
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.name': 'Louis' }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.name': 'Louie' }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.name': 'Lewi' }).should.equal(false)
+      })
 
       it('Can query for a specific element inside arrays thanks to dot notation', function () {
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.0.name": 'Louie' }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.1.name": 'Louie' }).should.equal(false);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.2.name": 'Louie' }).should.equal(true);
-        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.3.name": 'Louie' }).should.equal(false);
-      });
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.0.name': 'Louie' }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.1.name': 'Louie' }).should.equal(false)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.2.name': 'Louie' }).should.equal(true)
+        model.match({
+          childrens: [{ name: 'Huey', age: 3 }, { name: 'Dewey', age: 7 }, {
+            name: 'Louie',
+            age: 12
+          }]
+        }, { 'childrens.3.name': 'Louie' }).should.equal(false)
+      })
 
       it('A single array-specific operator and the query is treated as array specific', function () {
-        (function () { model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { "Fifi": true, $size: 3 } })}).should.throw();
-      });
+        (function () {
+          model.match({ childrens: ['Riri', 'Fifi', 'Loulou'] }, {
+            'childrens': {
+              'Fifi': true,
+              $size: 3
+            }
+          })
+        }).should.throw()
+      })
 
       it('Can mix queries on array fields and non array filds with array specific operators', function () {
-        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 2 }, uncle: 'Donald' }).should.equal(false);
-        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Donald' }).should.equal(true);
-        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 4 }, uncle: 'Donald' }).should.equal(false);
+        model.match({ uncle: 'Donald', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 2 },
+          uncle: 'Donald'
+        }).should.equal(false)
+        model.match({ uncle: 'Donald', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 3 },
+          uncle: 'Donald'
+        }).should.equal(true)
+        model.match({ uncle: 'Donald', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 4 },
+          uncle: 'Donald'
+        }).should.equal(false)
 
-        model.match({ uncle: 'Donals', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Picsou' }).should.equal(false);
-        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Donald' }).should.equal(true);
-        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Daisy' }).should.equal(false);
-      });
+        model.match({ uncle: 'Donals', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 3 },
+          uncle: 'Picsou'
+        }).should.equal(false)
+        model.match({ uncle: 'Donald', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 3 },
+          uncle: 'Donald'
+        }).should.equal(true)
+        model.match({ uncle: 'Donald', nephews: ['Riri', 'Fifi', 'Loulou'] }, {
+          nephews: { $size: 3 },
+          uncle: 'Daisy'
+        }).should.equal(false)
+      })
 
-    });
+    })
 
-  });   // ==== End of 'Querying' ==== //
+  })   // ==== End of 'Querying' ==== //
 
-});
+})

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,0 +1,1475 @@
+var model = require('../src/nedb/model')
+  , should = require('chai').should()
+  , assert = require('chai').assert
+  , expect = require('chai').expect
+  , _ = require('underscore')
+  , async = require('async')
+  , util = require('util')
+  , Datastore = require('../src/nedb/datastore')
+  , fs = require('fs')
+  ;
+
+
+describe('Model', function () {
+
+  describe('Serialization, deserialization', function () {
+
+    it('Can serialize and deserialize strings', function () {
+      var a, b, c;
+
+      a = { test: "Some string" };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      c.test.should.equal("Some string");
+
+      // Even if a property is a string containing a new line, the serialized
+      // version doesn't. The new line must still be there upon deserialization
+      a = { test: "With a new\nline" };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      c.test.should.equal("With a new\nline");
+      a.test.indexOf('\n').should.not.equal(-1);
+      b.indexOf('\n').should.equal(-1);
+      c.test.indexOf('\n').should.not.equal(-1);
+    });
+
+    it('Can serialize and deserialize booleans', function () {
+      var a, b, c;
+
+      a = { test: true };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      c.test.should.equal(true);
+    });
+
+    it('Can serialize and deserialize numbers', function () {
+      var a, b, c;
+
+      a = { test: 5 };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      c.test.should.equal(5);
+    });
+
+    it('Can serialize and deserialize null', function () {
+      var a, b, c;
+
+      a = { test: null };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      assert.isNull(a.test);
+    });
+
+    it('undefined fields are removed when serialized', function() {
+      var a = { bloup: undefined, hello: 'world' }
+        , b = model.serialize(a)
+        , c = model.deserialize(b)
+        ;
+
+      Object.keys(c).length.should.equal(1);
+      c.hello.should.equal('world');
+      assert.isUndefined(c.bloup);
+    });
+
+    it('Can serialize and deserialize a date', function () {
+      var a, b, c
+        , d = new Date();
+
+      a = { test: d };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      b.should.equal('{"test":{"$$date":' + d.getTime() + '}}');
+      util.isDate(c.test).should.equal(true);
+      c.test.getTime().should.equal(d.getTime());
+    });
+
+    it('Can serialize and deserialize sub objects', function () {
+      var a, b, c
+        , d = new Date();
+
+      a = { test: { something: 39, also: d, yes: { again: 'yes' } } };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      c.test.something.should.equal(39);
+      c.test.also.getTime().should.equal(d.getTime());
+      c.test.yes.again.should.equal('yes');
+    });
+
+    it('Can serialize and deserialize sub arrays', function () {
+      var a, b, c
+        , d = new Date();
+
+      a = { test: [ 39, d, { again: 'yes' } ] };
+      b = model.serialize(a);
+      c = model.deserialize(b);
+      b.indexOf('\n').should.equal(-1);
+      c.test[0].should.equal(39);
+      c.test[1].getTime().should.equal(d.getTime());
+      c.test[2].again.should.equal('yes');
+    });
+
+    it('Reject field names beginning with a $ sign or containing a dot, except the four edge cases', function () {
+      var a1 = { $something: 'totest' }
+        , a2 = { "with.dot": 'totest' }
+        , e1 = { $$date: 4321 }
+        , e2 = { $$deleted: true }
+        , e3 = { $$indexCreated: "indexName" }
+        , e4 = { $$indexRemoved: "indexName" }
+        , b;
+
+      // Normal cases
+      (function () { b = model.serialize(a1); }).should.throw();
+      (function () { b = model.serialize(a2); }).should.throw();
+
+      // Edge cases
+      b = model.serialize(e1);
+      b = model.serialize(e2);
+      b = model.serialize(e3);
+      b = model.serialize(e4);
+    });
+
+    it('Can serialize string fields with a new line without breaking the DB', function (done) {
+      var db1, db2
+        , badString = "world\r\nearth\nother\rline"
+      ;
+
+      if (fs.existsSync('workspace/test1.db')) { fs.unlinkSync('workspace/test1.db'); }
+      fs.existsSync('workspace/test1.db').should.equal(false);
+      db1 = new Datastore({ filename: 'workspace/test1.db' });
+
+      db1.loadDatabase(function (err) {
+        assert.isNull(err);
+        db1.insert({ hello: badString }, function (err) {
+          assert.isNull(err);
+
+          db2 = new Datastore({ filename: 'workspace/test1.db' });
+          db2.loadDatabase(function (err) {
+            assert.isNull(err);
+            db2.find({}, function (err, docs) {
+              assert.isNull(err);
+              docs.length.should.equal(1);
+              docs[0].hello.should.equal(badString);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it('Can accept objects whose keys are numbers', function () {
+      var o = { 42: true };
+
+      var s = model.serialize(o);
+    });
+
+  });   // ==== End of 'Serialization, deserialization' ==== //
+
+
+  describe('Object checking', function () {
+
+    it('Field names beginning with a $ sign are forbidden', function () {
+      assert.isDefined(model.checkObject);
+
+      (function () {
+        model.checkObject({ $bad: true });
+      }).should.throw();
+
+      (function () {
+        model.checkObject({ some: 42, nested: { again: "no", $worse: true } });
+      }).should.throw();
+
+      // This shouldn't throw since "$actuallyok" is not a field name
+      model.checkObject({ some: 42, nested: [ 5, "no", "$actuallyok", true ] });
+
+      (function () {
+        model.checkObject({ some: 42, nested: [ 5, "no", "$actuallyok", true, { $hidden: "useless" } ] });
+      }).should.throw();
+    });
+
+    it('Field names cannot contain a .', function () {
+      assert.isDefined(model.checkObject);
+
+      (function () {
+        model.checkObject({ "so.bad": true });
+      }).should.throw();
+
+      // Recursive behaviour testing done in the above test on $ signs
+    });
+
+    it('Properties with a null value dont trigger an error', function () {
+      var obj = { prop: null };
+
+      model.checkObject(obj);
+    });
+
+    it('Can check if an object is a primitive or not', function () {
+      model.isPrimitiveType(5).should.equal(true);
+      model.isPrimitiveType('sdsfdfs').should.equal(true);
+      model.isPrimitiveType(0).should.equal(true);
+      model.isPrimitiveType(true).should.equal(true);
+      model.isPrimitiveType(false).should.equal(true);
+      model.isPrimitiveType(new Date()).should.equal(true);
+      model.isPrimitiveType([]).should.equal(true);
+      model.isPrimitiveType([3, 'try']).should.equal(true);
+      model.isPrimitiveType(null).should.equal(true);
+
+      model.isPrimitiveType({}).should.equal(false);
+      model.isPrimitiveType({ a: 42 }).should.equal(false);
+    });
+
+  });   // ==== End of 'Object checking' ==== //
+
+
+  describe('Deep copying', function () {
+
+    it('Should be able to deep copy any serializable model', function () {
+      var d = new Date()
+        , obj = { a: ['ee', 'ff', 42], date: d, subobj: { a: 'b', b: 'c' } }
+        , res = model.deepCopy(obj);
+        ;
+
+      res.a.length.should.equal(3);
+      res.a[0].should.equal('ee');
+      res.a[1].should.equal('ff');
+      res.a[2].should.equal(42);
+      res.date.getTime().should.equal(d.getTime());
+      res.subobj.a.should.equal('b');
+      res.subobj.b.should.equal('c');
+
+      obj.a.push('ggg');
+      obj.date = 'notadate';
+      obj.subobj = [];
+
+      // Even if the original object is modified, the copied one isn't
+      res.a.length.should.equal(3);
+      res.a[0].should.equal('ee');
+      res.a[1].should.equal('ff');
+      res.a[2].should.equal(42);
+      res.date.getTime().should.equal(d.getTime());
+      res.subobj.a.should.equal('b');
+      res.subobj.b.should.equal('c');
+    });
+
+    it('Should deep copy the contents of an array', function () {
+      var a = [{ hello: 'world' }]
+        , b = model.deepCopy(a)
+      ;
+
+      b[0].hello.should.equal('world');
+      b[0].hello = 'another';
+      b[0].hello.should.equal('another');
+      a[0].hello.should.equal('world');
+    });
+
+    it('Without the strictKeys option, everything gets deep copied', function () {
+      var a = { a: 4, $e: 'rrr', 'eee.rt': 42, nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 }, array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }] }
+        , b = model.deepCopy(a)
+      ;
+
+      assert.deepEqual(a, b);
+    });
+
+    it('With the strictKeys option, only valid keys gets deep copied', function () {
+      var a = { a: 4, $e: 'rrr', 'eee.rt': 42, nested: { yes: 1, 'tt.yy': 2, $nopenope: 3 }, array: [{ 'rr.hh': 1 }, { yes: true }, { $yes: false }] }
+        , b = model.deepCopy(a, true)
+      ;
+
+      assert.deepEqual(b, { a: 4, nested: { yes: 1 }, array: [{}, { yes: true }, {}] });
+    });
+
+  });   // ==== End of 'Deep copying' ==== //
+
+
+  describe('Modifying documents', function () {
+
+    it('Queries not containing any modifier just replace the document by the contents of the query but keep its _id', function () {
+      var obj = { some: 'thing', _id: 'keepit' }
+        , updateQuery = { replace: 'done', bloup: [ 1, 8] }
+        , t
+        ;
+
+      t = model.modify(obj, updateQuery);
+      t.replace.should.equal('done');
+      t.bloup.length.should.equal(2);
+      t.bloup[0].should.equal(1);
+      t.bloup[1].should.equal(8);
+
+      assert.isUndefined(t.some);
+      t._id.should.equal('keepit');
+    });
+
+    it('Throw an error if trying to change the _id field in a copy-type modification', function () {
+      var obj = { some: 'thing', _id: 'keepit' }
+        , updateQuery = { replace: 'done', bloup: [ 1, 8], _id: 'donttryit' }
+        ;
+
+      expect(function () {
+        model.modify(obj, updateQuery);
+      }).to.throw("You cannot change a document's _id");
+
+      updateQuery._id = 'keepit';
+      model.modify(obj, updateQuery);   // No error thrown
+    });
+
+    it('Throw an error if trying to use modify in a mixed copy+modify way', function () {
+      var obj = { some: 'thing' }
+        , updateQuery = { replace: 'me', $modify: 'metoo' };
+
+      expect(function () {
+        model.modify(obj, updateQuery);
+      }).to.throw("You cannot mix modifiers and normal fields");
+    });
+
+    it('Throw an error if trying to use an inexistent modifier', function () {
+      var obj = { some: 'thing' }
+        , updateQuery = { $set: { it: 'exists' }, $modify: 'not this one' };
+
+      expect(function () {
+        model.modify(obj, updateQuery);
+      }).to.throw(/^Unknown modifier .modify/);
+    });
+
+    it('Throw an error if a modifier is used with a non-object argument', function () {
+      var obj = { some: 'thing' }
+        , updateQuery = { $set: 'this exists' };
+
+      expect(function () {
+        model.modify(obj, updateQuery);
+      }).to.throw(/Modifier .set's argument must be an object/);
+    });
+
+    describe('$set modifier', function () {
+      it('Can change already set fields without modfifying the underlying object', function () {
+        var obj = { some: 'thing', yup: 'yes', nay: 'noes' }
+          , updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
+          , modified = model.modify(obj, updateQuery);
+
+        Object.keys(modified).length.should.equal(3);
+        modified.some.should.equal('changed');
+        modified.yup.should.equal('yes');
+        modified.nay.should.equal('yes indeed');
+
+        Object.keys(obj).length.should.equal(3);
+        obj.some.should.equal('thing');
+        obj.yup.should.equal('yes');
+        obj.nay.should.equal('noes');
+      });
+
+      it('Creates fields to set if they dont exist yet', function () {
+        var obj = { yup: 'yes' }
+          , updateQuery = { $set: { some: 'changed', nay: 'yes indeed' } }
+          , modified = model.modify(obj, updateQuery);
+
+        Object.keys(modified).length.should.equal(3);
+        modified.some.should.equal('changed');
+        modified.yup.should.equal('yes');
+        modified.nay.should.equal('yes indeed');
+      });
+
+      it('Can set sub-fields and create them if necessary', function () {
+        var obj = { yup: { subfield: 'bloup' } }
+          , updateQuery = { $set: { "yup.subfield": 'changed', "yup.yop": 'yes indeed', "totally.doesnt.exist": 'now it does' } }
+          , modified = model.modify(obj, updateQuery);
+
+        _.isEqual(modified, { yup: { subfield: 'changed', yop: 'yes indeed' }, totally: { doesnt: { exist: 'now it does' } } }).should.equal(true);
+      });
+
+      it("Doesn't replace a falsy field by an object when recursively following dot notation", function () {
+        var obj = { nested: false }
+          , updateQuery = { $set: { "nested.now": 'it is' } }
+          , modified = model.modify(obj, updateQuery);
+
+        assert.deepEqual(modified, { nested: false });   // Object not modified as the nested field doesn't exist
+      });
+    });   // End of '$set modifier'
+
+    describe('$unset modifier', function () {
+
+      it('Can delete a field, not throwing an error if the field doesnt exist', function () {
+        var obj, updateQuery, modified;
+
+        obj = { yup: 'yes', other: 'also' }
+        updateQuery = { $unset: { yup: true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, { other: 'also' });
+
+        obj = { yup: 'yes', other: 'also' }
+        updateQuery = { $unset: { nope: true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, obj);
+
+        obj = { yup: 'yes', other: 'also' }
+        updateQuery = { $unset: { nope: true, other: true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, { yup: 'yes' });
+      });
+
+      it('Can unset sub-fields and entire nested documents', function () {
+        var obj, updateQuery, modified;
+
+        obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
+        updateQuery = { $unset: { nested: true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, { yup: 'yes' });
+
+        obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
+        updateQuery = { $unset: { 'nested.a': true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, { yup: 'yes', nested: { b: 'yeah' } });
+
+        obj = { yup: 'yes', nested: { a: 'also', b: 'yeah' } }
+        updateQuery = { $unset: { 'nested.a': true, 'nested.b': true } }
+        modified = model.modify(obj, updateQuery);
+        assert.deepEqual(modified, { yup: 'yes', nested: {} });
+      });
+
+      it("When unsetting nested fields, should not create an empty parent to nested field", function () {
+        var obj = model.modify({ argh: true }, { $unset: { 'bad.worse': true } });
+        assert.deepEqual(obj, { argh: true });
+
+        obj = model.modify({ argh: true, bad: { worse: 'oh' } }, { $unset: { 'bad.worse': true } });
+        assert.deepEqual(obj, { argh: true, bad: {} });
+
+        obj = model.modify({ argh: true, bad: {} }, { $unset: { 'bad.worse': true } });
+        assert.deepEqual(obj, { argh: true, bad: {} });
+      });
+
+    });   // End of '$unset modifier'
+
+    describe('$inc modifier', function () {
+      it('Throw an error if you try to use it with a non-number or on a non number field', function () {
+        (function () {
+          var obj = { some: 'thing', yup: 'yes', nay: 2 }
+            , updateQuery = { $inc: { nay: 'notanumber' } }
+            , modified = model.modify(obj, updateQuery);
+        }).should.throw();
+
+        (function () {
+          var obj = { some: 'thing', yup: 'yes', nay: 'nope' }
+            , updateQuery = { $inc: { nay: 1 } }
+            , modified = model.modify(obj, updateQuery);
+        }).should.throw();
+      });
+
+      it('Can increment number fields or create and initialize them if needed', function () {
+        var obj = { some: 'thing', nay: 40 }
+          , modified;
+
+        modified = model.modify(obj, { $inc: { nay: 2 } });
+        _.isEqual(modified, { some: 'thing', nay: 42 }).should.equal(true);
+
+        // Incidentally, this tests that obj was not modified
+        modified = model.modify(obj, { $inc: { inexistent: -6 } });
+        _.isEqual(modified, { some: 'thing', nay: 40, inexistent: -6 }).should.equal(true);
+      });
+
+      it('Works recursively', function () {
+        var obj = { some: 'thing', nay: { nope: 40 } }
+          , modified;
+
+        modified = model.modify(obj, { $inc: { "nay.nope": -2, "blip.blop": 123 } });
+        _.isEqual(modified, { some: 'thing', nay: { nope: 38 }, blip: { blop: 123 } }).should.equal(true);
+      });
+    });   // End of '$inc modifier'
+
+    describe('$push modifier', function () {
+
+      it('Can push an element to the end of an array', function () {
+        var obj = { arr: ['hello'] }
+          , modified;
+
+        modified = model.modify(obj, { $push: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['hello', 'world'] });
+      });
+
+      it('Can push an element to a non-existent field and will create the array', function () {
+        var obj = {}
+          , modified;
+
+        modified = model.modify(obj, { $push: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['world'] });
+      });
+
+      it('Can push on nested fields', function () {
+        var obj = { arr: { nested: ['hello'] } }
+          , modified;
+
+        modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
+        assert.deepEqual(modified, { arr: { nested: ['hello', 'world'] } });
+
+        obj = { arr: { a: 2 }};
+        modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
+        assert.deepEqual(modified, { arr: { a: 2, nested: ['world'] } });
+      });
+
+      it('Throw if we try to push to a non-array', function () {
+        var obj = { arr: 'hello' }
+          , modified;
+
+        (function () {
+          modified = model.modify(obj, { $push: { arr: 'world' } });
+        }).should.throw();
+
+        obj = { arr: { nested: 45 } };
+        (function () {
+          modified = model.modify(obj, { $push: { "arr.nested": 'world' } });
+        }).should.throw();
+      });
+
+      it('Can use the $each modifier to add multiple values to an array at once', function () {
+        var obj = { arr: ['hello'] }
+          , modified;
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'] } } });
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
+
+        (function () {
+          modified = model.modify(obj, { $push: { arr: { $each: 45 } } });
+        }).should.throw();
+
+        (function () {
+          modified = model.modify(obj, { $push: { arr: { $each: ['world'], unauthorized: true } } });
+        }).should.throw();
+      });
+
+      it('Can use the $slice modifier to limit the number of array elements', function () {
+        var obj = { arr: ['hello'] }
+          , modified;
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 1 } } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -1 } } });
+        assert.deepEqual(modified, { arr: ['everything'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 0 } } });
+        assert.deepEqual(modified, { arr: [] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 2 } } });
+        assert.deepEqual(modified, { arr: ['hello', 'world'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -2 } } });
+        assert.deepEqual(modified, { arr: ['earth', 'everything'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: -20 } } });
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: ['world', 'earth', 'everything'], $slice: 20 } } });
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth', 'everything'] });
+
+        modified = model.modify(obj, { $push: { arr: { $each: [], $slice: 1 } } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+
+        // $each not specified, but $slice is
+        modified = model.modify(obj, { $push: { arr: { $slice: 1 } } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+
+        (function () {
+          modified = model.modify(obj, { $push: { arr: { $slice: 1, unauthorized: true } } });
+        }).should.throw();
+
+        (function () {
+          modified = model.modify(obj, { $push: { arr: { $each: [], unauthorized: true } } });
+        }).should.throw();
+      });
+
+    });   // End of '$push modifier'
+
+    describe('$addToSet modifier', function () {
+
+      it('Can add an element to a set', function () {
+        var obj = { arr: ['hello'] }
+          , modified;
+
+        modified = model.modify(obj, { $addToSet: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['hello', 'world'] });
+
+        obj = { arr: ['hello'] };
+        modified = model.modify(obj, { $addToSet: { arr: 'hello' } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+      });
+
+      it('Can add an element to a non-existent set and will create the array', function () {
+        var obj = { arr: [] }
+          , modified;
+
+        modified = model.modify(obj, { $addToSet: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['world'] });
+      });
+
+      it('Throw if we try to addToSet to a non-array', function () {
+        var obj = { arr: 'hello' }
+          , modified;
+
+        (function () {
+          modified = model.modify(obj, { $addToSet: { arr: 'world' } });
+        }).should.throw();
+      });
+
+      it('Use deep-equality to check whether we can add a value to a set', function () {
+        var obj = { arr: [ { b: 2 } ] }
+          , modified;
+
+        modified = model.modify(obj, { $addToSet: { arr: { b: 3 } } });
+        assert.deepEqual(modified, { arr: [{ b: 2 }, { b: 3 }] });
+
+        obj = { arr: [ { b: 2 } ] }
+        modified = model.modify(obj, { $addToSet: { arr: { b: 2 } } });
+        assert.deepEqual(modified, { arr: [{ b: 2 }] });
+      });
+
+      it('Can use the $each modifier to add multiple values to a set at once', function () {
+        var obj = { arr: ['hello'] }
+          , modified;
+
+        modified = model.modify(obj, { $addToSet: { arr: { $each: ['world', 'earth', 'hello', 'earth'] } } });
+        assert.deepEqual(modified, { arr: ['hello', 'world', 'earth'] });
+
+        (function () {
+          modified = model.modify(obj, { $addToSet: { arr: { $each: 45 } } });
+        }).should.throw();
+
+        (function () {
+          modified = model.modify(obj, { $addToSet: { arr: { $each: ['world'], unauthorized: true } } });
+        }).should.throw();
+      });
+
+    });   // End of '$addToSet modifier'
+
+    describe('$pop modifier', function () {
+
+      it('Throw if called on a non array, a non defined field or a non integer', function () {
+        var obj = { arr: 'hello' }
+          , modified;
+
+        (function () {
+          modified = model.modify(obj, { $pop: { arr: 1 } });
+        }).should.throw();
+
+        obj = { bloup: 'nope' };
+        (function () {
+          modified = model.modify(obj, { $pop: { arr: 1 } });
+        }).should.throw();
+
+        obj = { arr: [1, 4, 8] };
+        (function () {
+          modified = model.modify(obj, { $pop: { arr: true } });
+        }).should.throw();
+      });
+
+      it('Can remove the first and last element of an array', function () {
+        var obj
+          , modified;
+
+        obj = { arr: [1, 4, 8] };
+        modified = model.modify(obj, { $pop: { arr: 1 } });
+        assert.deepEqual(modified, { arr: [1, 4] });
+
+        obj = { arr: [1, 4, 8] };
+        modified = model.modify(obj, { $pop: { arr: -1 } });
+        assert.deepEqual(modified, { arr: [4, 8] });
+
+        // Empty arrays are not changed
+        obj = { arr: [] };
+        modified = model.modify(obj, { $pop: { arr: 1 } });
+        assert.deepEqual(modified, { arr: [] });
+        modified = model.modify(obj, { $pop: { arr: -1 } });
+        assert.deepEqual(modified, { arr: [] });
+      });
+
+    });   // End of '$pop modifier'
+
+    describe('$pull modifier', function () {
+
+      it('Can remove an element from a set', function () {
+        var obj = { arr: ['hello', 'world'] }
+          , modified;
+
+        modified = model.modify(obj, { $pull: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+
+        obj = { arr: ['hello'] };
+        modified = model.modify(obj, { $pull: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['hello'] });
+      });
+
+      it('Can remove multiple matching elements', function () {
+        var obj = { arr: ['hello', 'world', 'hello', 'world'] }
+          , modified;
+
+        modified = model.modify(obj, { $pull: { arr: 'world' } });
+        assert.deepEqual(modified, { arr: ['hello', 'hello'] });
+      });
+
+      it('Throw if we try to pull from a non-array', function () {
+        var obj = { arr: 'hello' }
+          , modified;
+
+        (function () {
+          modified = model.modify(obj, { $pull: { arr: 'world' } });
+        }).should.throw();
+      });
+
+      it('Use deep-equality to check whether we can remove a value from a set', function () {
+        var obj = { arr: [{ b: 2 }, { b: 3 }] }
+          , modified;
+
+        modified = model.modify(obj, { $pull: { arr: { b: 3 } } });
+        assert.deepEqual(modified, { arr: [ { b: 2 } ] });
+
+        obj = { arr: [ { b: 2 } ] }
+        modified = model.modify(obj, { $pull: { arr: { b: 3 } } });
+        assert.deepEqual(modified, { arr: [{ b: 2 }] });
+      });
+
+      it('Can use any kind of nedb query with $pull', function () {
+        var obj = { arr: [4, 7, 12, 2], other: 'yup' }
+          , modified
+        ;
+
+        modified = model.modify(obj, { $pull: { arr: { $gte: 5 } } });
+        assert.deepEqual(modified, { arr: [4, 2], other: 'yup' });
+
+        obj = { arr: [{ b: 4 }, { b: 7 }, { b: 1 }], other: 'yeah' };
+        modified = model.modify(obj, { $pull: { arr: { b: { $gte: 5} } } });
+        assert.deepEqual(modified, { arr: [{ b: 4 }, { b: 1 }], other: 'yeah' });
+      });
+
+    });   // End of '$pull modifier'
+
+    describe('$max modifier', function () {
+      it('Will set the field to the updated value if value is greater than current one, without modifying the original object', function () {
+        var obj = { some:'thing', number: 10 }
+            , updateQuery = { $max: { number:12 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', number: 12 });
+        obj.should.deep.equal({ some: 'thing', number: 10 });
+      });
+
+      it('Will not update the field if new value is smaller than current one', function () {
+        var obj = { some:'thing', number: 10 }
+            , updateQuery = { $max: { number: 9 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some:'thing', number:10 });
+      });
+
+      it('Will create the field if it does not exist', function () {
+        var obj = { some: 'thing' }
+            , updateQuery = { $max: { number: 10 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', number: 10 });
+      });
+
+      it('Works on embedded documents', function () {
+        var obj = { some: 'thing', somethingElse: { number:10 } }
+            , updateQuery = { $max: { 'somethingElse.number': 12 } }
+            , modified = model.modify(obj,updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', somethingElse: { number:12 } });
+      });
+    });// End of '$max modifier'
+
+    describe('$min modifier', function () {
+      it('Will set the field to the updated value if value is smaller than current one, without modifying the original object', function () {
+        var obj = { some:'thing', number: 10 }
+            , updateQuery = { $min: { number: 8 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', number: 8 });
+        obj.should.deep.equal({ some: 'thing', number: 10 });
+      });
+
+      it('Will not update the field if new value is greater than current one', function () {
+        var obj = { some: 'thing', number: 10 }
+            , updateQuery = { $min: { number: 12 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', number: 10 });
+      });
+
+      it('Will create the field if it does not exist', function () {
+        var obj = { some: 'thing' }
+            , updateQuery = { $min: { number: 10 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', number: 10 });
+      });
+
+      it('Works on embedded documents', function () {
+        var obj = { some: 'thing', somethingElse: { number: 10 } }
+            , updateQuery = { $min: { 'somethingElse.number': 8 } }
+            , modified = model.modify(obj, updateQuery);
+
+        modified.should.deep.equal({ some: 'thing', somethingElse: { number: 8 } } );
+      });
+    });// End of '$min modifier'
+
+  });   // ==== End of 'Modifying documents' ==== //
+
+
+  describe('Comparing things', function () {
+
+    it('undefined is the smallest', function () {
+      var otherStuff = [null, "string", "", -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]];
+
+      model.compareThings(undefined, undefined).should.equal(0);
+
+      otherStuff.forEach(function (stuff) {
+        model.compareThings(undefined, stuff).should.equal(-1);
+        model.compareThings(stuff, undefined).should.equal(1);
+      });
+    });
+
+    it('Then null', function () {
+      var otherStuff = ["string", "", -1, 0, 5.3, 12, true, false, new Date(12345), {}, { hello: 'world' }, [], ['quite', 5]];
+
+      model.compareThings(null, null).should.equal(0);
+
+      otherStuff.forEach(function (stuff) {
+        model.compareThings(null, stuff).should.equal(-1);
+        model.compareThings(stuff, null).should.equal(1);
+      });
+    });
+
+    it('Then numbers', function () {
+      var otherStuff = ["string", "", true, false, new Date(4312), {}, { hello: 'world' }, [], ['quite', 5]]
+        , numbers = [-12, 0, 12, 5.7];
+
+      model.compareThings(-12, 0).should.equal(-1);
+      model.compareThings(0, -3).should.equal(1);
+      model.compareThings(5.7, 2).should.equal(1);
+      model.compareThings(5.7, 12.3).should.equal(-1);
+      model.compareThings(0, 0).should.equal(0);
+      model.compareThings(-2.6, -2.6).should.equal(0);
+      model.compareThings(5, 5).should.equal(0);
+
+      otherStuff.forEach(function (stuff) {
+        numbers.forEach(function (number) {
+          model.compareThings(number, stuff).should.equal(-1);
+          model.compareThings(stuff, number).should.equal(1);
+        });
+      });
+    });
+
+    it('Then strings', function () {
+      var otherStuff = [true, false, new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
+        , strings = ['', 'string', 'hello world'];
+
+      model.compareThings('', 'hey').should.equal(-1);
+      model.compareThings('hey', '').should.equal(1);
+      model.compareThings('hey', 'hew').should.equal(1);
+      model.compareThings('hey', 'hey').should.equal(0);
+
+      otherStuff.forEach(function (stuff) {
+        strings.forEach(function (string) {
+          model.compareThings(string, stuff).should.equal(-1);
+          model.compareThings(stuff, string).should.equal(1);
+        });
+      });
+    });
+
+    it('Then booleans', function () {
+      var otherStuff = [new Date(4321), {}, { hello: 'world' }, [], ['quite', 5]]
+        , bools = [true, false];
+
+      model.compareThings(true, true).should.equal(0);
+      model.compareThings(false, false).should.equal(0);
+      model.compareThings(true, false).should.equal(1);
+      model.compareThings(false, true).should.equal(-1);
+
+      otherStuff.forEach(function (stuff) {
+        bools.forEach(function (bool) {
+          model.compareThings(bool, stuff).should.equal(-1);
+          model.compareThings(stuff, bool).should.equal(1);
+        });
+      });
+    });
+
+    it('Then dates', function () {
+      var otherStuff = [{}, { hello: 'world' }, [], ['quite', 5]]
+        , dates = [new Date(-123), new Date(), new Date(5555), new Date(0)]
+        , now = new Date();
+
+      model.compareThings(now, now).should.equal(0);
+      model.compareThings(new Date(54341), now).should.equal(-1);
+      model.compareThings(now, new Date(54341)).should.equal(1);
+      model.compareThings(new Date(0), new Date(-54341)).should.equal(1);
+      model.compareThings(new Date(123), new Date(4341)).should.equal(-1);
+
+      otherStuff.forEach(function (stuff) {
+        dates.forEach(function (date) {
+          model.compareThings(date, stuff).should.equal(-1);
+          model.compareThings(stuff, date).should.equal(1);
+        });
+      });
+    });
+
+    it('Then arrays', function () {
+      var otherStuff = [{}, { hello: 'world' }]
+        , arrays = [[], ['yes'], ['hello', 5]]
+        ;
+
+      model.compareThings([], []).should.equal(0);
+      model.compareThings(['hello'], []).should.equal(1);
+      model.compareThings([], ['hello']).should.equal(-1);
+      model.compareThings(['hello'], ['hello', 'world']).should.equal(-1);
+      model.compareThings(['hello', 'earth'], ['hello', 'world']).should.equal(-1);
+      model.compareThings(['hello', 'zzz'], ['hello', 'world']).should.equal(1);
+      model.compareThings(['hello', 'world'], ['hello', 'world']).should.equal(0);
+
+      otherStuff.forEach(function (stuff) {
+        arrays.forEach(function (array) {
+          model.compareThings(array, stuff).should.equal(-1);
+          model.compareThings(stuff, array).should.equal(1);
+        });
+      });
+    });
+
+    it('And finally objects', function () {
+      model.compareThings({}, {}).should.equal(0);
+      model.compareThings({ a: 42 }, { a: 312}).should.equal(-1);
+      model.compareThings({ a: '42' }, { a: '312'}).should.equal(1);
+      model.compareThings({ a: 42, b: 312 }, { b: 312, a: 42 }).should.equal(0);
+      model.compareThings({ a: 42, b: 312, c: 54 }, { b: 313, a: 42 }).should.equal(-1);
+    });
+
+    it('Can specify custom string comparison function', function () {
+      model.compareThings('hello', 'bloup', function (a, b) { return a < b ? -1 : 1; }).should.equal(1);
+      model.compareThings('hello', 'bloup', function (a, b) { return a > b ? -1 : 1; }).should.equal(-1);
+    });
+
+  });   // ==== End of 'Comparing things' ==== //
+
+
+  describe('Querying', function () {
+
+    describe('Comparing things', function () {
+
+      it('Two things of different types cannot be equal, two identical native things are equal', function () {
+        var toTest = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+          , toTestAgainst = [null, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]   // Use another array so that we don't test pointer equality
+          , i, j
+          ;
+
+        for (i = 0; i < toTest.length; i += 1) {
+          for (j = 0; j < toTestAgainst.length; j += 1) {
+            model.areThingsEqual(toTest[i], toTestAgainst[j]).should.equal(i === j);
+          }
+        }
+      });
+
+      it('Can test native types null undefined string number boolean date equality', function () {
+        var toTest = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+          , toTestAgainst = [undefined, null, 'someotherstring', 5, false, new Date(111111), { hello: 'mars' }]
+          , i
+          ;
+
+        for (i = 0; i < toTest.length; i += 1) {
+          model.areThingsEqual(toTest[i], toTestAgainst[i]).should.equal(false);
+        }
+      });
+
+      it('If one side is an array or undefined, comparison fails', function () {
+        var toTestAgainst = [null, undefined, 'somestring', 42, true, new Date(72998322), { hello: 'world' }]
+          , i
+          ;
+
+        for (i = 0; i < toTestAgainst.length; i += 1) {
+          model.areThingsEqual([1, 2, 3], toTestAgainst[i]).should.equal(false);
+          model.areThingsEqual(toTestAgainst[i], []).should.equal(false);
+
+          model.areThingsEqual(undefined, toTestAgainst[i]).should.equal(false);
+          model.areThingsEqual(toTestAgainst[i], undefined).should.equal(false);
+        }
+      });
+
+      it('Can test objects equality', function () {
+        model.areThingsEqual({ hello: 'world' }, {}).should.equal(false);
+        model.areThingsEqual({ hello: 'world' }, { hello: 'mars' }).should.equal(false);
+        model.areThingsEqual({ hello: 'world' }, { hello: 'world', temperature: 42 }).should.equal(false);
+        model.areThingsEqual({ hello: 'world', other: { temperature: 42 }}, { hello: 'world', other: { temperature: 42 }}).should.equal(true);
+      });
+
+    });
+
+
+    describe('Getting a fields value in dot notation', function () {
+
+      it('Return first-level and nested values', function () {
+        model.getDotValue({ hello: 'world' }, 'hello').should.equal('world');
+        model.getDotValue({ hello: 'world', type: { planet: true, blue: true } }, 'type.planet').should.equal(true);
+      });
+
+      it('Return undefined if the field cannot be found in the object', function () {
+        assert.isUndefined(model.getDotValue({ hello: 'world' }, 'helloo'));
+        assert.isUndefined(model.getDotValue({ hello: 'world', type: { planet: true } }, 'type.plane'));
+      });
+
+      it("Can navigate inside arrays with dot notation, and return the array of values in that case", function () {
+        var dv;
+
+        // Simple array of subdocuments
+        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.name');
+        assert.deepEqual(dv, ['Earth', 'Mars', 'Pluton']);
+
+        // Nested array of subdocuments
+        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.number');
+        assert.deepEqual(dv, [3, 2, 9]);
+
+        // Nested array in a subdocument of an array (yay, inception!)
+        // TODO: make sure MongoDB doesn't flatten the array (it wouldn't make sense)
+        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', numbers: [ 1, 3 ] }, { name: 'Mars', numbers: [ 7 ] }, { name: 'Pluton', numbers: [ 9, 5, 1 ] } ] } }, 'data.planets.numbers');
+        assert.deepEqual(dv, [[ 1, 3 ], [ 7 ], [ 9, 5, 1 ]]);
+      });
+
+      it("Can get a single value out of an array using its index", function () {
+        var dv;
+
+        // Simple index in dot notation
+        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.1');
+        assert.deepEqual(dv, { name: 'Mars', number: 2 });
+
+        // Out of bounds index
+        dv = model.getDotValue({ planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] }, 'planets.3');
+        assert.isUndefined(dv);
+
+        // Index in nested array
+        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.2');
+        assert.deepEqual(dv, { name: 'Pluton', number: 9 });
+
+        // Dot notation with index in the middle
+        dv = model.getDotValue({ nedb: true, data: { planets: [ { name: 'Earth', number: 3 }, { name: 'Mars', number: 2 }, { name: 'Pluton', number: 9 } ] } }, 'data.planets.0.name');
+        dv.should.equal('Earth');
+      });
+
+    });
+
+
+    describe('Field equality', function () {
+
+      it('Can find documents with simple fields', function () {
+        model.match({ test: 'yeah' }, { test: 'yea' }).should.equal(false);
+        model.match({ test: 'yeah' }, { test: 'yeahh' }).should.equal(false);
+        model.match({ test: 'yeah' }, { test: 'yeah' }).should.equal(true);
+      });
+
+      it('Can find documents with the dot-notation', function () {
+        model.match({ test: { ooo: 'yeah' } }, { "test.ooo": 'yea' }).should.equal(false);
+        model.match({ test: { ooo: 'yeah' } }, { "test.oo": 'yeah' }).should.equal(false);
+        model.match({ test: { ooo: 'yeah' } }, { "tst.ooo": 'yeah' }).should.equal(false);
+        model.match({ test: { ooo: 'yeah' } }, { "test.ooo": 'yeah' }).should.equal(true);
+      });
+
+      it('Cannot find undefined', function () {
+        model.match({ test: undefined }, { test: undefined }).should.equal(false);
+        model.match({ test: { pp: undefined } }, { "test.pp": undefined }).should.equal(false);
+      });
+
+      it('Nested objects are deep-equality matched and not treated as sub-queries', function () {
+        model.match({ a: { b: 5 } }, { a: { b: 5 } }).should.equal(true);
+        model.match({ a: { b: 5, c: 3 } }, { a: { b: 5 } }).should.equal(false);
+
+        model.match({ a: { b: 5 } }, { a: { b: { $lt: 10 } } }).should.equal(false);
+        (function () { model.match({ a: { b: 5 } }, { a: { $or: [ { b: 10 }, { b: 5 } ] } }) }).should.throw();
+      });
+
+      it("Can match for field equality inside an array with the dot notation", function () {
+        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'node' }).should.equal(false);
+        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'embedded' }).should.equal(true);
+        model.match({ a: true, b: [ 'node', 'embedded', 'database' ] }, { 'b.1': 'database' }).should.equal(false);
+      })
+
+    });
+
+
+    describe('Regular expression matching', function () {
+
+      it('Matching a non-string to a regular expression always yields false', function () {
+        var d = new Date()
+          , r = new RegExp(d.getTime());
+
+        model.match({ test: true }, { test: /true/ }).should.equal(false);
+        model.match({ test: null }, { test: /null/ }).should.equal(false);
+        model.match({ test: 42 }, { test: /42/ }).should.equal(false);
+        model.match({ test: d }, { test: r }).should.equal(false);
+      });
+
+      it('Can match strings using basic querying', function () {
+        model.match({ test: 'true' }, { test: /true/ }).should.equal(true);
+        model.match({ test: 'babaaaar' }, { test: /aba+r/ }).should.equal(true);
+        model.match({ test: 'babaaaar' }, { test: /^aba+r/ }).should.equal(false);
+        model.match({ test: 'true' }, { test: /t[ru]e/ }).should.equal(false);
+      });
+
+      it('Can match strings using the $regex operator', function () {
+        model.match({ test: 'true' }, { test: { $regex: /true/ } }).should.equal(true);
+        model.match({ test: 'babaaaar' }, { test: { $regex: /aba+r/ } }).should.equal(true);
+        model.match({ test: 'babaaaar' }, { test: { $regex: /^aba+r/ } }).should.equal(false);
+        model.match({ test: 'true' }, { test: { $regex: /t[ru]e/ } }).should.equal(false);
+      });
+
+      it('Will throw if $regex operator is used with a non regex value', function () {
+        (function () {
+          model.match({ test: 'true' }, { test: { $regex: 42 } })
+        }).should.throw();
+
+        (function () {
+          model.match({ test: 'true' }, { test: { $regex: 'true' } })
+        }).should.throw();
+      });
+
+      it('Can use the $regex operator in cunjunction with other operators', function () {
+        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helL', 'helLop'] } }).should.equal(true);
+        model.match({ test: 'helLo' }, { test: { $regex: /ll/i, $nin: ['helLo', 'helLop'] } }).should.equal(false);
+      });
+
+      it('Can use dot-notation', function () {
+        model.match({ test: { nested: 'true' } }, { 'test.nested': /true/ }).should.equal(true);
+        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': /^aba+r/ }).should.equal(false);
+
+        model.match({ test: { nested: 'true' } }, { 'test.nested': { $regex: /true/ } }).should.equal(true);
+        model.match({ test: { nested: 'babaaaar' } }, { 'test.nested': { $regex: /^aba+r/ } }).should.equal(false);
+      });
+
+    });
+
+
+    describe('$lt', function () {
+
+      it('Cannot compare a field to an object, an array, null or a boolean, it will return false', function () {
+        model.match({ a: 5 }, { a: { $lt: { a: 6 } } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $lt: [6, 7] } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $lt: null } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $lt: true } }).should.equal(false);
+      });
+
+      it('Can compare numbers, with or without dot notation', function () {
+        model.match({ a: 5 }, { a: { $lt: 6 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $lt: 5 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $lt: 4 } }).should.equal(false);
+
+        model.match({ a: { b: 5 } }, { "a.b": { $lt: 6 } }).should.equal(true);
+        model.match({ a: { b: 5 } }, { "a.b": { $lt: 3 } }).should.equal(false);
+      });
+
+      it('Can compare strings, with or without dot notation', function () {
+        model.match({ a: "nedb" }, { a: { $lt: "nedc" } }).should.equal(true);
+        model.match({ a: "nedb" }, { a: { $lt: "neda" } }).should.equal(false);
+
+        model.match({ a: { b: "nedb" } }, { "a.b": { $lt: "nedc" } }).should.equal(true);
+        model.match({ a: { b: "nedb" } }, { "a.b": { $lt: "neda" } }).should.equal(false);
+      });
+
+      it('If field is an array field, a match means a match on at least one element', function () {
+        model.match({ a: [5, 10] }, { a: { $lt: 4 } }).should.equal(false);
+        model.match({ a: [5, 10] }, { a: { $lt: 6 } }).should.equal(true);
+        model.match({ a: [5, 10] }, { a: { $lt: 11 } }).should.equal(true);
+      });
+
+      it('Works with dates too', function () {
+        model.match({ a: new Date(1000) }, { a: { $gte: new Date(1001) } }).should.equal(false);
+        model.match({ a: new Date(1000) }, { a: { $lt: new Date(1001) } }).should.equal(true);
+      });
+
+    });
+
+
+    // General behaviour is tested in the block about $lt. Here we just test operators work
+    describe('Other comparison operators: $lte, $gt, $gte, $ne, $in, $exists', function () {
+
+      it('$lte', function () {
+        model.match({ a: 5 }, { a: { $lte: 6 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $lte: 5 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $lte: 4 } }).should.equal(false);
+      });
+
+      it('$gt', function () {
+        model.match({ a: 5 }, { a: { $gt: 6 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $gt: 5 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $gt: 4 } }).should.equal(true);
+      });
+
+      it('$gte', function () {
+        model.match({ a: 5 }, { a: { $gte: 6 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $gte: 5 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $gte: 4 } }).should.equal(true);
+      });
+
+      it('$ne', function () {
+        model.match({ a: 5 }, { a: { $ne: 4 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $ne: 5 } }).should.equal(false);
+        model.match({ a: 5 }, { b: { $ne: 5 } }).should.equal(true);
+        model.match({ a: false }, { a: { $ne: false } }).should.equal(false);
+      });
+
+      it('$in', function () {
+        model.match({ a: 5 }, { a: { $in: [6, 8, 9] } }).should.equal(false);
+        model.match({ a: 6 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
+        model.match({ a: 7 }, { a: { $in: [6, 8, 9] } }).should.equal(false);
+        model.match({ a: 8 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
+        model.match({ a: 9 }, { a: { $in: [6, 8, 9] } }).should.equal(true);
+
+        (function () { model.match({ a: 5 }, { a: { $in: 5 } }); }).should.throw();
+      });
+
+      it('$nin', function () {
+        model.match({ a: 5 }, { a: { $nin: [6, 8, 9] } }).should.equal(true);
+        model.match({ a: 6 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
+        model.match({ a: 7 }, { a: { $nin: [6, 8, 9] } }).should.equal(true);
+        model.match({ a: 8 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
+        model.match({ a: 9 }, { a: { $nin: [6, 8, 9] } }).should.equal(false);
+
+        // Matches if field doesn't exist
+        model.match({ a: 9 }, { b: { $nin: [6, 8, 9] } }).should.equal(true);
+
+        (function () { model.match({ a: 5 }, { a: { $in: 5 } }); }).should.throw();
+      });
+
+      it('$exists', function () {
+        model.match({ a: 5 }, { a: { $exists: 1 } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: true } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: new Date() } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: '' } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: [] } }).should.equal(true);
+        model.match({ a: 5 }, { a: { $exists: {} } }).should.equal(true);
+
+        model.match({ a: 5 }, { a: { $exists: 0 } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $exists: false } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $exists: null } }).should.equal(false);
+        model.match({ a: 5 }, { a: { $exists: undefined } }).should.equal(false);
+
+        model.match({ a: 5 }, { b: { $exists: true } }).should.equal(false);
+
+        model.match({ a: 5 }, { b: { $exists: false } }).should.equal(true);
+      });
+
+    });
+
+
+    describe('Comparing on arrays', function () {
+
+      it("Can perform a direct array match", function () {
+        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Mars'] }).should.equal(false);
+        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Mars', 'Pluto'] }).should.equal(true);
+        model.match({ planets: ['Earth', 'Mars', 'Pluto'], something: 'else' }, { planets: ['Earth', 'Pluto', 'Mars'] }).should.equal(false);
+      });
+
+      it('Can query on the size of an array field', function () {
+        // Non nested documents
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 0 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 1 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 2 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $size: 3 } }).should.equal(true);
+
+        // Nested documents
+        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 0 } }).should.equal(false);
+        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 1 } }).should.equal(false);
+        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 2 } }).should.equal(true);
+        model.match({ hello: 'world', description: { satellites: ['Moon', 'Hubble'], diameter: 6300 } }, { "description.satellites": { $size: 3 } }).should.equal(false);
+
+        // Using a projected array
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 0 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 1 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 2 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.names": { $size: 3 } }).should.equal(true);
+      });
+
+      it('$size operator works with empty arrays', function () {
+        model.match({ childrens: [] }, { "childrens": { $size: 0 } }).should.equal(true);
+        model.match({ childrens: [] }, { "childrens": { $size: 2 } }).should.equal(false);
+        model.match({ childrens: [] }, { "childrens": { $size: 3 } }).should.equal(false);
+      });
+
+      it('Should throw an error if a query operator is used without comparing to an integer', function () {
+        (function () { model.match({ a: [1, 5] }, { a: { $size: 1.4 } }); }).should.throw();
+        (function () { model.match({ a: [1, 5] }, { a: { $size: 'fdf' } }); }).should.throw();
+        (function () { model.match({ a: [1, 5] }, { a: { $size: { $lt: 5 } } }); }).should.throw();
+      });
+
+      it('Using $size operator on a non-array field should prevent match but not throw', function () {
+        model.match({ a: 5 }, { a: { $size: 1 } }).should.equal(false);
+      });
+
+      it('Can use $size several times in the same matcher', function () {
+        model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { $size: 3, $size: 3 } }).should.equal(true);
+        model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { $size: 3, $size: 4 } }).should.equal(false);   // Of course this can never be true
+      });
+
+      it('Can query array documents with multiple simultaneous conditions', function () {
+        // Non nested documents
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: 7 } } }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: 12 } } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Louie", age: 3 } } }).should.equal(false);
+
+        // Nested documents
+        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Dewey", age: 7 } } }).should.equal(true);
+        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Dewey", age: 12 } } }).should.equal(false);
+        model.match({ outer: { childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] } }, { "outer.childrens": { $elemMatch: { name: "Louie", age: 3 } } }).should.equal(false);
+
+      });
+
+      it('$elemMatch operator works with empty arrays', function () {
+        model.match({ childrens: [] }, { "childrens": { $elemMatch: { name: "Mitsos" } } }).should.equal(false);
+        model.match({ childrens: [] }, { "childrens": { $elemMatch: {} } }).should.equal(false);
+      });
+
+      it('Can use more complex comparisons inside nested query documents', function () {
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $gt: 6, $lt: 8 } } } }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $in: [ 6, 7, 8 ] } } } } ).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Dewey", age: { $gt: 6, $lt: 7 } } } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens": { $elemMatch: { name: "Louie", age: { $gt: 6, $lte: 7 } } } }).should.equal(false);
+      });
+    });
+
+
+    describe('Logical operators $or, $and, $not', function () {
+
+      it('Any of the subqueries should match for an $or to match', function () {
+        model.match({ hello: 'world' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(true);
+        model.match({ hello: 'pluton' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(true);
+        model.match({ hello: 'nope' }, { $or: [ { hello: 'pluton' }, { hello: 'world' } ] }).should.equal(false);
+        model.match({ hello: 'world', age: 15 }, { $or: [ { hello: 'pluton' }, { age: { $lt: 20 } } ] }).should.equal(true);
+        model.match({ hello: 'world', age: 15 }, { $or: [ { hello: 'pluton' }, { age: { $lt: 10 } } ] }).should.equal(false);
+      });
+
+      it('All of the subqueries should match for an $and to match', function () {
+        model.match({ hello: 'world', age: 15 }, { $and: [ { age: 15 }, { hello: 'world' } ] }).should.equal(true);
+        model.match({ hello: 'world', age: 15 }, { $and: [ { age: 16 }, { hello: 'world' } ] }).should.equal(false);
+        model.match({ hello: 'world', age: 15 }, { $and: [ { hello: 'world' }, { age: { $lt: 20 } } ] }).should.equal(true);
+        model.match({ hello: 'world', age: 15 }, { $and: [ { hello: 'pluton' }, { age: { $lt: 20 } } ] }).should.equal(false);
+      });
+
+      it('Subquery should not match for a $not to match', function () {
+        model.match({ a: 5, b: 10 }, { a: 5 }).should.equal(true);
+        model.match({ a: 5, b: 10 }, { $not: { a: 5 } }).should.equal(false);
+      });
+
+      it('Logical operators are all top-level, only other logical operators can be above', function () {
+        (function () { model.match({ a: { b: 7 } }, { a: { $or: [ { b: 5 }, { b: 7 } ] } })}).should.throw();
+        model.match({ a: { b: 7 } }, { $or: [ { "a.b": 5 }, { "a.b": 7 } ] }).should.equal(true);
+      });
+
+      it('Logical operators can be combined as long as they are on top of the decision tree', function () {
+        model.match({ a: 5, b: 7, c: 12 }, { $or: [ { $and: [ { a: 5 }, { b: 8 } ] }, { $and: [{ a: 5 }, { c : { $lt: 40 } }] } ] }).should.equal(true);
+        model.match({ a: 5, b: 7, c: 12 }, { $or: [ { $and: [ { a: 5 }, { b: 8 } ] }, { $and: [{ a: 5 }, { c : { $lt: 10 } }] } ] }).should.equal(false);
+      });
+
+      it('Should throw an error if a logical operator is used without an array or if an unknown logical operator is used', function () {
+        (function () { model.match({ a: 5 }, { $or: { a: 5, a: 6 } }); }).should.throw();
+        (function () { model.match({ a: 5 }, { $and: { a: 5, a: 6 } }); }).should.throw();
+        (function () { model.match({ a: 5 }, { $unknown: [ { a: 5 } ] }); }).should.throw();
+      });
+
+    });
+
+
+    describe('Comparison operator $where', function () {
+
+      it('Function should match and not match correctly', function () {
+        model.match({ a: 4}, { $where: function () { return this.a === 4; } }).should.equal(true);
+        model.match({ a: 4}, { $where: function () { return this.a === 5; } }).should.equal(false);
+      });
+
+      it('Should throw an error if the $where function is not, in fact, a function', function () {
+        (function () { model.match({ a: 4 }, { $where: 'not a function' }); }).should.throw();
+      });
+
+      it('Should throw an error if the $where function returns a non-boolean', function () {
+        (function () { model.match({ a: 4 }, { $where: function () { return 'not a boolean'; } }); }).should.throw();
+      });
+
+      it('Should be able to do the complex matching it must be used for', function () {
+        var checkEmail = function() {
+          if (!this.firstName || !this.lastName) { return false; }
+          return this.firstName.toLowerCase() + "." + this.lastName.toLowerCase() + "@gmail.com" === this.email;
+        };
+        model.match({ firstName: "John", lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(true);
+        model.match({ firstName: "john", lastName: "doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(true);
+        model.match({ firstName: "Jane", lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
+        model.match({ firstName: "John", lastName: "Deere", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
+        model.match({ lastName: "Doe", email: "john.doe@gmail.com" }, { $where: checkEmail }).should.equal(false);
+      });
+
+    });
+
+
+    describe('Array fields', function () {
+
+      it('Field equality', function () {
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'python' }).should.equal(false);
+        model.match({ tags: ['node', 'js', 'db'] }, { tagss: 'js' }).should.equal(false);
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js' }).should.equal(true);
+        model.match({ tags: ['node', 'js', 'db'] }, { tags: 'js', tags: 'node' }).should.equal(true);
+
+        // Mixed matching with array and non array
+        model.match({ tags: ['node', 'js', 'db'], nedb: true }, { tags: 'js', nedb: true }).should.equal(true);
+
+        // Nested matching
+        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { "data.tags": 'js' }).should.equal(true);
+        model.match({ number: 5, data: { tags: ['node', 'js', 'db'] } }, { "data.tags": 'j' }).should.equal(false);
+      });
+
+      it('With one comparison operator', function () {
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 2 } }).should.equal(false);
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 3 } }).should.equal(false);
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 4 } }).should.equal(true);
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 8 } }).should.equal(true);
+        model.match({ ages: [3, 7, 12] }, { ages: { $lt: 13 } }).should.equal(true);
+      });
+
+      it('Works with arrays that are in subdocuments', function () {
+        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 2 } }).should.equal(false);
+        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 3 } }).should.equal(false);
+        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 4 } }).should.equal(true);
+        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 8 } }).should.equal(true);
+        model.match({ children: { ages: [3, 7, 12] } }, { "children.ages": { $lt: 13 } }).should.equal(true);
+      });
+
+      it('Can query inside arrays thanks to dot notation', function () {
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 2 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 3 } }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 4 } }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 8 } }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.age": { $lt: 13 } }).should.equal(true);
+
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Louis' }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Louie' }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.name": 'Lewi' }).should.equal(false);
+      });
+
+      it('Can query for a specific element inside arrays thanks to dot notation', function () {
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.0.name": 'Louie' }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.1.name": 'Louie' }).should.equal(false);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.2.name": 'Louie' }).should.equal(true);
+        model.match({ childrens: [ { name: "Huey", age: 3 }, { name: "Dewey", age: 7 }, { name: "Louie", age: 12 } ] }, { "childrens.3.name": 'Louie' }).should.equal(false);
+      });
+
+      it('A single array-specific operator and the query is treated as array specific', function () {
+        (function () { model.match({ childrens: [ 'Riri', 'Fifi', 'Loulou' ] }, { "childrens": { "Fifi": true, $size: 3 } })}).should.throw();
+      });
+
+      it('Can mix queries on array fields and non array filds with array specific operators', function () {
+        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 2 }, uncle: 'Donald' }).should.equal(false);
+        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Donald' }).should.equal(true);
+        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 4 }, uncle: 'Donald' }).should.equal(false);
+
+        model.match({ uncle: 'Donals', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Picsou' }).should.equal(false);
+        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Donald' }).should.equal(true);
+        model.match({ uncle: 'Donald', nephews: [ 'Riri', 'Fifi', 'Loulou' ] }, { nephews: { $size: 3 }, uncle: 'Daisy' }).should.equal(false);
+      });
+
+    });
+
+  });   // ==== End of 'Querying' ==== //
+
+});

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -1,0 +1,926 @@
+var should = require('chai').should()
+  , assert = require('chai').assert
+  , testDb = 'workspace/test.db'
+  , fs = require('fs')
+  , path = require('path')
+  , _ = require('underscore')
+  , async = require('async')
+  , model = require('../src/nedb/model')
+  , customUtils = require('../src/nedb/customUtils')
+  , Datastore = require('../src/nedb/datastore')
+  , Persistence = require('../src/nedb/persistence')
+  , storage = require('../src/nedb/storage')
+  , child_process = require('child_process')
+;
+
+
+describe('Persistence', function () {
+  var d;
+
+  beforeEach(function (done) {
+    d = new Datastore({ filename: testDb });
+    d.filename.should.equal(testDb);
+    d.inMemoryOnly.should.equal(false);
+
+    async.waterfall([
+      function (cb) {
+        Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
+          fs.exists(testDb, function (exists) {
+            if (exists) {
+              fs.unlink(testDb, cb);
+            } else { return cb(); }
+          });
+        });
+      }
+    , function (cb) {
+  d.loadDatabase(function (err) {
+    assert.isNull(err);
+    d.getAllData().length.should.equal(0);
+    return cb();
+  });
+    }
+    ], done);
+  });
+
+  it('Every line represents a document', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
+    model.serialize({ _id: "3", nested: { today: now } })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(3);
+    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+    _.isEqual(treatedData[2], { _id: "3", nested: { today: now } }).should.equal(true);
+  });
+
+  it('Badly formatted lines have no impact on the treated data', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    'garbage\n' +
+    model.serialize({ _id: "3", nested: { today: now } })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "3", nested: { today: now } }).should.equal(true);
+  });
+
+  it('Well formatted lines that have no _id are not included in the data', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
+    model.serialize({ nested: { today: now } })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+  });
+
+  it('If two lines concern the same doc (= same _id), the last one is the good version', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
+    model.serialize({ _id: "1", nested: { today: now } })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "1", nested: { today: now } }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
+  });
+
+  it('If a doc contains $$deleted: true, that means we need to remove it from the data', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
+    model.serialize({ _id: "1", $$deleted: true }) + '\n' +
+    model.serialize({ _id: "3", today: now })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "2", hello: 'world' }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+  });
+
+  it('If a doc contains $$deleted: true, no error is thrown if the doc wasnt in the list before', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ _id: "2", $$deleted: true }) + '\n' +
+    model.serialize({ _id: "3", today: now })
+      , treatedData = d.persistence.treatRawData(rawData).data
+    ;
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+  });
+
+  it('If a doc contains $$indexCreated, no error is thrown during treatRawData and we can get the index options', function () {
+    var now = new Date()
+      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
+    model.serialize({ $$indexCreated: { fieldName: "test", unique: true } }) + '\n' +
+    model.serialize({ _id: "3", today: now })
+      , treatedData = d.persistence.treatRawData(rawData).data
+      , indexes = d.persistence.treatRawData(rawData).indexes
+    ;
+
+    Object.keys(indexes).length.should.equal(1);
+    assert.deepEqual(indexes.test, { fieldName: "test", unique: true });
+
+    treatedData.sort(function (a, b) { return a._id - b._id; });
+    treatedData.length.should.equal(2);
+    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
+    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
+  });
+
+  it('Compact database on load', function (done) {
+    d.insert({ a: 2 }, function () {
+      d.insert({ a: 4 }, function () {
+        d.remove({ a: 2 }, {}, function () {
+          // Here, the underlying file is 3 lines long for only one document
+          var data = fs.readFileSync(d.filename, 'utf8').split('\n')
+            , filledCount = 0;
+
+          data.forEach(function (item) { if (item.length > 0) { filledCount += 1; } });
+          filledCount.should.equal(3);
+
+          d.loadDatabase(function (err) {
+            assert.isNull(err);
+
+            // Now, the file has been compacted and is only 1 line long
+            var data = fs.readFileSync(d.filename, 'utf8').split('\n')
+              , filledCount = 0;
+
+            data.forEach(function (item) { if (item.length > 0) { filledCount += 1; } });
+            filledCount.should.equal(1);
+
+            done();
+          });
+        })
+      });
+    });
+  });
+
+  it('Calling loadDatabase after the data was modified doesnt change its contents', function (done) {
+    d.loadDatabase(function () {
+      d.insert({ a: 1 }, function (err) {
+        assert.isNull(err);
+        d.insert({ a: 2 }, function (err) {
+          var data = d.getAllData()
+            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
+            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
+          ;
+          assert.isNull(err);
+          data.length.should.equal(2);
+          doc1.a.should.equal(1);
+          doc2.a.should.equal(2);
+
+          d.loadDatabase(function (err) {
+            var data = d.getAllData()
+              , doc1 = _.find(data, function (doc) { return doc.a === 1; })
+              , doc2 = _.find(data, function (doc) { return doc.a === 2; })
+            ;
+            assert.isNull(err);
+            data.length.should.equal(2);
+            doc1.a.should.equal(1);
+            doc2.a.should.equal(2);
+
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  it('Calling loadDatabase after the datafile was removed will reset the database', function (done) {
+    d.loadDatabase(function () {
+      d.insert({ a: 1 }, function (err) {
+        assert.isNull(err);
+        d.insert({ a: 2 }, function (err) {
+          var data = d.getAllData()
+            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
+            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
+          ;
+          assert.isNull(err);
+          data.length.should.equal(2);
+          doc1.a.should.equal(1);
+          doc2.a.should.equal(2);
+
+          fs.unlink(testDb, function (err) {
+            assert.isNull(err);
+            d.loadDatabase(function (err) {
+              assert.isNull(err);
+              d.getAllData().length.should.equal(0);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('Calling loadDatabase after the datafile was modified loads the new data', function (done) {
+    d.loadDatabase(function () {
+      d.insert({ a: 1 }, function (err) {
+        assert.isNull(err);
+        d.insert({ a: 2 }, function (err) {
+          var data = d.getAllData()
+            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
+            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
+          ;
+          assert.isNull(err);
+          data.length.should.equal(2);
+          doc1.a.should.equal(1);
+          doc2.a.should.equal(2);
+
+          fs.writeFile(testDb, '{"a":3,"_id":"aaa"}', 'utf8', function (err) {
+            assert.isNull(err);
+            d.loadDatabase(function (err) {
+              var data = d.getAllData()
+                , doc1 = _.find(data, function (doc) { return doc.a === 1; })
+                , doc2 = _.find(data, function (doc) { return doc.a === 2; })
+                , doc3 = _.find(data, function (doc) { return doc.a === 3; })
+              ;
+              assert.isNull(err);
+              data.length.should.equal(1);
+              doc3.a.should.equal(3);
+              assert.isUndefined(doc1);
+              assert.isUndefined(doc2);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it("When treating raw data, refuse to proceed if too much data is corrupt, to avoid data loss", function (done) {
+    var corruptTestFilename = 'workspace/corruptTest.db'
+      , fakeData = '{"_id":"one","hello":"world"}\n' + 'Some corrupt data\n' + '{"_id":"two","hello":"earth"}\n' + '{"_id":"three","hello":"you"}\n'
+      , d
+    ;
+    fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
+
+    // Default corruptAlertThreshold
+    d = new Datastore({ filename: corruptTestFilename });
+    d.loadDatabase(function (err) {
+      assert.isDefined(err);
+      assert.isNotNull(err);
+
+      fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
+      d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 1 });
+      d.loadDatabase(function (err) {
+        assert.isNull(err);
+
+        fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
+        d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 0 });
+        d.loadDatabase(function (err) {
+          assert.isDefined(err);
+          assert.isNotNull(err);
+
+          done();
+        });
+      });
+    });
+  });
+
+  it("Can listen to compaction events", function (done) {
+    d.on('compaction.done', function () {
+      d.removeAllListeners('compaction.done');   // Tidy up for next tests
+      done();
+    });
+
+    d.persistence.compactDatafile();
+  });
+
+
+  describe('Serialization hooks', function () {
+    var as = function (s) { return "before_" + s + "_after"; }
+      , bd = function (s) { return s.substring(7, s.length - 6); }
+
+    it("Declaring only one hook will throw an exception to prevent data loss", function (done) {
+      var hookTestFilename = 'workspace/hookTest.db'
+      storage.ensureFileDoesntExist(hookTestFilename, function () {
+        fs.writeFileSync(hookTestFilename, "Some content", "utf8");
+
+        (function () {
+          new Datastore({ filename: hookTestFilename, autoload: true
+                        , afterSerialization: as
+          });
+        }).should.throw();
+
+        // Data file left untouched
+        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+
+        (function () {
+          new Datastore({ filename: hookTestFilename, autoload: true
+                        , beforeDeserialization: bd
+          });
+        }).should.throw();
+
+        // Data file left untouched
+        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+
+        done();
+      });
+    });
+
+    it("Declaring two hooks that are not reverse of one another will cause an exception to prevent data loss", function (done) {
+      var hookTestFilename = 'workspace/hookTest.db'
+      storage.ensureFileDoesntExist(hookTestFilename, function () {
+        fs.writeFileSync(hookTestFilename, "Some content", "utf8");
+
+        (function () {
+          new Datastore({ filename: hookTestFilename, autoload: true
+                        , afterSerialization: as
+                        , beforeDeserialization: function (s) { return s; }
+          });
+        }).should.throw();
+
+        // Data file left untouched
+        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+
+        done();
+      });
+    });
+
+    it("A serialization hook can be used to transform data before writing new state to disk", function (done) {
+      var hookTestFilename = 'workspace/hookTest.db'
+      storage.ensureFileDoesntExist(hookTestFilename, function () {
+        var d = new Datastore({ filename: hookTestFilename, autoload: true
+          , afterSerialization: as
+          , beforeDeserialization: bd
+        })
+        ;
+
+        d.insert({ hello: "world" }, function () {
+          var _data = fs.readFileSync(hookTestFilename, 'utf8')
+            , data = _data.split('\n')
+            , doc0 = bd(data[0])
+          ;
+
+          data.length.should.equal(2);
+
+          data[0].substring(0, 7).should.equal('before_');
+          data[0].substring(data[0].length - 6).should.equal('_after');
+
+          doc0 = model.deserialize(doc0);
+          Object.keys(doc0).length.should.equal(2);
+          doc0.hello.should.equal('world');
+
+          d.insert({ p: 'Mars' }, function () {
+            var _data = fs.readFileSync(hookTestFilename, 'utf8')
+              , data = _data.split('\n')
+              , doc0 = bd(data[0])
+              , doc1 = bd(data[1])
+            ;
+
+            data.length.should.equal(3);
+
+            data[0].substring(0, 7).should.equal('before_');
+            data[0].substring(data[0].length - 6).should.equal('_after');
+            data[1].substring(0, 7).should.equal('before_');
+            data[1].substring(data[1].length - 6).should.equal('_after');
+
+            doc0 = model.deserialize(doc0);
+            Object.keys(doc0).length.should.equal(2);
+            doc0.hello.should.equal('world');
+
+            doc1 = model.deserialize(doc1);
+            Object.keys(doc1).length.should.equal(2);
+            doc1.p.should.equal('Mars');
+
+            d.ensureIndex({ fieldName: 'idefix' }, function () {
+              var _data = fs.readFileSync(hookTestFilename, 'utf8')
+                , data = _data.split('\n')
+                , doc0 = bd(data[0])
+                , doc1 = bd(data[1])
+                , idx = bd(data[2])
+              ;
+
+              data.length.should.equal(4);
+
+              data[0].substring(0, 7).should.equal('before_');
+              data[0].substring(data[0].length - 6).should.equal('_after');
+              data[1].substring(0, 7).should.equal('before_');
+              data[1].substring(data[1].length - 6).should.equal('_after');
+
+              doc0 = model.deserialize(doc0);
+              Object.keys(doc0).length.should.equal(2);
+              doc0.hello.should.equal('world');
+
+              doc1 = model.deserialize(doc1);
+              Object.keys(doc1).length.should.equal(2);
+              doc1.p.should.equal('Mars');
+
+              idx = model.deserialize(idx);
+              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } });
+
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    it("Use serialization hook when persisting cached database or compacting", function (done) {
+      var hookTestFilename = 'workspace/hookTest.db'
+      storage.ensureFileDoesntExist(hookTestFilename, function () {
+        var d = new Datastore({ filename: hookTestFilename, autoload: true
+          , afterSerialization: as
+          , beforeDeserialization: bd
+        })
+        ;
+
+        d.insert({ hello: "world" }, function () {
+          d.update({ hello: "world" }, { $set: { hello: "earth" } }, {}, function () {
+            d.ensureIndex({ fieldName: 'idefix' }, function () {
+              var _data = fs.readFileSync(hookTestFilename, 'utf8')
+                , data = _data.split('\n')
+                , doc0 = bd(data[0])
+                , doc1 = bd(data[1])
+                , idx = bd(data[2])
+                , _id
+              ;
+
+              data.length.should.equal(4);
+
+              doc0 = model.deserialize(doc0);
+              Object.keys(doc0).length.should.equal(2);
+              doc0.hello.should.equal('world');
+
+              doc1 = model.deserialize(doc1);
+              Object.keys(doc1).length.should.equal(2);
+              doc1.hello.should.equal('earth');
+
+              doc0._id.should.equal(doc1._id);
+              _id = doc0._id;
+
+              idx = model.deserialize(idx);
+              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } });
+
+              d.persistence.persistCachedDatabase(function () {
+                var _data = fs.readFileSync(hookTestFilename, 'utf8')
+                  , data = _data.split('\n')
+                  , doc0 = bd(data[0])
+                  , idx = bd(data[1])
+                ;
+
+                data.length.should.equal(3);
+
+                doc0 = model.deserialize(doc0);
+                Object.keys(doc0).length.should.equal(2);
+                doc0.hello.should.equal('earth');
+
+                doc0._id.should.equal(_id);
+
+                idx = model.deserialize(idx);
+                assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix', unique: false, sparse: false } });
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it("Deserialization hook is correctly used when loading data", function (done) {
+      var hookTestFilename = 'workspace/hookTest.db'
+      storage.ensureFileDoesntExist(hookTestFilename, function () {
+        var d = new Datastore({ filename: hookTestFilename, autoload: true
+          , afterSerialization: as
+          , beforeDeserialization: bd
+        })
+        ;
+
+        d.insert({ hello: "world" }, function (err, doc) {
+          var _id = doc._id;
+          d.insert({ yo: "ya" }, function () {
+            d.update({ hello: "world" }, { $set: { hello: "earth" } }, {}, function () {
+              d.remove({ yo: "ya" }, {}, function () {
+                d.ensureIndex({ fieldName: 'idefix' }, function () {
+                  var _data = fs.readFileSync(hookTestFilename, 'utf8')
+                    , data = _data.split('\n')
+                  ;
+
+                  data.length.should.equal(6);
+
+                  // Everything is deserialized correctly, including deletes and indexes
+                  var d = new Datastore({ filename: hookTestFilename
+                    , afterSerialization: as
+                    , beforeDeserialization: bd
+                  })
+                  ;
+                  d.loadDatabase(function () {
+                    d.find({}, function (err, docs) {
+                      docs.length.should.equal(1);
+                      docs[0].hello.should.equal("earth");
+                      docs[0]._id.should.equal(_id);
+
+                      Object.keys(d.indexes).length.should.equal(2);
+                      Object.keys(d.indexes).indexOf("idefix").should.not.equal(-1);
+
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+  });   // ==== End of 'Serialization hooks' ==== //
+
+  describe('Prevent dataloss when persisting data', function () {
+
+    it('Creating a datastore with in memory as true and a bad filename wont cause an error', function () {
+      new Datastore({ filename: 'workspace/bad.db~', inMemoryOnly: true });
+    })
+
+    it('Creating a persistent datastore with a bad filename will cause an error', function () {
+      (function () { new Datastore({ filename: 'workspace/bad.db~' }); }).should.throw();
+    })
+
+    it('If no file exists, ensureDatafileIntegrity creates an empty datafile', function (done) {
+      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+
+      fs.existsSync('workspace/it.db').should.equal(false);
+      fs.existsSync('workspace/it.db~').should.equal(false);
+
+      storage.ensureDatafileIntegrity(p.filename, function (err) {
+        assert.isNull(err);
+
+        fs.existsSync('workspace/it.db').should.equal(true);
+        fs.existsSync('workspace/it.db~').should.equal(false);
+
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('');
+
+        done();
+      });
+    });
+
+    it('If only datafile exists, ensureDatafileIntegrity will use it', function (done) {
+      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+
+      fs.writeFileSync('workspace/it.db', 'something', 'utf8');
+
+      fs.existsSync('workspace/it.db').should.equal(true);
+      fs.existsSync('workspace/it.db~').should.equal(false);
+
+      storage.ensureDatafileIntegrity(p.filename, function (err) {
+        assert.isNull(err);
+
+        fs.existsSync('workspace/it.db').should.equal(true);
+        fs.existsSync('workspace/it.db~').should.equal(false);
+
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something');
+
+        done();
+      });
+    });
+
+    it('If temp datafile exists and datafile doesnt, ensureDatafileIntegrity will use it (cannot happen except upon first use)', function (done) {
+      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~~'); }
+
+      fs.writeFileSync('workspace/it.db~', 'something', 'utf8');
+
+      fs.existsSync('workspace/it.db').should.equal(false);
+      fs.existsSync('workspace/it.db~').should.equal(true);
+
+      storage.ensureDatafileIntegrity(p.filename, function (err) {
+        assert.isNull(err);
+
+        fs.existsSync('workspace/it.db').should.equal(true);
+        fs.existsSync('workspace/it.db~').should.equal(false);
+
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something');
+
+        done();
+      });
+    });
+
+    // Technically it could also mean the write was successful but the rename wasn't, but there is in any case no guarantee that the data in the temp file is whole so we have to discard the whole file
+    it('If both temp and current datafiles exist, ensureDatafileIntegrity will use the datafile, as it means that the write of the temp file failed', function (done) {
+      var theDb = new Datastore({ filename: 'workspace/it.db' });
+
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+
+      fs.writeFileSync('workspace/it.db', '{"_id":"0","hello":"world"}', 'utf8');
+      fs.writeFileSync('workspace/it.db~', '{"_id":"0","hello":"other"}', 'utf8');
+
+      fs.existsSync('workspace/it.db').should.equal(true);
+      fs.existsSync('workspace/it.db~').should.equal(true);
+
+      storage.ensureDatafileIntegrity(theDb.persistence.filename, function (err) {
+        assert.isNull(err);
+
+        fs.existsSync('workspace/it.db').should.equal(true);
+        fs.existsSync('workspace/it.db~').should.equal(true);
+
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('{"_id":"0","hello":"world"}');
+
+        theDb.loadDatabase(function (err) {
+          assert.isNull(err);
+          theDb.find({}, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(1);
+            docs[0].hello.should.equal("world");
+            fs.existsSync('workspace/it.db').should.equal(true);
+            fs.existsSync('workspace/it.db~').should.equal(false);
+            done();
+          });
+        });
+      });
+    });
+
+    it('persistCachedDatabase should update the contents of the datafile and leave a clean state', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
+          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~'); }
+          fs.existsSync(testDb).should.equal(false);
+
+          fs.writeFileSync(testDb + '~', 'something', 'utf8');
+          fs.existsSync(testDb + '~').should.equal(true);
+
+          d.persistence.persistCachedDatabase(function (err) {
+            var contents = fs.readFileSync(testDb, 'utf8');
+            assert.isNull(err);
+            fs.existsSync(testDb).should.equal(true);
+            fs.existsSync(testDb + '~').should.equal(false);
+            if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
+              throw new Error("Datafile contents not as expected");
+            }
+            done();
+          });
+        });
+      });
+    });
+
+    it('After a persistCachedDatabase, there should be no temp or old filename', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
+          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~'); }
+          fs.existsSync(testDb).should.equal(false);
+          fs.existsSync(testDb + '~').should.equal(false);
+
+          fs.writeFileSync(testDb + '~', 'bloup', 'utf8');
+          fs.existsSync(testDb + '~').should.equal(true);
+
+          d.persistence.persistCachedDatabase(function (err) {
+            var contents = fs.readFileSync(testDb, 'utf8');
+            assert.isNull(err);
+            fs.existsSync(testDb).should.equal(true);
+            fs.existsSync(testDb + '~').should.equal(false);
+            if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
+              throw new Error("Datafile contents not as expected");
+            }
+            done();
+          });
+        });
+      });
+    });
+
+    it('persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile', function (done) {
+      d.insert({ hello: 'world' }, function () {
+        d.find({}, function (err, docs) {
+          docs.length.should.equal(1);
+
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
+          fs.writeFileSync(testDb + '~', 'blabla', 'utf8');
+          fs.existsSync(testDb).should.equal(false);
+          fs.existsSync(testDb + '~').should.equal(true);
+
+          d.persistence.persistCachedDatabase(function (err) {
+            var contents = fs.readFileSync(testDb, 'utf8');
+            assert.isNull(err);
+            fs.existsSync(testDb).should.equal(true);
+            fs.existsSync(testDb + '~').should.equal(false);
+            if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
+              throw new Error("Datafile contents not as expected");
+            }
+            done();
+          });
+        });
+      });
+    });
+
+    it('persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile', function (done) {
+      var dbFile = 'workspace/test2.db', theDb;
+
+      if (fs.existsSync(dbFile)) { fs.unlinkSync(dbFile); }
+      if (fs.existsSync(dbFile + '~')) { fs.unlinkSync(dbFile + '~'); }
+
+      theDb = new Datastore({ filename: dbFile });
+
+      theDb.loadDatabase(function (err) {
+        var contents = fs.readFileSync(dbFile, 'utf8');
+        assert.isNull(err);
+        fs.existsSync(dbFile).should.equal(true);
+        fs.existsSync(dbFile + '~').should.equal(false);
+        if (contents != "") {
+          throw new Error("Datafile contents not as expected");
+        }
+        done();
+      });
+    });
+
+    it('Persistence works as expected when everything goes fine', function (done) {
+      var dbFile = 'workspace/test2.db', theDb, theDb2, doc1, doc2;
+
+      async.waterfall([
+          async.apply(storage.ensureFileDoesntExist, dbFile)
+        , async.apply(storage.ensureFileDoesntExist, dbFile + '~')
+        , function (cb) {
+          theDb = new Datastore({ filename: dbFile });
+          theDb.loadDatabase(cb);
+        }
+        , function (cb) {
+          theDb.find({}, function (err, docs) {
+            assert.isNull(err);
+            docs.length.should.equal(0);
+            return cb();
+          });
+        }
+      , function (cb) {
+        theDb.insert({ a: 'hello' }, function (err, _doc1) {
+        assert.isNull(err);
+          doc1 = _doc1;
+          theDb.insert({ a: 'world' }, function (err, _doc2) {
+            assert.isNull(err);
+            doc2 = _doc2;
+            return cb();
+          });
+        });
+      }
+      , function (cb) {
+        theDb.find({}, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(2);
+          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
+          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
+          return cb();
+        });
+      }
+      , function (cb) {
+        theDb.loadDatabase(cb);
+      }
+      , function (cb) {   // No change
+        theDb.find({}, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(2);
+          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
+          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
+          return cb();
+        });
+      }
+      , function (cb) {
+        fs.existsSync(dbFile).should.equal(true);
+        fs.existsSync(dbFile + '~').should.equal(false);
+        return cb();
+      }
+      , function (cb) {
+        theDb2 = new Datastore({ filename: dbFile });
+        theDb2.loadDatabase(cb);
+      }
+      , function (cb) {   // No change in second db
+        theDb2.find({}, function (err, docs) {
+          assert.isNull(err);
+          docs.length.should.equal(2);
+          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
+          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
+          return cb();
+        });
+      }
+      , function (cb) {
+        fs.existsSync(dbFile).should.equal(true);
+        fs.existsSync(dbFile + '~').should.equal(false);
+        return cb();
+      }
+      ], done);
+    });
+
+    // The child process will load the database with the given datafile, but the fs.writeFile function
+    // is rewritten to crash the process before it finished (after 5000 bytes), to ensure data was not lost
+    it('If system crashes during a loadDatabase, the former version is not lost', function (done) {
+      var N = 500, toWrite = "", i, doc_i;
+
+      // Ensuring the state is clean
+      if (fs.existsSync('workspace/lac.db')) { fs.unlinkSync('workspace/lac.db'); }
+      if (fs.existsSync('workspace/lac.db~')) { fs.unlinkSync('workspace/lac.db~'); }
+
+      // Creating a db file with 150k records (a bit long to load)
+      for (i = 0; i < N; i += 1) {
+        toWrite += model.serialize({ _id: 'anid_' + i, hello: 'world' }) + '\n';
+      }
+      fs.writeFileSync('workspace/lac.db', toWrite, 'utf8');
+
+      var datafileLength = fs.readFileSync('workspace/lac.db', 'utf8').length;
+
+      // Loading it in a separate process that we will crash before finishing the loadDatabase
+      child_process.fork('test_lac/loadAndCrash.test').on('exit', function (code) {
+        code.should.equal(1);   // See test_lac/loadAndCrash.test.js
+
+        fs.existsSync('workspace/lac.db').should.equal(true);
+        fs.existsSync('workspace/lac.db~').should.equal(true);
+        fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength);
+        fs.readFileSync('workspace/lac.db~', 'utf8').length.should.equal(5000);
+
+        // Reload database without a crash, check that no data was lost and fs state is clean (no temp file)
+        var db = new Datastore({ filename: 'workspace/lac.db' });
+        db.loadDatabase(function (err) {
+          assert.isNull(err);
+
+          fs.existsSync('workspace/lac.db').should.equal(true);
+          fs.existsSync('workspace/lac.db~').should.equal(false);
+          fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength);
+
+          db.find({}, function (err, docs) {
+            docs.length.should.equal(N);
+            for (i = 0; i < N; i += 1) {
+              doc_i = _.find(docs, function (d) { return d._id === 'anid_' + i; });
+              assert.isDefined(doc_i);
+              assert.deepEqual({ hello: 'world', _id: 'anid_' + i }, doc_i);
+            }
+            return done();
+          });
+        });
+      });
+    });
+
+    // Not run on Windows as there is no clean way to set maximum file descriptors. Not an issue as the code itself is tested.
+    it("Cannot cause EMFILE errors by opening too many file descriptors", function (done) {
+      if (process.platform === 'win32' || process.platform === 'win64') { return done(); }
+      child_process.execFile('test_lac/openFdsLaunch.sh', function (err, stdout, stderr) {
+        if (err) { return done(err); }
+
+        // The subprocess will not output anything to stdout unless part of the test fails
+        if (stdout.length !== 0) {
+          return done(stdout);
+        } else {
+          return done();
+        }
+      });
+    });
+
+  });   // ==== End of 'Prevent dataloss when persisting data' ====
+
+
+  describe('ensureFileDoesntExist', function () {
+
+    it('Doesnt do anything if file already doesnt exist', function (done) {
+      storage.ensureFileDoesntExist('workspace/nonexisting', function (err) {
+        assert.isNull(err);
+        fs.existsSync('workspace/nonexisting').should.equal(false);
+        done();
+      });
+    });
+
+    it('Deletes file if it exists', function (done) {
+      fs.writeFileSync('workspace/existing', 'hello world', 'utf8');
+      fs.existsSync('workspace/existing').should.equal(true);
+
+      storage.ensureFileDoesntExist('workspace/existing', function (err) {
+        assert.isNull(err);
+        fs.existsSync('workspace/existing').should.equal(false);
+        done();
+      });
+    });
+
+  });   // ==== End of 'ensureFileDoesntExist' ====
+
+
+});

--- a/test/persistence.test.js
+++ b/test/persistence.test.js
@@ -1,926 +1,910 @@
-var should = require('chai').should()
-  , assert = require('chai').assert
-  , testDb = 'workspace/test.db'
-  , fs = require('fs')
-  , path = require('path')
-  , _ = require('underscore')
-  , async = require('async')
-  , model = require('../src/nedb/model')
-  , customUtils = require('../src/nedb/customUtils')
-  , Datastore = require('../src/nedb/datastore')
-  , Persistence = require('../src/nedb/persistence')
-  , storage = require('../src/nedb/storage')
-  , child_process = require('child_process')
-;
-
+const should = require('chai').should()
+const assert = require('chai').assert
+const testDb = 'workspace/test.db'
+const fs = require('fs')
+const path = require('path')
+const _ = require('underscore')
+const async = require('async')
+const model = require('../src/nedb/model')
+const customUtils = require('../src/nedb/customUtils')
+const Datastore = require('../src/nedb/datastore')
+const Persistence = require('../src/nedb/persistence')
+const storage = require('../src/nedb/storage')
+const child_process = require('child_process')
 
 describe('Persistence', function () {
-  var d;
+  let d
 
   beforeEach(function (done) {
-    d = new Datastore({ filename: testDb });
-    d.filename.should.equal(testDb);
-    d.inMemoryOnly.should.equal(false);
+    d = new Datastore({ filename: testDb })
+    d.filename.should.equal(testDb)
+    d.inMemoryOnly.should.equal(false)
 
     async.waterfall([
       function (cb) {
         Persistence.ensureDirectoryExists(path.dirname(testDb), function () {
           fs.exists(testDb, function (exists) {
             if (exists) {
-              fs.unlink(testDb, cb);
-            } else { return cb(); }
-          });
-        });
+              fs.unlink(testDb, cb)
+            } else { return cb() }
+          })
+        })
       }
-    , function (cb) {
-  d.loadDatabase(function (err) {
-    assert.isNull(err);
-    d.getAllData().length.should.equal(0);
-    return cb();
-  });
-    }
-    ], done);
-  });
+      , function (cb) {
+        d.loadDatabase(function (err) {
+          assert.isNull(err)
+          d.getAllData().length.should.equal(0)
+          return cb()
+        })
+      }
+    ], done)
+  })
 
   it('Every line represents a document', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
-    model.serialize({ _id: "3", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ _id: '2', hello: 'world' }) + '\n' +
+      model.serialize({ _id: '3', nested: { today: now } })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(3);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
-    _.isEqual(treatedData[2], { _id: "3", nested: { today: now } }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(3)
+    _.isEqual(treatedData[0], { _id: '1', a: 2, ages: [1, 5, 12] }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '2', hello: 'world' }).should.equal(true)
+    _.isEqual(treatedData[2], { _id: '3', nested: { today: now } }).should.equal(true)
+  })
 
   it('Badly formatted lines have no impact on the treated data', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    'garbage\n' +
-    model.serialize({ _id: "3", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      'garbage\n' +
+      model.serialize({ _id: '3', nested: { today: now } })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", nested: { today: now } }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '1', a: 2, ages: [1, 5, 12] }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '3', nested: { today: now } }).should.equal(true)
+  })
 
   it('Well formatted lines that have no _id are not included in the data', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
-    model.serialize({ nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ _id: '2', hello: 'world' }) + '\n' +
+      model.serialize({ nested: { today: now } })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '1', a: 2, ages: [1, 5, 12] }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '2', hello: 'world' }).should.equal(true)
+  })
 
   it('If two lines concern the same doc (= same _id), the last one is the good version', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
-    model.serialize({ _id: "1", nested: { today: now } })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ _id: '2', hello: 'world' }) + '\n' +
+      model.serialize({ _id: '1', nested: { today: now } })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", nested: { today: now } }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "2", hello: 'world' }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '1', nested: { today: now } }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '2', hello: 'world' }).should.equal(true)
+  })
 
   it('If a doc contains $$deleted: true, that means we need to remove it from the data', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ _id: "2", hello: 'world' }) + '\n' +
-    model.serialize({ _id: "1", $$deleted: true }) + '\n' +
-    model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ _id: '2', hello: 'world' }) + '\n' +
+      model.serialize({ _id: '1', $$deleted: true }) + '\n' +
+      model.serialize({ _id: '3', today: now })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "2", hello: 'world' }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '2', hello: 'world' }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '3', today: now }).should.equal(true)
+  })
 
   it('If a doc contains $$deleted: true, no error is thrown if the doc wasnt in the list before', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ _id: "2", $$deleted: true }) + '\n' +
-    model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ _id: '2', $$deleted: true }) + '\n' +
+      model.serialize({ _id: '3', today: now })
+    const treatedData = d.persistence.treatRawData(rawData).data
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '1', a: 2, ages: [1, 5, 12] }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '3', today: now }).should.equal(true)
+  })
 
   it('If a doc contains $$indexCreated, no error is thrown during treatRawData and we can get the index options', function () {
-    var now = new Date()
-      , rawData = model.serialize({ _id: "1", a: 2, ages: [1, 5, 12] }) + '\n' +
-    model.serialize({ $$indexCreated: { fieldName: "test", unique: true } }) + '\n' +
-    model.serialize({ _id: "3", today: now })
-      , treatedData = d.persistence.treatRawData(rawData).data
-      , indexes = d.persistence.treatRawData(rawData).indexes
-    ;
+    const now = new Date()
+    const rawData = model.serialize({ _id: '1', a: 2, ages: [1, 5, 12] }) + '\n' +
+      model.serialize({ $$indexCreated: { fieldName: 'test', unique: true } }) + '\n' +
+      model.serialize({ _id: '3', today: now })
+    const treatedData = d.persistence.treatRawData(rawData).data
+    const indexes = d.persistence.treatRawData(rawData).indexes
 
-    Object.keys(indexes).length.should.equal(1);
-    assert.deepEqual(indexes.test, { fieldName: "test", unique: true });
+    Object.keys(indexes).length.should.equal(1)
+    assert.deepEqual(indexes.test, { fieldName: 'test', unique: true })
 
-    treatedData.sort(function (a, b) { return a._id - b._id; });
-    treatedData.length.should.equal(2);
-    _.isEqual(treatedData[0], { _id: "1", a: 2, ages: [1, 5, 12] }).should.equal(true);
-    _.isEqual(treatedData[1], { _id: "3", today: now }).should.equal(true);
-  });
+    treatedData.sort(function (a, b) { return a._id - b._id })
+    treatedData.length.should.equal(2)
+    _.isEqual(treatedData[0], { _id: '1', a: 2, ages: [1, 5, 12] }).should.equal(true)
+    _.isEqual(treatedData[1], { _id: '3', today: now }).should.equal(true)
+  })
 
   it('Compact database on load', function (done) {
     d.insert({ a: 2 }, function () {
       d.insert({ a: 4 }, function () {
         d.remove({ a: 2 }, {}, function () {
           // Here, the underlying file is 3 lines long for only one document
-          var data = fs.readFileSync(d.filename, 'utf8').split('\n')
-            , filledCount = 0;
+          const data = fs.readFileSync(d.filename, 'utf8').split('\n')
+          let filledCount = 0
 
-          data.forEach(function (item) { if (item.length > 0) { filledCount += 1; } });
-          filledCount.should.equal(3);
+          data.forEach(function (item) { if (item.length > 0) { filledCount += 1 } })
+          filledCount.should.equal(3)
 
           d.loadDatabase(function (err) {
-            assert.isNull(err);
+            assert.isNull(err)
 
             // Now, the file has been compacted and is only 1 line long
-            var data = fs.readFileSync(d.filename, 'utf8').split('\n')
-              , filledCount = 0;
+            const data = fs.readFileSync(d.filename, 'utf8').split('\n')
+            let filledCount = 0
 
-            data.forEach(function (item) { if (item.length > 0) { filledCount += 1; } });
-            filledCount.should.equal(1);
+            data.forEach(function (item) { if (item.length > 0) { filledCount += 1 } })
+            filledCount.should.equal(1)
 
-            done();
-          });
+            done()
+          })
         })
-      });
-    });
-  });
+      })
+    })
+  })
 
   it('Calling loadDatabase after the data was modified doesnt change its contents', function (done) {
     d.loadDatabase(function () {
       d.insert({ a: 1 }, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
         d.insert({ a: 2 }, function (err) {
-          var data = d.getAllData()
-            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
-            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
-          ;
-          assert.isNull(err);
-          data.length.should.equal(2);
-          doc1.a.should.equal(1);
-          doc2.a.should.equal(2);
+          const data = d.getAllData()
+          const doc1 = _.find(data, function (doc) { return doc.a === 1 })
+          const doc2 = _.find(data, function (doc) { return doc.a === 2 })
+          assert.isNull(err)
+          data.length.should.equal(2)
+          doc1.a.should.equal(1)
+          doc2.a.should.equal(2)
 
           d.loadDatabase(function (err) {
-            var data = d.getAllData()
-              , doc1 = _.find(data, function (doc) { return doc.a === 1; })
-              , doc2 = _.find(data, function (doc) { return doc.a === 2; })
-            ;
-            assert.isNull(err);
-            data.length.should.equal(2);
-            doc1.a.should.equal(1);
-            doc2.a.should.equal(2);
+            const data = d.getAllData()
+            const doc1 = _.find(data, function (doc) { return doc.a === 1 })
+            const doc2 = _.find(data, function (doc) { return doc.a === 2 })
+            assert.isNull(err)
+            data.length.should.equal(2)
+            doc1.a.should.equal(1)
+            doc2.a.should.equal(2)
 
-            done();
-          });
-        });
-      });
-    });
-  });
+            done()
+          })
+        })
+      })
+    })
+  })
 
   it('Calling loadDatabase after the datafile was removed will reset the database', function (done) {
     d.loadDatabase(function () {
       d.insert({ a: 1 }, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
         d.insert({ a: 2 }, function (err) {
-          var data = d.getAllData()
-            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
-            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
-          ;
-          assert.isNull(err);
-          data.length.should.equal(2);
-          doc1.a.should.equal(1);
-          doc2.a.should.equal(2);
+          const data = d.getAllData()
+            , doc1 = _.find(data, function (doc) { return doc.a === 1 })
+            , doc2 = _.find(data, function (doc) { return doc.a === 2 })
+          assert.isNull(err)
+          data.length.should.equal(2)
+          doc1.a.should.equal(1)
+          doc2.a.should.equal(2)
 
           fs.unlink(testDb, function (err) {
-            assert.isNull(err);
+            assert.isNull(err)
             d.loadDatabase(function (err) {
-              assert.isNull(err);
-              d.getAllData().length.should.equal(0);
+              assert.isNull(err)
+              d.getAllData().length.should.equal(0)
 
-              done();
-            });
-          });
-        });
-      });
-    });
-  });
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
 
   it('Calling loadDatabase after the datafile was modified loads the new data', function (done) {
     d.loadDatabase(function () {
       d.insert({ a: 1 }, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
         d.insert({ a: 2 }, function (err) {
-          var data = d.getAllData()
-            , doc1 = _.find(data, function (doc) { return doc.a === 1; })
-            , doc2 = _.find(data, function (doc) { return doc.a === 2; })
-          ;
-          assert.isNull(err);
-          data.length.should.equal(2);
-          doc1.a.should.equal(1);
-          doc2.a.should.equal(2);
+          const data = d.getAllData()
+          const doc1 = _.find(data, function (doc) { return doc.a === 1 })
+          const doc2 = _.find(data, function (doc) { return doc.a === 2 })
+          assert.isNull(err)
+          data.length.should.equal(2)
+          doc1.a.should.equal(1)
+          doc2.a.should.equal(2)
 
           fs.writeFile(testDb, '{"a":3,"_id":"aaa"}', 'utf8', function (err) {
-            assert.isNull(err);
+            assert.isNull(err)
             d.loadDatabase(function (err) {
-              var data = d.getAllData()
-                , doc1 = _.find(data, function (doc) { return doc.a === 1; })
-                , doc2 = _.find(data, function (doc) { return doc.a === 2; })
-                , doc3 = _.find(data, function (doc) { return doc.a === 3; })
-              ;
-              assert.isNull(err);
-              data.length.should.equal(1);
-              doc3.a.should.equal(3);
-              assert.isUndefined(doc1);
-              assert.isUndefined(doc2);
+              const data = d.getAllData()
+              const doc1 = _.find(data, function (doc) { return doc.a === 1 })
+              const doc2 = _.find(data, function (doc) { return doc.a === 2 })
+              const doc3 = _.find(data, function (doc) { return doc.a === 3 })
+              assert.isNull(err)
+              data.length.should.equal(1)
+              doc3.a.should.equal(3)
+              assert.isUndefined(doc1)
+              assert.isUndefined(doc2)
 
-              done();
-            });
-          });
-        });
-      });
-    });
-  });
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
 
-  it("When treating raw data, refuse to proceed if too much data is corrupt, to avoid data loss", function (done) {
-    var corruptTestFilename = 'workspace/corruptTest.db'
-      , fakeData = '{"_id":"one","hello":"world"}\n' + 'Some corrupt data\n' + '{"_id":"two","hello":"earth"}\n' + '{"_id":"three","hello":"you"}\n'
-      , d
-    ;
-    fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
+  it('When treating raw data, refuse to proceed if too much data is corrupt, to avoid data loss', function (done) {
+    const corruptTestFilename = 'workspace/corruptTest.db'
+    const fakeData = '{"_id":"one","hello":"world"}\n' + 'Some corrupt data\n' + '{"_id":"two","hello":"earth"}\n' + '{"_id":"three","hello":"you"}\n'
+    let d
+    fs.writeFileSync(corruptTestFilename, fakeData, 'utf8')
 
     // Default corruptAlertThreshold
-    d = new Datastore({ filename: corruptTestFilename });
+    d = new Datastore({ filename: corruptTestFilename })
     d.loadDatabase(function (err) {
-      assert.isDefined(err);
-      assert.isNotNull(err);
+      assert.isDefined(err)
+      assert.isNotNull(err)
 
-      fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
-      d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 1 });
+      fs.writeFileSync(corruptTestFilename, fakeData, 'utf8')
+      d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 1 })
       d.loadDatabase(function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
 
-        fs.writeFileSync(corruptTestFilename, fakeData, "utf8");
-        d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 0 });
+        fs.writeFileSync(corruptTestFilename, fakeData, 'utf8')
+        d = new Datastore({ filename: corruptTestFilename, corruptAlertThreshold: 0 })
         d.loadDatabase(function (err) {
-          assert.isDefined(err);
-          assert.isNotNull(err);
+          assert.isDefined(err)
+          assert.isNotNull(err)
 
-          done();
-        });
-      });
-    });
-  });
+          done()
+        })
+      })
+    })
+  })
 
-  it("Can listen to compaction events", function (done) {
+  it('Can listen to compaction events', function (done) {
     d.on('compaction.done', function () {
-      d.removeAllListeners('compaction.done');   // Tidy up for next tests
-      done();
-    });
+      d.removeAllListeners('compaction.done')   // Tidy up for next tests
+      done()
+    })
 
-    d.persistence.compactDatafile();
-  });
-
+    d.persistence.compactDatafile()
+  })
 
   describe('Serialization hooks', function () {
-    var as = function (s) { return "before_" + s + "_after"; }
-      , bd = function (s) { return s.substring(7, s.length - 6); }
+    const as = function (s) { return 'before_' + s + '_after' }
+    const bd = function (s) { return s.substring(7, s.length - 6) }
 
-    it("Declaring only one hook will throw an exception to prevent data loss", function (done) {
-      var hookTestFilename = 'workspace/hookTest.db'
+    it('Declaring only one hook will throw an exception to prevent data loss', function (done) {
+      const hookTestFilename = 'workspace/hookTest.db'
       storage.ensureFileDoesntExist(hookTestFilename, function () {
-        fs.writeFileSync(hookTestFilename, "Some content", "utf8");
+        fs.writeFileSync(hookTestFilename, 'Some content', 'utf8');
 
         (function () {
-          new Datastore({ filename: hookTestFilename, autoload: true
-                        , afterSerialization: as
-          });
-        }).should.throw();
+          new Datastore({
+            filename: hookTestFilename, autoload: true
+            , afterSerialization: as
+          })
+        }).should.throw()
 
         // Data file left untouched
-        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+        fs.readFileSync(hookTestFilename, 'utf8').should.equal('Some content');
 
         (function () {
-          new Datastore({ filename: hookTestFilename, autoload: true
-                        , beforeDeserialization: bd
-          });
-        }).should.throw();
+          new Datastore({
+            filename: hookTestFilename, autoload: true
+            , beforeDeserialization: bd
+          })
+        }).should.throw()
 
         // Data file left untouched
-        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+        fs.readFileSync(hookTestFilename, 'utf8').should.equal('Some content')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-    it("Declaring two hooks that are not reverse of one another will cause an exception to prevent data loss", function (done) {
-      var hookTestFilename = 'workspace/hookTest.db'
+    it('Declaring two hooks that are not reverse of one another will cause an exception to prevent data loss', function (done) {
+      const hookTestFilename = 'workspace/hookTest.db'
       storage.ensureFileDoesntExist(hookTestFilename, function () {
-        fs.writeFileSync(hookTestFilename, "Some content", "utf8");
+        fs.writeFileSync(hookTestFilename, 'Some content', 'utf8');
 
         (function () {
-          new Datastore({ filename: hookTestFilename, autoload: true
-                        , afterSerialization: as
-                        , beforeDeserialization: function (s) { return s; }
-          });
-        }).should.throw();
+          new Datastore({
+            filename: hookTestFilename, autoload: true
+            , afterSerialization: as
+            , beforeDeserialization: function (s) { return s }
+          })
+        }).should.throw()
 
         // Data file left untouched
-        fs.readFileSync(hookTestFilename, "utf8").should.equal("Some content");
+        fs.readFileSync(hookTestFilename, 'utf8').should.equal('Some content')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
-    it("A serialization hook can be used to transform data before writing new state to disk", function (done) {
-      var hookTestFilename = 'workspace/hookTest.db'
+    it('A serialization hook can be used to transform data before writing new state to disk', function (done) {
+      const hookTestFilename = 'workspace/hookTest.db'
       storage.ensureFileDoesntExist(hookTestFilename, function () {
-        var d = new Datastore({ filename: hookTestFilename, autoload: true
+        const d = new Datastore({
+          filename: hookTestFilename, autoload: true
           , afterSerialization: as
           , beforeDeserialization: bd
         })
-        ;
 
-        d.insert({ hello: "world" }, function () {
-          var _data = fs.readFileSync(hookTestFilename, 'utf8')
-            , data = _data.split('\n')
-            , doc0 = bd(data[0])
-          ;
+        d.insert({ hello: 'world' }, function () {
+          const _data = fs.readFileSync(hookTestFilename, 'utf8')
+          const data = _data.split('\n')
+          let doc0 = bd(data[0])
 
-          data.length.should.equal(2);
+          data.length.should.equal(2)
 
-          data[0].substring(0, 7).should.equal('before_');
-          data[0].substring(data[0].length - 6).should.equal('_after');
+          data[0].substring(0, 7).should.equal('before_')
+          data[0].substring(data[0].length - 6).should.equal('_after')
 
-          doc0 = model.deserialize(doc0);
-          Object.keys(doc0).length.should.equal(2);
-          doc0.hello.should.equal('world');
+          doc0 = model.deserialize(doc0)
+          Object.keys(doc0).length.should.equal(2)
+          doc0.hello.should.equal('world')
 
           d.insert({ p: 'Mars' }, function () {
-            var _data = fs.readFileSync(hookTestFilename, 'utf8')
-              , data = _data.split('\n')
-              , doc0 = bd(data[0])
-              , doc1 = bd(data[1])
-            ;
+            const _data = fs.readFileSync(hookTestFilename, 'utf8')
+            const data = _data.split('\n')
+            let doc0 = bd(data[0])
+            let doc1 = bd(data[1])
 
-            data.length.should.equal(3);
+            data.length.should.equal(3)
 
-            data[0].substring(0, 7).should.equal('before_');
-            data[0].substring(data[0].length - 6).should.equal('_after');
-            data[1].substring(0, 7).should.equal('before_');
-            data[1].substring(data[1].length - 6).should.equal('_after');
+            data[0].substring(0, 7).should.equal('before_')
+            data[0].substring(data[0].length - 6).should.equal('_after')
+            data[1].substring(0, 7).should.equal('before_')
+            data[1].substring(data[1].length - 6).should.equal('_after')
 
-            doc0 = model.deserialize(doc0);
-            Object.keys(doc0).length.should.equal(2);
-            doc0.hello.should.equal('world');
+            doc0 = model.deserialize(doc0)
+            Object.keys(doc0).length.should.equal(2)
+            doc0.hello.should.equal('world')
 
-            doc1 = model.deserialize(doc1);
-            Object.keys(doc1).length.should.equal(2);
-            doc1.p.should.equal('Mars');
+            doc1 = model.deserialize(doc1)
+            Object.keys(doc1).length.should.equal(2)
+            doc1.p.should.equal('Mars')
 
             d.ensureIndex({ fieldName: 'idefix' }, function () {
-              var _data = fs.readFileSync(hookTestFilename, 'utf8')
-                , data = _data.split('\n')
-                , doc0 = bd(data[0])
-                , doc1 = bd(data[1])
-                , idx = bd(data[2])
-              ;
+              const _data = fs.readFileSync(hookTestFilename, 'utf8')
+              const data = _data.split('\n')
+              let doc0 = bd(data[0])
+              let doc1 = bd(data[1])
+              let idx = bd(data[2])
 
-              data.length.should.equal(4);
+              data.length.should.equal(4)
 
-              data[0].substring(0, 7).should.equal('before_');
-              data[0].substring(data[0].length - 6).should.equal('_after');
-              data[1].substring(0, 7).should.equal('before_');
-              data[1].substring(data[1].length - 6).should.equal('_after');
+              data[0].substring(0, 7).should.equal('before_')
+              data[0].substring(data[0].length - 6).should.equal('_after')
+              data[1].substring(0, 7).should.equal('before_')
+              data[1].substring(data[1].length - 6).should.equal('_after')
 
-              doc0 = model.deserialize(doc0);
-              Object.keys(doc0).length.should.equal(2);
-              doc0.hello.should.equal('world');
+              doc0 = model.deserialize(doc0)
+              Object.keys(doc0).length.should.equal(2)
+              doc0.hello.should.equal('world')
 
-              doc1 = model.deserialize(doc1);
-              Object.keys(doc1).length.should.equal(2);
-              doc1.p.should.equal('Mars');
+              doc1 = model.deserialize(doc1)
+              Object.keys(doc1).length.should.equal(2)
+              doc1.p.should.equal('Mars')
 
-              idx = model.deserialize(idx);
-              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } });
+              idx = model.deserialize(idx)
+              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } })
 
-              done();
-            });
-          });
-        });
-      });
-    });
+              done()
+            })
+          })
+        })
+      })
+    })
 
-    it("Use serialization hook when persisting cached database or compacting", function (done) {
-      var hookTestFilename = 'workspace/hookTest.db'
+    it('Use serialization hook when persisting cached database or compacting', function (done) {
+      const hookTestFilename = 'workspace/hookTest.db'
       storage.ensureFileDoesntExist(hookTestFilename, function () {
-        var d = new Datastore({ filename: hookTestFilename, autoload: true
+        const d = new Datastore({
+          filename: hookTestFilename, autoload: true
           , afterSerialization: as
           , beforeDeserialization: bd
         })
-        ;
 
-        d.insert({ hello: "world" }, function () {
-          d.update({ hello: "world" }, { $set: { hello: "earth" } }, {}, function () {
+        d.insert({ hello: 'world' }, function () {
+          d.update({ hello: 'world' }, { $set: { hello: 'earth' } }, {}, function () {
             d.ensureIndex({ fieldName: 'idefix' }, function () {
-              var _data = fs.readFileSync(hookTestFilename, 'utf8')
-                , data = _data.split('\n')
-                , doc0 = bd(data[0])
-                , doc1 = bd(data[1])
-                , idx = bd(data[2])
-                , _id
-              ;
+              const _data = fs.readFileSync(hookTestFilename, 'utf8')
+              const data = _data.split('\n')
+              let doc0 = bd(data[0])
+              let doc1 = bd(data[1])
+              let idx = bd(data[2])
+              let _id
 
-              data.length.should.equal(4);
+              data.length.should.equal(4)
 
-              doc0 = model.deserialize(doc0);
-              Object.keys(doc0).length.should.equal(2);
-              doc0.hello.should.equal('world');
+              doc0 = model.deserialize(doc0)
+              Object.keys(doc0).length.should.equal(2)
+              doc0.hello.should.equal('world')
 
-              doc1 = model.deserialize(doc1);
-              Object.keys(doc1).length.should.equal(2);
-              doc1.hello.should.equal('earth');
+              doc1 = model.deserialize(doc1)
+              Object.keys(doc1).length.should.equal(2)
+              doc1.hello.should.equal('earth')
 
-              doc0._id.should.equal(doc1._id);
-              _id = doc0._id;
+              doc0._id.should.equal(doc1._id)
+              _id = doc0._id
 
-              idx = model.deserialize(idx);
-              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } });
+              idx = model.deserialize(idx)
+              assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix' } })
 
               d.persistence.persistCachedDatabase(function () {
-                var _data = fs.readFileSync(hookTestFilename, 'utf8')
-                  , data = _data.split('\n')
-                  , doc0 = bd(data[0])
-                  , idx = bd(data[1])
-                ;
+                const _data = fs.readFileSync(hookTestFilename, 'utf8')
+                const data = _data.split('\n')
+                let doc0 = bd(data[0])
+                let idx = bd(data[1])
 
-                data.length.should.equal(3);
+                data.length.should.equal(3)
 
-                doc0 = model.deserialize(doc0);
-                Object.keys(doc0).length.should.equal(2);
-                doc0.hello.should.equal('earth');
+                doc0 = model.deserialize(doc0)
+                Object.keys(doc0).length.should.equal(2)
+                doc0.hello.should.equal('earth')
 
-                doc0._id.should.equal(_id);
+                doc0._id.should.equal(_id)
 
-                idx = model.deserialize(idx);
-                assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix', unique: false, sparse: false } });
+                idx = model.deserialize(idx)
+                assert.deepEqual(idx, { '$$indexCreated': { fieldName: 'idefix', unique: false, sparse: false } })
 
-                done();
-              });
-            });
-          });
-        });
-      });
-    });
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
 
-    it("Deserialization hook is correctly used when loading data", function (done) {
-      var hookTestFilename = 'workspace/hookTest.db'
+    it('Deserialization hook is correctly used when loading data', function (done) {
+      const hookTestFilename = 'workspace/hookTest.db'
       storage.ensureFileDoesntExist(hookTestFilename, function () {
-        var d = new Datastore({ filename: hookTestFilename, autoload: true
+        const d = new Datastore({
+          filename: hookTestFilename, autoload: true
           , afterSerialization: as
           , beforeDeserialization: bd
         })
-        ;
 
-        d.insert({ hello: "world" }, function (err, doc) {
-          var _id = doc._id;
-          d.insert({ yo: "ya" }, function () {
-            d.update({ hello: "world" }, { $set: { hello: "earth" } }, {}, function () {
-              d.remove({ yo: "ya" }, {}, function () {
+        d.insert({ hello: 'world' }, function (err, doc) {
+          const _id = doc._id
+          d.insert({ yo: 'ya' }, function () {
+            d.update({ hello: 'world' }, { $set: { hello: 'earth' } }, {}, function () {
+              d.remove({ yo: 'ya' }, {}, function () {
                 d.ensureIndex({ fieldName: 'idefix' }, function () {
-                  var _data = fs.readFileSync(hookTestFilename, 'utf8')
-                    , data = _data.split('\n')
-                  ;
+                  const _data = fs.readFileSync(hookTestFilename, 'utf8')
+                  const data = _data.split('\n')
 
-                  data.length.should.equal(6);
+                  data.length.should.equal(6)
 
                   // Everything is deserialized correctly, including deletes and indexes
-                  var d = new Datastore({ filename: hookTestFilename
+                  const d = new Datastore({
+                    filename: hookTestFilename
                     , afterSerialization: as
                     , beforeDeserialization: bd
                   })
-                  ;
                   d.loadDatabase(function () {
                     d.find({}, function (err, docs) {
-                      docs.length.should.equal(1);
-                      docs[0].hello.should.equal("earth");
-                      docs[0]._id.should.equal(_id);
+                      docs.length.should.equal(1)
+                      docs[0].hello.should.equal('earth')
+                      docs[0]._id.should.equal(_id)
 
-                      Object.keys(d.indexes).length.should.equal(2);
-                      Object.keys(d.indexes).indexOf("idefix").should.not.equal(-1);
+                      Object.keys(d.indexes).length.should.equal(2)
+                      Object.keys(d.indexes).indexOf('idefix').should.not.equal(-1)
 
-                      done();
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+                      done()
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
 
-  });   // ==== End of 'Serialization hooks' ==== //
+  })   // ==== End of 'Serialization hooks' ==== //
 
   describe('Prevent dataloss when persisting data', function () {
 
     it('Creating a datastore with in memory as true and a bad filename wont cause an error', function () {
-      new Datastore({ filename: 'workspace/bad.db~', inMemoryOnly: true });
+      new Datastore({ filename: 'workspace/bad.db~', inMemoryOnly: true })
     })
 
     it('Creating a persistent datastore with a bad filename will cause an error', function () {
-      (function () { new Datastore({ filename: 'workspace/bad.db~' }); }).should.throw();
+      (function () { new Datastore({ filename: 'workspace/bad.db~' }) }).should.throw()
     })
 
     it('If no file exists, ensureDatafileIntegrity creates an empty datafile', function (done) {
-      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+      const p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } })
 
-      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
-      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db') }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~') }
 
-      fs.existsSync('workspace/it.db').should.equal(false);
-      fs.existsSync('workspace/it.db~').should.equal(false);
+      fs.existsSync('workspace/it.db').should.equal(false)
+      fs.existsSync('workspace/it.db~').should.equal(false)
 
       storage.ensureDatafileIntegrity(p.filename, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
 
-        fs.existsSync('workspace/it.db').should.equal(true);
-        fs.existsSync('workspace/it.db~').should.equal(false);
+        fs.existsSync('workspace/it.db').should.equal(true)
+        fs.existsSync('workspace/it.db~').should.equal(false)
 
-        fs.readFileSync('workspace/it.db', 'utf8').should.equal('');
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it('If only datafile exists, ensureDatafileIntegrity will use it', function (done) {
-      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+      const p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } })
 
-      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
-      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db') }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~') }
 
-      fs.writeFileSync('workspace/it.db', 'something', 'utf8');
+      fs.writeFileSync('workspace/it.db', 'something', 'utf8')
 
-      fs.existsSync('workspace/it.db').should.equal(true);
-      fs.existsSync('workspace/it.db~').should.equal(false);
+      fs.existsSync('workspace/it.db').should.equal(true)
+      fs.existsSync('workspace/it.db~').should.equal(false)
 
       storage.ensureDatafileIntegrity(p.filename, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
 
-        fs.existsSync('workspace/it.db').should.equal(true);
-        fs.existsSync('workspace/it.db~').should.equal(false);
+        fs.existsSync('workspace/it.db').should.equal(true)
+        fs.existsSync('workspace/it.db~').should.equal(false)
 
-        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something');
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it('If temp datafile exists and datafile doesnt, ensureDatafileIntegrity will use it (cannot happen except upon first use)', function (done) {
-      var p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } });
+      const p = new Persistence({ db: { inMemoryOnly: false, filename: 'workspace/it.db' } })
 
-      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
-      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~~'); }
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db') }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~~') }
 
-      fs.writeFileSync('workspace/it.db~', 'something', 'utf8');
+      fs.writeFileSync('workspace/it.db~', 'something', 'utf8')
 
-      fs.existsSync('workspace/it.db').should.equal(false);
-      fs.existsSync('workspace/it.db~').should.equal(true);
+      fs.existsSync('workspace/it.db').should.equal(false)
+      fs.existsSync('workspace/it.db~').should.equal(true)
 
       storage.ensureDatafileIntegrity(p.filename, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
 
-        fs.existsSync('workspace/it.db').should.equal(true);
-        fs.existsSync('workspace/it.db~').should.equal(false);
+        fs.existsSync('workspace/it.db').should.equal(true)
+        fs.existsSync('workspace/it.db~').should.equal(false)
 
-        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something');
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('something')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     // Technically it could also mean the write was successful but the rename wasn't, but there is in any case no guarantee that the data in the temp file is whole so we have to discard the whole file
     it('If both temp and current datafiles exist, ensureDatafileIntegrity will use the datafile, as it means that the write of the temp file failed', function (done) {
-      var theDb = new Datastore({ filename: 'workspace/it.db' });
+      const theDb = new Datastore({ filename: 'workspace/it.db' })
 
-      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db'); }
-      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~'); }
+      if (fs.existsSync('workspace/it.db')) { fs.unlinkSync('workspace/it.db') }
+      if (fs.existsSync('workspace/it.db~')) { fs.unlinkSync('workspace/it.db~') }
 
-      fs.writeFileSync('workspace/it.db', '{"_id":"0","hello":"world"}', 'utf8');
-      fs.writeFileSync('workspace/it.db~', '{"_id":"0","hello":"other"}', 'utf8');
+      fs.writeFileSync('workspace/it.db', '{"_id":"0","hello":"world"}', 'utf8')
+      fs.writeFileSync('workspace/it.db~', '{"_id":"0","hello":"other"}', 'utf8')
 
-      fs.existsSync('workspace/it.db').should.equal(true);
-      fs.existsSync('workspace/it.db~').should.equal(true);
+      fs.existsSync('workspace/it.db').should.equal(true)
+      fs.existsSync('workspace/it.db~').should.equal(true)
 
       storage.ensureDatafileIntegrity(theDb.persistence.filename, function (err) {
-        assert.isNull(err);
+        assert.isNull(err)
 
-        fs.existsSync('workspace/it.db').should.equal(true);
-        fs.existsSync('workspace/it.db~').should.equal(true);
+        fs.existsSync('workspace/it.db').should.equal(true)
+        fs.existsSync('workspace/it.db~').should.equal(true)
 
-        fs.readFileSync('workspace/it.db', 'utf8').should.equal('{"_id":"0","hello":"world"}');
+        fs.readFileSync('workspace/it.db', 'utf8').should.equal('{"_id":"0","hello":"world"}')
 
         theDb.loadDatabase(function (err) {
-          assert.isNull(err);
+          assert.isNull(err)
           theDb.find({}, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(1);
-            docs[0].hello.should.equal("world");
-            fs.existsSync('workspace/it.db').should.equal(true);
-            fs.existsSync('workspace/it.db~').should.equal(false);
-            done();
-          });
-        });
-      });
-    });
+            assert.isNull(err)
+            docs.length.should.equal(1)
+            docs[0].hello.should.equal('world')
+            fs.existsSync('workspace/it.db').should.equal(true)
+            fs.existsSync('workspace/it.db~').should.equal(false)
+            done()
+          })
+        })
+      })
+    })
 
     it('persistCachedDatabase should update the contents of the datafile and leave a clean state', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
+          docs.length.should.equal(1)
 
-          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
-          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~'); }
-          fs.existsSync(testDb).should.equal(false);
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb) }
+          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~') }
+          fs.existsSync(testDb).should.equal(false)
 
-          fs.writeFileSync(testDb + '~', 'something', 'utf8');
-          fs.existsSync(testDb + '~').should.equal(true);
+          fs.writeFileSync(testDb + '~', 'something', 'utf8')
+          fs.existsSync(testDb + '~').should.equal(true)
 
           d.persistence.persistCachedDatabase(function (err) {
-            var contents = fs.readFileSync(testDb, 'utf8');
-            assert.isNull(err);
-            fs.existsSync(testDb).should.equal(true);
-            fs.existsSync(testDb + '~').should.equal(false);
+            const contents = fs.readFileSync(testDb, 'utf8')
+            assert.isNull(err)
+            fs.existsSync(testDb).should.equal(true)
+            fs.existsSync(testDb + '~').should.equal(false)
             if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
-              throw new Error("Datafile contents not as expected");
+              throw new Error('Datafile contents not as expected')
             }
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('After a persistCachedDatabase, there should be no temp or old filename', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
+          docs.length.should.equal(1)
 
-          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
-          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~'); }
-          fs.existsSync(testDb).should.equal(false);
-          fs.existsSync(testDb + '~').should.equal(false);
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb) }
+          if (fs.existsSync(testDb + '~')) { fs.unlinkSync(testDb + '~') }
+          fs.existsSync(testDb).should.equal(false)
+          fs.existsSync(testDb + '~').should.equal(false)
 
-          fs.writeFileSync(testDb + '~', 'bloup', 'utf8');
-          fs.existsSync(testDb + '~').should.equal(true);
+          fs.writeFileSync(testDb + '~', 'bloup', 'utf8')
+          fs.existsSync(testDb + '~').should.equal(true)
 
           d.persistence.persistCachedDatabase(function (err) {
-            var contents = fs.readFileSync(testDb, 'utf8');
-            assert.isNull(err);
-            fs.existsSync(testDb).should.equal(true);
-            fs.existsSync(testDb + '~').should.equal(false);
+            const contents = fs.readFileSync(testDb, 'utf8')
+            assert.isNull(err)
+            fs.existsSync(testDb).should.equal(true)
+            fs.existsSync(testDb + '~').should.equal(false)
             if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
-              throw new Error("Datafile contents not as expected");
+              throw new Error('Datafile contents not as expected')
             }
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile', function (done) {
       d.insert({ hello: 'world' }, function () {
         d.find({}, function (err, docs) {
-          docs.length.should.equal(1);
+          docs.length.should.equal(1)
 
-          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb); }
-          fs.writeFileSync(testDb + '~', 'blabla', 'utf8');
-          fs.existsSync(testDb).should.equal(false);
-          fs.existsSync(testDb + '~').should.equal(true);
+          if (fs.existsSync(testDb)) { fs.unlinkSync(testDb) }
+          fs.writeFileSync(testDb + '~', 'blabla', 'utf8')
+          fs.existsSync(testDb).should.equal(false)
+          fs.existsSync(testDb + '~').should.equal(true)
 
           d.persistence.persistCachedDatabase(function (err) {
-            var contents = fs.readFileSync(testDb, 'utf8');
-            assert.isNull(err);
-            fs.existsSync(testDb).should.equal(true);
-            fs.existsSync(testDb + '~').should.equal(false);
+            const contents = fs.readFileSync(testDb, 'utf8')
+            assert.isNull(err)
+            fs.existsSync(testDb).should.equal(true)
+            fs.existsSync(testDb + '~').should.equal(false)
             if (!contents.match(/^{"hello":"world","_id":"[0-9a-zA-Z]{16}"}\n$/)) {
-              throw new Error("Datafile contents not as expected");
+              throw new Error('Datafile contents not as expected')
             }
-            done();
-          });
-        });
-      });
-    });
+            done()
+          })
+        })
+      })
+    })
 
     it('persistCachedDatabase should update the contents of the datafile and leave a clean state even if there is a temp datafile', function (done) {
-      var dbFile = 'workspace/test2.db', theDb;
+      const dbFile = 'workspace/test2.db'
+      let theDb
 
-      if (fs.existsSync(dbFile)) { fs.unlinkSync(dbFile); }
-      if (fs.existsSync(dbFile + '~')) { fs.unlinkSync(dbFile + '~'); }
+      if (fs.existsSync(dbFile)) { fs.unlinkSync(dbFile) }
+      if (fs.existsSync(dbFile + '~')) { fs.unlinkSync(dbFile + '~') }
 
-      theDb = new Datastore({ filename: dbFile });
+      theDb = new Datastore({ filename: dbFile })
 
       theDb.loadDatabase(function (err) {
-        var contents = fs.readFileSync(dbFile, 'utf8');
-        assert.isNull(err);
-        fs.existsSync(dbFile).should.equal(true);
-        fs.existsSync(dbFile + '~').should.equal(false);
-        if (contents != "") {
-          throw new Error("Datafile contents not as expected");
+        const contents = fs.readFileSync(dbFile, 'utf8')
+        assert.isNull(err)
+        fs.existsSync(dbFile).should.equal(true)
+        fs.existsSync(dbFile + '~').should.equal(false)
+        if (contents != '') {
+          throw new Error('Datafile contents not as expected')
         }
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it('Persistence works as expected when everything goes fine', function (done) {
-      var dbFile = 'workspace/test2.db', theDb, theDb2, doc1, doc2;
+      const dbFile = 'workspace/test2.db'
+      let theDb, theDb2, doc1, doc2
 
       async.waterfall([
-          async.apply(storage.ensureFileDoesntExist, dbFile)
+        async.apply(storage.ensureFileDoesntExist, dbFile)
         , async.apply(storage.ensureFileDoesntExist, dbFile + '~')
         , function (cb) {
-          theDb = new Datastore({ filename: dbFile });
-          theDb.loadDatabase(cb);
+          theDb = new Datastore({ filename: dbFile })
+          theDb.loadDatabase(cb)
         }
         , function (cb) {
           theDb.find({}, function (err, docs) {
-            assert.isNull(err);
-            docs.length.should.equal(0);
-            return cb();
-          });
+            assert.isNull(err)
+            docs.length.should.equal(0)
+            return cb()
+          })
         }
-      , function (cb) {
-        theDb.insert({ a: 'hello' }, function (err, _doc1) {
-        assert.isNull(err);
-          doc1 = _doc1;
-          theDb.insert({ a: 'world' }, function (err, _doc2) {
-            assert.isNull(err);
-            doc2 = _doc2;
-            return cb();
-          });
-        });
-      }
-      , function (cb) {
-        theDb.find({}, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(2);
-          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
-          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
-          return cb();
-        });
-      }
-      , function (cb) {
-        theDb.loadDatabase(cb);
-      }
-      , function (cb) {   // No change
-        theDb.find({}, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(2);
-          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
-          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
-          return cb();
-        });
-      }
-      , function (cb) {
-        fs.existsSync(dbFile).should.equal(true);
-        fs.existsSync(dbFile + '~').should.equal(false);
-        return cb();
-      }
-      , function (cb) {
-        theDb2 = new Datastore({ filename: dbFile });
-        theDb2.loadDatabase(cb);
-      }
-      , function (cb) {   // No change in second db
-        theDb2.find({}, function (err, docs) {
-          assert.isNull(err);
-          docs.length.should.equal(2);
-          _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello');
-          _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world');
-          return cb();
-        });
-      }
-      , function (cb) {
-        fs.existsSync(dbFile).should.equal(true);
-        fs.existsSync(dbFile + '~').should.equal(false);
-        return cb();
-      }
-      ], done);
-    });
+        , function (cb) {
+          theDb.insert({ a: 'hello' }, function (err, _doc1) {
+            assert.isNull(err)
+            doc1 = _doc1
+            theDb.insert({ a: 'world' }, function (err, _doc2) {
+              assert.isNull(err)
+              doc2 = _doc2
+              return cb()
+            })
+          })
+        }
+        , function (cb) {
+          theDb.find({}, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello')
+            _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world')
+            return cb()
+          })
+        }
+        , function (cb) {
+          theDb.loadDatabase(cb)
+        }
+        , function (cb) {   // No change
+          theDb.find({}, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello')
+            _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world')
+            return cb()
+          })
+        }
+        , function (cb) {
+          fs.existsSync(dbFile).should.equal(true)
+          fs.existsSync(dbFile + '~').should.equal(false)
+          return cb()
+        }
+        , function (cb) {
+          theDb2 = new Datastore({ filename: dbFile })
+          theDb2.loadDatabase(cb)
+        }
+        , function (cb) {   // No change in second db
+          theDb2.find({}, function (err, docs) {
+            assert.isNull(err)
+            docs.length.should.equal(2)
+            _.find(docs, function (item) { return item._id === doc1._id }).a.should.equal('hello')
+            _.find(docs, function (item) { return item._id === doc2._id }).a.should.equal('world')
+            return cb()
+          })
+        }
+        , function (cb) {
+          fs.existsSync(dbFile).should.equal(true)
+          fs.existsSync(dbFile + '~').should.equal(false)
+          return cb()
+        }
+      ], done)
+    })
 
     // The child process will load the database with the given datafile, but the fs.writeFile function
     // is rewritten to crash the process before it finished (after 5000 bytes), to ensure data was not lost
     it('If system crashes during a loadDatabase, the former version is not lost', function (done) {
-      var N = 500, toWrite = "", i, doc_i;
+      const N = 500
+      let toWrite = ''
+      let i
+      let doc_i
 
       // Ensuring the state is clean
-      if (fs.existsSync('workspace/lac.db')) { fs.unlinkSync('workspace/lac.db'); }
-      if (fs.existsSync('workspace/lac.db~')) { fs.unlinkSync('workspace/lac.db~'); }
+      if (fs.existsSync('workspace/lac.db')) { fs.unlinkSync('workspace/lac.db') }
+      if (fs.existsSync('workspace/lac.db~')) { fs.unlinkSync('workspace/lac.db~') }
 
       // Creating a db file with 150k records (a bit long to load)
       for (i = 0; i < N; i += 1) {
-        toWrite += model.serialize({ _id: 'anid_' + i, hello: 'world' }) + '\n';
+        toWrite += model.serialize({ _id: 'anid_' + i, hello: 'world' }) + '\n'
       }
-      fs.writeFileSync('workspace/lac.db', toWrite, 'utf8');
+      fs.writeFileSync('workspace/lac.db', toWrite, 'utf8')
 
-      var datafileLength = fs.readFileSync('workspace/lac.db', 'utf8').length;
+      const datafileLength = fs.readFileSync('workspace/lac.db', 'utf8').length
 
       // Loading it in a separate process that we will crash before finishing the loadDatabase
       child_process.fork('test_lac/loadAndCrash.test').on('exit', function (code) {
-        code.should.equal(1);   // See test_lac/loadAndCrash.test.js
+        code.should.equal(1)   // See test_lac/loadAndCrash.test.js
 
-        fs.existsSync('workspace/lac.db').should.equal(true);
-        fs.existsSync('workspace/lac.db~').should.equal(true);
-        fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength);
-        fs.readFileSync('workspace/lac.db~', 'utf8').length.should.equal(5000);
+        fs.existsSync('workspace/lac.db').should.equal(true)
+        fs.existsSync('workspace/lac.db~').should.equal(true)
+        fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength)
+        fs.readFileSync('workspace/lac.db~', 'utf8').length.should.equal(5000)
 
         // Reload database without a crash, check that no data was lost and fs state is clean (no temp file)
-        var db = new Datastore({ filename: 'workspace/lac.db' });
+        const db = new Datastore({ filename: 'workspace/lac.db' })
         db.loadDatabase(function (err) {
-          assert.isNull(err);
+          assert.isNull(err)
 
-          fs.existsSync('workspace/lac.db').should.equal(true);
-          fs.existsSync('workspace/lac.db~').should.equal(false);
-          fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength);
+          fs.existsSync('workspace/lac.db').should.equal(true)
+          fs.existsSync('workspace/lac.db~').should.equal(false)
+          fs.readFileSync('workspace/lac.db', 'utf8').length.should.equal(datafileLength)
 
           db.find({}, function (err, docs) {
-            docs.length.should.equal(N);
+            docs.length.should.equal(N)
             for (i = 0; i < N; i += 1) {
-              doc_i = _.find(docs, function (d) { return d._id === 'anid_' + i; });
-              assert.isDefined(doc_i);
-              assert.deepEqual({ hello: 'world', _id: 'anid_' + i }, doc_i);
+              doc_i = _.find(docs, function (d) { return d._id === 'anid_' + i })
+              assert.isDefined(doc_i)
+              assert.deepEqual({ hello: 'world', _id: 'anid_' + i }, doc_i)
             }
-            return done();
-          });
-        });
-      });
-    });
+            return done()
+          })
+        })
+      })
+    })
 
     // Not run on Windows as there is no clean way to set maximum file descriptors. Not an issue as the code itself is tested.
-    it("Cannot cause EMFILE errors by opening too many file descriptors", function (done) {
-      if (process.platform === 'win32' || process.platform === 'win64') { return done(); }
+    it('Cannot cause EMFILE errors by opening too many file descriptors', function (done) {
+      if (process.platform === 'win32' || process.platform === 'win64') { return done() }
       child_process.execFile('test_lac/openFdsLaunch.sh', function (err, stdout, stderr) {
-        if (err) { return done(err); }
+        if (err) { return done(err) }
 
         // The subprocess will not output anything to stdout unless part of the test fails
         if (stdout.length !== 0) {
-          return done(stdout);
+          return done(stdout)
         } else {
-          return done();
+          return done()
         }
-      });
-    });
+      })
+    })
 
-  });   // ==== End of 'Prevent dataloss when persisting data' ====
-
+  })   // ==== End of 'Prevent dataloss when persisting data' ====
 
   describe('ensureFileDoesntExist', function () {
 
     it('Doesnt do anything if file already doesnt exist', function (done) {
       storage.ensureFileDoesntExist('workspace/nonexisting', function (err) {
-        assert.isNull(err);
-        fs.existsSync('workspace/nonexisting').should.equal(false);
-        done();
-      });
-    });
+        assert.isNull(err)
+        fs.existsSync('workspace/nonexisting').should.equal(false)
+        done()
+      })
+    })
 
     it('Deletes file if it exists', function (done) {
-      fs.writeFileSync('workspace/existing', 'hello world', 'utf8');
-      fs.existsSync('workspace/existing').should.equal(true);
+      fs.writeFileSync('workspace/existing', 'hello world', 'utf8')
+      fs.existsSync('workspace/existing').should.equal(true)
 
       storage.ensureFileDoesntExist('workspace/existing', function (err) {
-        assert.isNull(err);
-        fs.existsSync('workspace/existing').should.equal(false);
-        done();
-      });
-    });
+        assert.isNull(err)
+        fs.existsSync('workspace/existing').should.equal(false)
+        done()
+      })
+    })
 
-  });   // ==== End of 'ensureFileDoesntExist' ====
+  })   // ==== End of 'ensureFileDoesntExist' ====
 
-
-});
+})

--- a/test_lac/loadAndCrash.test.js
+++ b/test_lac/loadAndCrash.test.js
@@ -105,8 +105,7 @@ fs.writeFile = function (path, data, options, callback_) {
   })
 
   function writeFd (fd, isUserFd) {
-    const buffer = (data instanceof Buffer) ? data : new Buffer('' + data,
-      options.encoding || 'utf8')
+    const buffer = (data instanceof Buffer) ? data : Buffer.from('' + data, options.encoding || 'utf8')
     const position = /a/.test(flag) ? null : 0
 
     writeAll(fd, isUserFd, buffer, 0, buffer.length, position, callback)

--- a/test_lac/loadAndCrash.test.js
+++ b/test_lac/loadAndCrash.test.js
@@ -1,123 +1,120 @@
 /**
  * Load and modify part of fs to ensure writeFile will crash after writing 5000 bytes
  */
-var fs = require('fs');
+const fs = require('fs')
 
-function rethrow() {
+function rethrow () {
   // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
   // is fairly slow to generate.
   if (DEBUG) {
-    var backtrace = new Error();
-    return function(err) {
+    const backtrace = new Error()
+    return function (err) {
       if (err) {
         backtrace.stack = err.name + ': ' + err.message +
-                          backtrace.stack.substr(backtrace.name.length);
-        throw backtrace;
+          backtrace.stack.substr(backtrace.name.length)
+        throw backtrace
       }
-    };
-  }
-
-  return function(err) {
-    if (err) {
-      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
     }
-  };
-}
+  }
 
-function maybeCallback(cb) {
-  return typeof cb === 'function' ? cb : rethrow();
-}
-
-function isFd(path) {
-  return (path >>> 0) === path;
-}
-
-function assertEncoding(encoding) {
-  if (encoding && !Buffer.isEncoding(encoding)) {
-    throw new Error('Unknown encoding: ' + encoding);
+  return function (err) {
+    if (err) {
+      throw err  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
+    }
   }
 }
 
-var onePassDone = false;
-function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
+function maybeCallback (cb) {
+  return typeof cb === 'function' ? cb : rethrow()
+}
 
-  if (onePassDone) { process.exit(1); }   // Crash on purpose before rewrite done
-  var l = Math.min(5000, length);   // Force write by chunks of 5000 bytes to ensure data will be incomplete on crash
+function isFd (path) {
+  return (path >>> 0) === path
+}
+
+function assertEncoding (encoding) {
+  if (encoding && !Buffer.isEncoding(encoding)) {
+    throw new Error('Unknown encoding: ' + encoding)
+  }
+}
+
+let onePassDone = false
+
+function writeAll (fd, isUserFd, buffer, offset, length, position, callback_) {
+  const callback = maybeCallback(arguments[arguments.length - 1])
+
+  if (onePassDone) { process.exit(1) }   // Crash on purpose before rewrite done
+  const l = Math.min(5000, length)   // Force write by chunks of 5000 bytes to ensure data will be incomplete on crash
 
   // write(fd, buffer, offset, length, position, callback)
-  fs.write(fd, buffer, offset, l, position, function(writeErr, written) {
+  fs.write(fd, buffer, offset, l, position, function (writeErr, written) {
     if (writeErr) {
       if (isUserFd) {
-        if (callback) callback(writeErr);
+        if (callback) callback(writeErr)
       } else {
-        fs.close(fd, function() {
-          if (callback) callback(writeErr);
-        });
+        fs.close(fd, function () {
+          if (callback) callback(writeErr)
+        })
       }
     } else {
-      onePassDone = true;
+      onePassDone = true
       if (written === length) {
         if (isUserFd) {
-          if (callback) callback(null);
+          if (callback) callback(null)
         } else {
-          fs.close(fd, callback);
+          fs.close(fd, callback)
         }
       } else {
-        offset += written;
-        length -= written;
+        offset += written
+        length -= written
         if (position !== null) {
-          position += written;
+          position += written
         }
-        writeAll(fd, isUserFd, buffer, offset, length, position, callback);
+        writeAll(fd, isUserFd, buffer, offset, length, position, callback)
       }
     }
-  });
+  })
 }
 
-fs.writeFile = function(path, data, options, callback_) {
-  var callback = maybeCallback(arguments[arguments.length - 1]);
+fs.writeFile = function (path, data, options, callback_) {
+  const callback = maybeCallback(arguments[arguments.length - 1])
 
   if (!options || typeof options === 'function') {
-    options = { encoding: 'utf8', mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
+    options = { encoding: 'utf8', mode: 438, flag: 'w' } // Mode 438 == 0o666 (compatibility with older Node releases)
   } else if (typeof options === 'string') {
-    options = { encoding: options, mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
+    options = { encoding: options, mode: 438, flag: 'w' } // Mode 438 == 0o666 (compatibility with older Node releases)
   } else if (typeof options !== 'object') {
-    throwOptionsError(options);
+    throwOptionsError(options)
   }
 
-  assertEncoding(options.encoding);
+  assertEncoding(options.encoding)
 
-  var flag = options.flag || 'w';
+  const flag = options.flag || 'w'
 
   if (isFd(path)) {
-    writeFd(path, true);
-    return;
+    writeFd(path, true)
+    return
   }
 
-  fs.open(path, flag, options.mode, function(openErr, fd) {
+  fs.open(path, flag, options.mode, function (openErr, fd) {
     if (openErr) {
-      if (callback) callback(openErr);
+      if (callback) callback(openErr)
     } else {
-      writeFd(fd, false);
+      writeFd(fd, false)
     }
-  });
+  })
 
-  function writeFd(fd, isUserFd) {
-    var buffer = (data instanceof Buffer) ? data : new Buffer('' + data,
-        options.encoding || 'utf8');
-    var position = /a/.test(flag) ? null : 0;
+  function writeFd (fd, isUserFd) {
+    const buffer = (data instanceof Buffer) ? data : new Buffer('' + data,
+      options.encoding || 'utf8')
+    const position = /a/.test(flag) ? null : 0
 
-    writeAll(fd, isUserFd, buffer, 0, buffer.length, position, callback);
+    writeAll(fd, isUserFd, buffer, 0, buffer.length, position, callback)
   }
-};
-
-
-
+}
 
 // End of fs modification
-var Nedb = require('../src/nedb/datastore.js')
-  , db = new Nedb({ filename: 'workspace/lac.db' })
-  ;
+const Nedb = require('../src/nedb/datastore.js')
+const db = new Nedb({ filename: 'workspace/lac.db' })
 
-db.loadDatabase();
+db.loadDatabase()

--- a/test_lac/loadAndCrash.test.js
+++ b/test_lac/loadAndCrash.test.js
@@ -1,0 +1,123 @@
+/**
+ * Load and modify part of fs to ensure writeFile will crash after writing 5000 bytes
+ */
+var fs = require('fs');
+
+function rethrow() {
+  // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
+  // is fairly slow to generate.
+  if (DEBUG) {
+    var backtrace = new Error();
+    return function(err) {
+      if (err) {
+        backtrace.stack = err.name + ': ' + err.message +
+                          backtrace.stack.substr(backtrace.name.length);
+        throw backtrace;
+      }
+    };
+  }
+
+  return function(err) {
+    if (err) {
+      throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
+    }
+  };
+}
+
+function maybeCallback(cb) {
+  return typeof cb === 'function' ? cb : rethrow();
+}
+
+function isFd(path) {
+  return (path >>> 0) === path;
+}
+
+function assertEncoding(encoding) {
+  if (encoding && !Buffer.isEncoding(encoding)) {
+    throw new Error('Unknown encoding: ' + encoding);
+  }
+}
+
+var onePassDone = false;
+function writeAll(fd, isUserFd, buffer, offset, length, position, callback_) {
+  var callback = maybeCallback(arguments[arguments.length - 1]);
+
+  if (onePassDone) { process.exit(1); }   // Crash on purpose before rewrite done
+  var l = Math.min(5000, length);   // Force write by chunks of 5000 bytes to ensure data will be incomplete on crash
+
+  // write(fd, buffer, offset, length, position, callback)
+  fs.write(fd, buffer, offset, l, position, function(writeErr, written) {
+    if (writeErr) {
+      if (isUserFd) {
+        if (callback) callback(writeErr);
+      } else {
+        fs.close(fd, function() {
+          if (callback) callback(writeErr);
+        });
+      }
+    } else {
+      onePassDone = true;
+      if (written === length) {
+        if (isUserFd) {
+          if (callback) callback(null);
+        } else {
+          fs.close(fd, callback);
+        }
+      } else {
+        offset += written;
+        length -= written;
+        if (position !== null) {
+          position += written;
+        }
+        writeAll(fd, isUserFd, buffer, offset, length, position, callback);
+      }
+    }
+  });
+}
+
+fs.writeFile = function(path, data, options, callback_) {
+  var callback = maybeCallback(arguments[arguments.length - 1]);
+
+  if (!options || typeof options === 'function') {
+    options = { encoding: 'utf8', mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
+  } else if (typeof options === 'string') {
+    options = { encoding: options, mode: 438, flag: 'w' }; // Mode 438 == 0o666 (compatibility with older Node releases)
+  } else if (typeof options !== 'object') {
+    throwOptionsError(options);
+  }
+
+  assertEncoding(options.encoding);
+
+  var flag = options.flag || 'w';
+
+  if (isFd(path)) {
+    writeFd(path, true);
+    return;
+  }
+
+  fs.open(path, flag, options.mode, function(openErr, fd) {
+    if (openErr) {
+      if (callback) callback(openErr);
+    } else {
+      writeFd(fd, false);
+    }
+  });
+
+  function writeFd(fd, isUserFd) {
+    var buffer = (data instanceof Buffer) ? data : new Buffer('' + data,
+        options.encoding || 'utf8');
+    var position = /a/.test(flag) ? null : 0;
+
+    writeAll(fd, isUserFd, buffer, 0, buffer.length, position, callback);
+  }
+};
+
+
+
+
+// End of fs modification
+var Nedb = require('../src/nedb/datastore.js')
+  , db = new Nedb({ filename: 'workspace/lac.db' })
+  ;
+
+db.loadDatabase();

--- a/test_lac/openFds.test.js
+++ b/test_lac/openFds.test.js
@@ -1,67 +1,67 @@
-var fs = require('fs')
-  , child_process = require('child_process')
-  , async = require('async')
-  , Nedb = require('../src/nedb/datastore')
-  , db = new Nedb({ filename: './workspace/openfds.db', autoload: true })
-  , N = 64   // Half the allowed file descriptors
-  , i, fds
-  ;
+const fs = require('fs')
+const child_process = require('child_process')
+const async = require('async')
+const Nedb = require('../src/nedb/datastore')
+const db = new Nedb({ filename: './workspace/openfds.db', autoload: true })
+const N = 64
+let i
+let fds
 
 function multipleOpen (filename, N, callback) {
-  async.whilst( function () { return i < N; }
-              , function (cb) {
-                fs.open(filename, 'r', function (err, fd) {
-                  i += 1;
-                  if (fd) { fds.push(fd); }
-                  return cb(err);
-                });
-              }
-              , callback);
+  async.whilst(function () { return i < N }
+    , function (cb) {
+      fs.open(filename, 'r', function (err, fd) {
+        i += 1
+        if (fd) { fds.push(fd) }
+        return cb(err)
+      })
+    }
+    , callback)
 }
 
 async.waterfall([
   // Check that ulimit has been set to the correct value
   function (cb) {
-    i = 0;
-    fds = [];
+    i = 0
+    fds = []
     multipleOpen('./test_lac/openFdsTestFile', 2 * N + 1, function (err) {
-      if (!err) { console.log("No error occured while opening a file too many times"); }
-      fds.forEach(function (fd) { fs.closeSync(fd); });
-      return cb();
+      if (!err) { console.log('No error occured while opening a file too many times') }
+      fds.forEach(function (fd) { fs.closeSync(fd) })
+      return cb()
     })
   }
-, function (cb) {
-    i = 0;
-    fds = [];
+  , function (cb) {
+    i = 0
+    fds = []
     multipleOpen('./test_lac/openFdsTestFile2', N, function (err) {
-      if (err) { console.log('An unexpected error occured when opening file not too many times: ' + err); }
-      fds.forEach(function (fd) { fs.closeSync(fd); });
-      return cb();
+      if (err) { console.log('An unexpected error occured when opening file not too many times: ' + err) }
+      fds.forEach(function (fd) { fs.closeSync(fd) })
+      return cb()
     })
   }
   // Then actually test NeDB persistence
-, function () {
+  , function () {
     db.remove({}, { multi: true }, function (err) {
-      if (err) { console.log(err); }
+      if (err) { console.log(err) }
       db.insert({ hello: 'world' }, function (err) {
-        if (err) { console.log(err); }
+        if (err) { console.log(err) }
 
-        i = 0;
-        async.whilst( function () { return i < 2 * N  + 1; }
-                    , function (cb) {
-                        db.persistence.persistCachedDatabase(function (err) {
-                          if (err) { return cb(err); }
-                          i += 1;
-                          return cb();
-                        });
-                      }
-                    , function (err) {
-                      if (err) { console.log("Got unexpected error during one peresistence operation: " + err); }
-                      }
-                    );
+        i = 0
+        async.whilst(function () { return i < 2 * N + 1 }
+          , function (cb) {
+            db.persistence.persistCachedDatabase(function (err) {
+              if (err) { return cb(err) }
+              i += 1
+              return cb()
+            })
+          }
+          , function (err) {
+            if (err) { console.log('Got unexpected error during one peresistence operation: ' + err) }
+          }
+        )
 
-      });
-    });
+      })
+    })
   }
-]);
+])
 

--- a/test_lac/openFds.test.js
+++ b/test_lac/openFds.test.js
@@ -1,0 +1,67 @@
+var fs = require('fs')
+  , child_process = require('child_process')
+  , async = require('async')
+  , Nedb = require('../src/nedb/datastore')
+  , db = new Nedb({ filename: './workspace/openfds.db', autoload: true })
+  , N = 64   // Half the allowed file descriptors
+  , i, fds
+  ;
+
+function multipleOpen (filename, N, callback) {
+  async.whilst( function () { return i < N; }
+              , function (cb) {
+                fs.open(filename, 'r', function (err, fd) {
+                  i += 1;
+                  if (fd) { fds.push(fd); }
+                  return cb(err);
+                });
+              }
+              , callback);
+}
+
+async.waterfall([
+  // Check that ulimit has been set to the correct value
+  function (cb) {
+    i = 0;
+    fds = [];
+    multipleOpen('./test_lac/openFdsTestFile', 2 * N + 1, function (err) {
+      if (!err) { console.log("No error occured while opening a file too many times"); }
+      fds.forEach(function (fd) { fs.closeSync(fd); });
+      return cb();
+    })
+  }
+, function (cb) {
+    i = 0;
+    fds = [];
+    multipleOpen('./test_lac/openFdsTestFile2', N, function (err) {
+      if (err) { console.log('An unexpected error occured when opening file not too many times: ' + err); }
+      fds.forEach(function (fd) { fs.closeSync(fd); });
+      return cb();
+    })
+  }
+  // Then actually test NeDB persistence
+, function () {
+    db.remove({}, { multi: true }, function (err) {
+      if (err) { console.log(err); }
+      db.insert({ hello: 'world' }, function (err) {
+        if (err) { console.log(err); }
+
+        i = 0;
+        async.whilst( function () { return i < 2 * N  + 1; }
+                    , function (cb) {
+                        db.persistence.persistCachedDatabase(function (err) {
+                          if (err) { return cb(err); }
+                          i += 1;
+                          return cb();
+                        });
+                      }
+                    , function (err) {
+                      if (err) { console.log("Got unexpected error during one peresistence operation: " + err); }
+                      }
+                    );
+
+      });
+    });
+  }
+]);
+

--- a/test_lac/openFdsLaunch.sh
+++ b/test_lac/openFdsLaunch.sh
@@ -1,0 +1,2 @@
+ulimit -n 128
+node ./test_lac/openFds.test.js

--- a/test_lac/openFdsTestFile
+++ b/test_lac/openFdsTestFile
@@ -1,0 +1,1 @@
+Random stuff

--- a/test_lac/openFdsTestFile2
+++ b/test_lac/openFdsTestFile2
@@ -1,0 +1,1 @@
+Some other random stuff


### PR DESCRIPTION
Following the discussion on https://github.com/bajankristof/nedb-promises/issues/45, I feel like this is a good time to fork nedb for good, cleanup everything, and expose a native Promise-based interface instead of shimming it.

This PR currently:
- copies lib files from [`nedb@1.8.0`](https://github.com/louischatriot/nedb) into `src/nedb` and uses it instead of requiring `nedb`;
- copies test files from [`nedb@1.8.0`](https://github.com/louischatriot/nedb) into `tests` except benchmarks;
- copies lib files from [`binary-search-tree@0.2.6`](https://github.com/louischatriot/node-binary-search-tree) into `src/binarySearchTree`and uses it instead of requiring `binary-search-tree` within `nedb`
- copies test files from [`binary-search-tree@0.2.6`](https://github.com/louischatriot/node-binary-search-tree) into `test`;
- removes all unnecessary semicolons;
- replaces all `var` with `const` or `let`, and avoids declaring multiple declarations in one statement;
- updates the `underscore`, `localforage` and `mkdirp` dependencies, removes `nedb`;

What still needs to be done is:
- rewrite everything that is callback-based into something that is `Promise`-based;
- update `async` dependency which is massively outdated, if it is even necessary after the rewrite into `Promise`-based code
- merge the code base of the wrapper with the original code.