### PR TITLE
Use CommonJS export in TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -541,4 +541,4 @@ declare namespace NeDB {
   }
 }
 
-export default NeDB.Datastore;
+export = NeDB.Datastore;


### PR DESCRIPTION
nedb-promises uses CommonJS exports, and so it does not have an ECMAScript Modules default export.

This PR uses the `export =` syntax to accurately represent this.

This resolves an issue where TypeScript will not throw when compiling, but will throw during runtime, when a developer uses `import from` syntax with `esModulesInterop: false` in `tsconfig.json` (which is the default).

This also resolves an issue where VS Code incorrectly auto imports nedb-promises and displays incorrect suggestions when using the correct import syntax.

Fixes #56 