### PR TITLE
move generic to class level

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ type Document = {
  *
  * @class
  */
-declare class Datastore extends EventEmitter {
+declare class Datastore<T = any> extends EventEmitter {
 
   persistence: Nedb.Persistence
 
@@ -104,7 +104,7 @@ declare class Datastore extends EventEmitter {
    * // in an async function
    * await datastore.find({ ... }).sort({ ... })
    */
-  find<T>(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Nedb.Cursor<T & Document>
+  find(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Nedb.Cursor<T & Document>
 
   /**
    * Find a document that matches a query.
@@ -112,7 +112,7 @@ declare class Datastore extends EventEmitter {
    * It's basically the same as the original:
    * https://github.com/louischatriot/nedb#finding-documents
    */
-  findOne<T>(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Promise<T & Document>
+  findOne(query: any, projection?: {[p in keyof T | '_id' | 'createdAt' | 'updatedAt']?:number}): Promise<T & Document>
 
   /**
    * Insert a document or documents.
@@ -123,7 +123,7 @@ declare class Datastore extends EventEmitter {
    * @param  {Object|Object[]} docs
    * @return {Promise.<Object|Object[]>}
    */
-  insert<T extends any | any[]>(docs: T): Promise<T & Document>
+  insert(docs: T | T[]): Promise<T & Document>
 
   /**
    * Update documents that match a query.
@@ -137,19 +137,19 @@ declare class Datastore extends EventEmitter {
    * with an array of objects.
    */
 
-  update<T>(
+  update(
     query: any,
     updateQuery: any,
     options?: Nedb.UpdateOptions & { returnUpdatedDocs?: false }
   ): Promise<number>
 
-  update<T>(
+  update(
     query: any,
     updateQuery: any,
     options?: Nedb.UpdateOptions & { returnUpdatedDocs: true; multi?: false }
   ): Promise<T & Document>
 
-  update<T>(
+  update(
     query: any,
     updateQuery: any,
     options?: Nedb.UpdateOptions & { returnUpdatedDocs: true; multi: true }
@@ -191,7 +191,7 @@ declare class Datastore extends EventEmitter {
    * For more information visit:
    * https://github.com/louischatriot/nedb#creatingloading-a-database
    */
-  static create(pathOrOptions?: string | Nedb.DatastoreOptions): Datastore
+  static create<T = any>(pathOrOptions?: string | Nedb.DatastoreOptions): Datastore<T>
 }
 
 declare namespace Nedb {


### PR DESCRIPTION
This change moves the generic type to the class level & `create` function. 

This change is useful because you can add types from a Factory function. 

I don't think there will be an edge case where you'd want to pass different types to different functions on the same Datastore. 

This is how I'm using this package, and thought others might find it useful too. 


